### PR TITLE
feat(subscription): Plan change enhancements: Billing anchor pivot support and conflict resolution policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ shannon-setup/
 
 # Local git worktrees for isolated feature work (superpowers:using-git-worktrees)
 .worktrees/
+*.code-workspace

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -8154,7 +8154,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Change a subscription's plan in place. Subscription id, billing anchor and period bounds are preserved; line items are sliced and settled in one transaction.\n\nchange_at controls timing. Omitted or 'immediate' applies the change now. 'end_of_period' records a pending schedule that executes at the subscription's current period end: the response returns is_scheduled, schedule_id and scheduled_at instead of a completed change, and nothing is swapped or billed until the boundary.\n\nscheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away — inspect scheduled_at to see this.\n\nOnly one plan change may be pending per subscription; request a second one and this returns 400. Cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.",
+                "description": "Change a subscription's plan in place. Subscription id, billing anchor and period bounds are preserved; line items are sliced and settled in one transaction.\n\nchange_at controls timing. Omitted or 'immediate' applies the change now. 'end_of_period' records a pending schedule that executes at the subscription's current period end: the response returns is_scheduled, schedule_id and scheduled_at instead of a completed change, and nothing is swapped or billed until the boundary.\n\nscheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away — inspect scheduled_at to see this.\n\nOnly one plan change may be pending per subscription. By default (on_conflict_policies.on_pending_schedule = 'reject') a second request returns 400; cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.\n\nSet on_conflict_policies.on_pending_schedule to 'supersede' to replace the queued change instead: the pending schedule is cancelled and this request applied in the same transaction, so both land or neither does. The cancelled schedule ids are returned in superseded_schedules, and preview reports the same list without writing.",
                 "consumes": [
                     "application/json"
                 ],
@@ -14099,6 +14099,23 @@ const docTemplate = `{
                 }
             }
         },
+        "BillingPeriodConfig": {
+            "type": "object",
+            "properties": {
+                "billing_anchor": {
+                    "type": "string"
+                },
+                "billing_cycle": {
+                    "$ref": "#/definitions/types.BillingCycle"
+                },
+                "billing_period_count": {
+                    "type": "integer"
+                },
+                "billing_period_unit": {
+                    "$ref": "#/definitions/types.BillingPeriod"
+                }
+            }
+        },
         "BillingPeriodInfo": {
             "type": "object",
             "properties": {
@@ -17761,7 +17778,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/types.EntityChangeBehaviour"
                 },
                 "overrides": {
-                    "description": "Overrides is keyed by addon_associations.id (instance), not catalogue addon_id.",
+                    "description": "Overrides is keyed by addon_associations.id (instance), not catalogue addon_id.\nThat is the id an EntityChangeResult reports as EntityID.",
                     "type": "object",
                     "additionalProperties": {
                         "$ref": "#/definitions/types.EntityChangeBehaviour"
@@ -17779,7 +17796,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
+                    "$ref": "#/definitions/types.SubscriptionChangeEntityType"
                 },
                 "reference_id": {
                     "type": "string"
@@ -20043,6 +20060,14 @@ const docTemplate = `{
                 }
             }
         },
+        "PriceFeatureResponse": {
+            "type": "object",
+            "properties": {
+                "reporting_unit": {
+                    "$ref": "#/definitions/types.ReportingUnit"
+                }
+            }
+        },
         "PriceLookupResult": {
             "type": "object",
             "properties": {
@@ -20133,6 +20158,9 @@ const docTemplate = `{
                 "environment_id": {
                     "description": "EnvironmentID is the environment identifier for the price",
                     "type": "string"
+                },
+                "feature": {
+                    "$ref": "#/definitions/PriceFeatureResponse"
                 },
                 "group": {
                     "$ref": "#/definitions/GroupResponse"
@@ -20814,6 +20842,36 @@ const docTemplate = `{
                 }
             }
         },
+        "SubscriptionChangeBillingPeriodResult": {
+            "type": "object",
+            "properties": {
+                "behaviour": {
+                    "$ref": "#/definitions/types.BillingPeriodBehaviour"
+                },
+                "billing_anchor": {
+                    "type": "string"
+                },
+                "current_period_end": {
+                    "type": "string"
+                },
+                "current_period_start": {
+                    "type": "string"
+                }
+            }
+        },
+        "SubscriptionChangeConflictPolicies": {
+            "type": "object",
+            "properties": {
+                "on_pending_schedule": {
+                    "description": "OnPendingSchedule applies to a queued plan change only. A pending cancellation\nor pause is still rejected outright: clearing those would mean un-cancelling or\nauto-resuming the subscription.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.OnPendingSchedulePolicy"
+                        }
+                    ]
+                }
+            }
+        },
         "SubscriptionChangeEntityPolicies": {
             "type": "object",
             "properties": {
@@ -21050,6 +21108,17 @@ const docTemplate = `{
                 "target_plan_id"
             ],
             "properties": {
+                "billing_period_behaviour": {
+                    "description": "BillingPeriodBehaviour controls the billing anchor. Omitted means \"unchanged\":\nthe swap is priced as a prorated delta inside the running period.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/types.BillingPeriodBehaviour"
+                        }
+                    ]
+                },
+                "billing_period_config": {
+                    "$ref": "#/definitions/BillingPeriodConfig"
+                },
                 "change_at": {
                     "description": "ChangeAt controls when the change takes effect. nil or \"immediate\" applies\nit now; \"end_of_period\" schedules it at the subscription's current period end.",
                     "allOf": [
@@ -21070,6 +21139,9 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "on_conflict_policies": {
+                    "$ref": "#/definitions/SubscriptionChangeConflictPolicies"
+                },
                 "proration_behavior": {
                     "$ref": "#/definitions/types.ProrationBehavior"
                 },
@@ -21081,6 +21153,9 @@ const docTemplate = `{
         "SubscriptionChangeV2Response": {
             "type": "object",
             "properties": {
+                "billing_period": {
+                    "$ref": "#/definitions/SubscriptionChangeBillingPeriodResult"
+                },
                 "change_type": {
                     "$ref": "#/definitions/types.SubscriptionChangeType"
                 },
@@ -21117,6 +21192,13 @@ const docTemplate = `{
                 },
                 "subscription": {
                     "$ref": "#/definitions/SubscriptionResponse"
+                },
+                "superseded_schedules": {
+                    "description": "SupersededSchedules lists the plan-change schedules this request cancelled under\non_conflict_policies.on_pending_schedule. Preview reports what execute would cancel.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "to_plan": {
                     "$ref": "#/definitions/PlanSummary"
@@ -25916,6 +25998,19 @@ const docTemplate = `{
                 "BILLING_PERIOD_ONETIME"
             ]
         },
+        "types.BillingPeriodBehaviour": {
+            "type": "string",
+            "enum": [
+                "unchanged",
+                "anchor_at_effect",
+                "anchor_at_config"
+            ],
+            "x-enum-varnames": [
+                "BillingPeriodBehaviourUnchanged",
+                "BillingPeriodBehaviourAnchorAtEffect",
+                "BillingPeriodBehaviourAnchorAtConfig"
+            ]
+        },
         "types.BillingTier": {
             "type": "string",
             "enum": [
@@ -26624,11 +26719,13 @@ const docTemplate = `{
             "type": "string",
             "enum": [
                 "carry",
-                "drop"
+                "drop",
+                "add"
             ],
             "x-enum-varnames": [
                 "EntityChangeBehaviourCarry",
-                "EntityChangeBehaviourDrop"
+                "EntityChangeBehaviourDrop",
+                "EntityChangeBehaviourAdd"
             ]
         },
         "types.EntitySyncConfig": {
@@ -27289,6 +27386,17 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "types.OnPendingSchedulePolicy": {
+            "type": "string",
+            "enum": [
+                "reject",
+                "supersede"
+            ],
+            "x-enum-varnames": [
+                "OnPendingSchedulePolicyReject",
+                "OnPendingSchedulePolicySupersede"
+            ]
         },
         "types.PaginationResponse": {
             "type": "object",
@@ -28087,6 +28195,23 @@ const docTemplate = `{
                 "StatusPublished",
                 "StatusDeleted",
                 "StatusArchived"
+            ]
+        },
+        "types.SubscriptionChangeEntityType": {
+            "type": "string",
+            "enum": [
+                "plan",
+                "addon",
+                "credit_grant",
+                "entitlement",
+                "entitlement_grant"
+            ],
+            "x-enum-varnames": [
+                "SubscriptionChangeEntityTypePlan",
+                "SubscriptionChangeEntityTypeAddon",
+                "SubscriptionChangeEntityTypeCreditGrant",
+                "SubscriptionChangeEntityTypeEntitlement",
+                "SubscriptionChangeEntityTypeEntitlementGrant"
             ]
         },
         "types.SubscriptionChangeType": {

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -9788,7 +9788,7 @@
           "Subscriptions"
         ],
         "summary": "Execute a plan change (v2, swap in place)",
-        "description": "Change a subscription's plan in place. Subscription id, billing anchor and period bounds are preserved; line items are sliced and settled in one transaction.\n\nchange_at controls timing. Omitted or 'immediate' applies the change now. 'end_of_period' records a pending schedule that executes at the subscription's current period end: the response returns is_scheduled, schedule_id and scheduled_at instead of a completed change, and nothing is swapped or billed until the boundary.\n\nscheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away \u2014 inspect scheduled_at to see this.\n\nOnly one plan change may be pending per subscription; request a second one and this returns 400. Cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.",
+        "description": "Change a subscription's plan in place. Subscription id, billing anchor and period bounds are preserved; line items are sliced and settled in one transaction.\n\nchange_at controls timing. Omitted or 'immediate' applies the change now. 'end_of_period' records a pending schedule that executes at the subscription's current period end: the response returns is_scheduled, schedule_id and scheduled_at instead of a completed change, and nothing is swapped or billed until the boundary.\n\nscheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away \u2014 inspect scheduled_at to see this.\n\nOnly one plan change may be pending per subscription. By default (on_conflict_policies.on_pending_schedule = 'reject') a second request returns 400; cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.\n\nSet on_conflict_policies.on_pending_schedule to 'supersede' to replace the queued change instead: the pending schedule is cancelled and this request applied in the same transaction, so both land or neither does. The cancelled schedule ids are returned in superseded_schedules, and preview reports the same list without writing.",
         "operationId": "executeSubscriptionPlanChangeV2",
         "parameters": [
           {
@@ -16343,6 +16343,24 @@
           }
         }
       },
+      "BillingPeriodConfig": {
+        "type": "object",
+        "properties": {
+          "billing_anchor": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "billing_cycle": {
+            "$ref": "#/components/schemas/types.BillingCycle"
+          },
+          "billing_period_count": {
+            "type": "integer"
+          },
+          "billing_period_unit": {
+            "$ref": "#/components/schemas/types.BillingPeriod"
+          }
+        }
+      },
       "BillingPeriodInfo": {
         "type": "object",
         "properties": {
@@ -19758,7 +19776,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/types.EntityChangeBehaviour"
             },
-            "description": "Overrides is keyed by addon_associations.id (instance), not catalogue addon_id."
+            "description": "Overrides is keyed by addon_associations.id (instance), not catalogue addon_id.\nThat is the id an EntityChangeResult reports as EntityID."
           }
         }
       },
@@ -19772,7 +19790,7 @@
             "type": "string"
           },
           "entity_type": {
-            "$ref": "#/components/schemas/types.SubscriptionLineItemEntityType"
+            "$ref": "#/components/schemas/types.SubscriptionChangeEntityType"
           },
           "reference_id": {
             "type": "string"
@@ -22029,6 +22047,14 @@
           }
         }
       },
+      "PriceFeatureResponse": {
+        "type": "object",
+        "properties": {
+          "reporting_unit": {
+            "$ref": "#/components/schemas/types.ReportingUnit"
+          }
+        }
+      },
       "PriceLookupResult": {
         "type": "object",
         "properties": {
@@ -22115,6 +22141,9 @@
           "environment_id": {
             "type": "string",
             "description": "EnvironmentID is the environment identifier for the price"
+          },
+          "feature": {
+            "$ref": "#/components/schemas/PriceFeatureResponse"
           },
           "group": {
             "$ref": "#/components/schemas/GroupResponse"
@@ -22750,6 +22779,34 @@
           }
         }
       },
+      "SubscriptionChangeBillingPeriodResult": {
+        "type": "object",
+        "properties": {
+          "behaviour": {
+            "$ref": "#/components/schemas/types.BillingPeriodBehaviour"
+          },
+          "billing_anchor": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "current_period_end": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "current_period_start": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "SubscriptionChangeConflictPolicies": {
+        "type": "object",
+        "properties": {
+          "on_pending_schedule": {
+            "$ref": "#/components/schemas/types.OnPendingSchedulePolicy"
+          }
+        }
+      },
       "SubscriptionChangeEntityPolicies": {
         "type": "object",
         "properties": {
@@ -22908,6 +22965,12 @@
         ],
         "type": "object",
         "properties": {
+          "billing_period_behaviour": {
+            "$ref": "#/components/schemas/types.BillingPeriodBehaviour"
+          },
+          "billing_period_config": {
+            "$ref": "#/components/schemas/BillingPeriodConfig"
+          },
           "change_at": {
             "$ref": "#/components/schemas/types.ScheduleType"
           },
@@ -22923,6 +22986,9 @@
               "type": "string"
             }
           },
+          "on_conflict_policies": {
+            "$ref": "#/components/schemas/SubscriptionChangeConflictPolicies"
+          },
           "proration_behavior": {
             "$ref": "#/components/schemas/types.ProrationBehavior"
           },
@@ -22934,6 +23000,9 @@
       "SubscriptionChangeV2Response": {
         "type": "object",
         "properties": {
+          "billing_period": {
+            "$ref": "#/components/schemas/SubscriptionChangeBillingPeriodResult"
+          },
           "change_type": {
             "$ref": "#/components/schemas/types.SubscriptionChangeType"
           },
@@ -22972,6 +23041,13 @@
           },
           "subscription": {
             "$ref": "#/components/schemas/SubscriptionResponse"
+          },
+          "superseded_schedules": {
+            "type": "array",
+            "description": "SupersededSchedules lists the plan-change schedules this request cancelled under\non_conflict_policies.on_pending_schedule. Preview reports what execute would cancel.",
+            "items": {
+              "type": "string"
+            }
           },
           "to_plan": {
             "$ref": "#/components/schemas/PlanSummary"
@@ -27665,6 +27741,20 @@
         ],
         "x-speakeasy-name-override": "BillingPeriod"
       },
+      "types.BillingPeriodBehaviour": {
+        "type": "string",
+        "enum": [
+          "unchanged",
+          "anchor_at_effect",
+          "anchor_at_config"
+        ],
+        "x-enum-varnames": [
+          "BillingPeriodBehaviourUnchanged",
+          "BillingPeriodBehaviourAnchorAtEffect",
+          "BillingPeriodBehaviourAnchorAtConfig"
+        ],
+        "x-speakeasy-name-override": "BillingPeriodBehaviour"
+      },
       "types.BillingTier": {
         "type": "string",
         "enum": [
@@ -28416,11 +28506,13 @@
         "type": "string",
         "enum": [
           "carry",
-          "drop"
+          "drop",
+          "add"
         ],
         "x-enum-varnames": [
           "EntityChangeBehaviourCarry",
-          "EntityChangeBehaviourDrop"
+          "EntityChangeBehaviourDrop",
+          "EntityChangeBehaviourAdd"
         ],
         "x-speakeasy-name-override": "EntityChangeBehaviour"
       },
@@ -29092,6 +29184,18 @@
           }
         },
         "x-speakeasy-name-override": "ModifySubscriptionParams"
+      },
+      "types.OnPendingSchedulePolicy": {
+        "type": "string",
+        "enum": [
+          "reject",
+          "supersede"
+        ],
+        "x-enum-varnames": [
+          "OnPendingSchedulePolicyReject",
+          "OnPendingSchedulePolicySupersede"
+        ],
+        "x-speakeasy-name-override": "OnPendingSchedulePolicy"
       },
       "types.PaginationResponse": {
         "type": "object",
@@ -29915,6 +30019,24 @@
           "StatusArchived"
         ],
         "x-speakeasy-name-override": "Status"
+      },
+      "types.SubscriptionChangeEntityType": {
+        "type": "string",
+        "enum": [
+          "plan",
+          "addon",
+          "credit_grant",
+          "entitlement",
+          "entitlement_grant"
+        ],
+        "x-enum-varnames": [
+          "SubscriptionChangeEntityTypePlan",
+          "SubscriptionChangeEntityTypeAddon",
+          "SubscriptionChangeEntityTypeCreditGrant",
+          "SubscriptionChangeEntityTypeEntitlement",
+          "SubscriptionChangeEntityTypeEntitlementGrant"
+        ],
+        "x-speakeasy-name-override": "SubscriptionChangeEntityType"
       },
       "types.SubscriptionChangeType": {
         "type": "string",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -8150,7 +8150,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Change a subscription's plan in place. Subscription id, billing anchor and period bounds are preserved; line items are sliced and settled in one transaction.\n\nchange_at controls timing. Omitted or 'immediate' applies the change now. 'end_of_period' records a pending schedule that executes at the subscription's current period end: the response returns is_scheduled, schedule_id and scheduled_at instead of a completed change, and nothing is swapped or billed until the boundary.\n\nscheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away — inspect scheduled_at to see this.\n\nOnly one plan change may be pending per subscription; request a second one and this returns 400. Cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.",
+                "description": "Change a subscription's plan in place. Subscription id, billing anchor and period bounds are preserved; line items are sliced and settled in one transaction.\n\nchange_at controls timing. Omitted or 'immediate' applies the change now. 'end_of_period' records a pending schedule that executes at the subscription's current period end: the response returns is_scheduled, schedule_id and scheduled_at instead of a completed change, and nothing is swapped or billed until the boundary.\n\nscheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away — inspect scheduled_at to see this.\n\nOnly one plan change may be pending per subscription. By default (on_conflict_policies.on_pending_schedule = 'reject') a second request returns 400; cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.\n\nSet on_conflict_policies.on_pending_schedule to 'supersede' to replace the queued change instead: the pending schedule is cancelled and this request applied in the same transaction, so both land or neither does. The cancelled schedule ids are returned in superseded_schedules, and preview reports the same list without writing.",
                 "consumes": [
                     "application/json"
                 ],
@@ -14067,6 +14067,23 @@
                 }
             }
         },
+        "BillingPeriodConfig": {
+            "type": "object",
+            "properties": {
+                "billing_anchor": {
+                    "type": "string"
+                },
+                "billing_cycle": {
+                    "$ref": "#/definitions/types.BillingCycle"
+                },
+                "billing_period_count": {
+                    "type": "integer"
+                },
+                "billing_period_unit": {
+                    "$ref": "#/definitions/types.BillingPeriod"
+                }
+            }
+        },
         "BillingPeriodInfo": {
             "type": "object",
             "properties": {
@@ -17485,7 +17502,7 @@
                     "$ref": "#/definitions/types.EntityChangeBehaviour"
                 },
                 "overrides": {
-                    "description": "Overrides is keyed by addon_associations.id (instance), not catalogue addon_id.",
+                    "description": "Overrides is keyed by addon_associations.id (instance), not catalogue addon_id.\nThat is the id an EntityChangeResult reports as EntityID.",
                     "type": "object",
                     "additionalProperties": {
                         "$ref": "#/definitions/types.EntityChangeBehaviour"
@@ -17503,7 +17520,7 @@
                     "type": "string"
                 },
                 "entity_type": {
-                    "$ref": "#/definitions/types.SubscriptionLineItemEntityType"
+                    "$ref": "#/definitions/types.SubscriptionChangeEntityType"
                 },
                 "reference_id": {
                     "type": "string"
@@ -19715,6 +19732,14 @@
                 }
             }
         },
+        "PriceFeatureResponse": {
+            "type": "object",
+            "properties": {
+                "reporting_unit": {
+                    "$ref": "#/definitions/types.ReportingUnit"
+                }
+            }
+        },
         "PriceLookupResult": {
             "type": "object",
             "properties": {
@@ -19801,6 +19826,9 @@
                 "environment_id": {
                     "description": "EnvironmentID is the environment identifier for the price",
                     "type": "string"
+                },
+                "feature": {
+                    "$ref": "#/definitions/PriceFeatureResponse"
                 },
                 "group": {
                     "$ref": "#/definitions/GroupResponse"
@@ -20434,6 +20462,32 @@
                 }
             }
         },
+        "SubscriptionChangeBillingPeriodResult": {
+            "type": "object",
+            "properties": {
+                "behaviour": {
+                    "$ref": "#/definitions/types.BillingPeriodBehaviour"
+                },
+                "billing_anchor": {
+                    "type": "string"
+                },
+                "current_period_end": {
+                    "type": "string"
+                },
+                "current_period_start": {
+                    "type": "string"
+                }
+            }
+        },
+        "SubscriptionChangeConflictPolicies": {
+            "type": "object",
+            "properties": {
+                "on_pending_schedule": {
+                    "description": "OnPendingSchedule applies to a queued plan change only. A pending cancellation\nor pause is still rejected outright: clearing those would mean un-cancelling or\nauto-resuming the subscription.",
+                    "$ref": "#/definitions/types.OnPendingSchedulePolicy"
+                }
+            }
+        },
         "SubscriptionChangeEntityPolicies": {
             "type": "object",
             "properties": {
@@ -20606,6 +20660,13 @@
                 "target_plan_id"
             ],
             "properties": {
+                "billing_period_behaviour": {
+                    "description": "BillingPeriodBehaviour controls the billing anchor. Omitted means \"unchanged\":\nthe swap is priced as a prorated delta inside the running period.",
+                    "$ref": "#/definitions/types.BillingPeriodBehaviour"
+                },
+                "billing_period_config": {
+                    "$ref": "#/definitions/BillingPeriodConfig"
+                },
                 "change_at": {
                     "description": "ChangeAt controls when the change takes effect. nil or \"immediate\" applies\nit now; \"end_of_period\" schedules it at the subscription's current period end.",
                     "$ref": "#/definitions/types.ScheduleType"
@@ -20622,6 +20683,9 @@
                         "type": "string"
                     }
                 },
+                "on_conflict_policies": {
+                    "$ref": "#/definitions/SubscriptionChangeConflictPolicies"
+                },
                 "proration_behavior": {
                     "$ref": "#/definitions/types.ProrationBehavior"
                 },
@@ -20633,6 +20697,9 @@
         "SubscriptionChangeV2Response": {
             "type": "object",
             "properties": {
+                "billing_period": {
+                    "$ref": "#/definitions/SubscriptionChangeBillingPeriodResult"
+                },
                 "change_type": {
                     "$ref": "#/definitions/types.SubscriptionChangeType"
                 },
@@ -20669,6 +20736,13 @@
                 },
                 "subscription": {
                     "$ref": "#/definitions/SubscriptionResponse"
+                },
+                "superseded_schedules": {
+                    "description": "SupersededSchedules lists the plan-change schedules this request cancelled under\non_conflict_policies.on_pending_schedule. Preview reports what execute would cancel.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "to_plan": {
                     "$ref": "#/definitions/PlanSummary"
@@ -25256,6 +25330,19 @@
                 "BILLING_PERIOD_ONETIME"
             ]
         },
+        "types.BillingPeriodBehaviour": {
+            "type": "string",
+            "enum": [
+                "unchanged",
+                "anchor_at_effect",
+                "anchor_at_config"
+            ],
+            "x-enum-varnames": [
+                "BillingPeriodBehaviourUnchanged",
+                "BillingPeriodBehaviourAnchorAtEffect",
+                "BillingPeriodBehaviourAnchorAtConfig"
+            ]
+        },
         "types.BillingTier": {
             "type": "string",
             "enum": [
@@ -25964,11 +26051,13 @@
             "type": "string",
             "enum": [
                 "carry",
-                "drop"
+                "drop",
+                "add"
             ],
             "x-enum-varnames": [
                 "EntityChangeBehaviourCarry",
-                "EntityChangeBehaviourDrop"
+                "EntityChangeBehaviourDrop",
+                "EntityChangeBehaviourAdd"
             ]
         },
         "types.EntitySyncConfig": {
@@ -26609,6 +26698,17 @@
                     "type": "string"
                 }
             }
+        },
+        "types.OnPendingSchedulePolicy": {
+            "type": "string",
+            "enum": [
+                "reject",
+                "supersede"
+            ],
+            "x-enum-varnames": [
+                "OnPendingSchedulePolicyReject",
+                "OnPendingSchedulePolicySupersede"
+            ]
         },
         "types.PaginationResponse": {
             "type": "object",
@@ -27391,6 +27491,23 @@
                 "StatusPublished",
                 "StatusDeleted",
                 "StatusArchived"
+            ]
+        },
+        "types.SubscriptionChangeEntityType": {
+            "type": "string",
+            "enum": [
+                "plan",
+                "addon",
+                "credit_grant",
+                "entitlement",
+                "entitlement_grant"
+            ],
+            "x-enum-varnames": [
+                "SubscriptionChangeEntityTypePlan",
+                "SubscriptionChangeEntityTypeAddon",
+                "SubscriptionChangeEntityTypeCreditGrant",
+                "SubscriptionChangeEntityTypeEntitlement",
+                "SubscriptionChangeEntityTypeEntitlementGrant"
             ]
         },
         "types.SubscriptionChangeType": {

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -830,6 +830,17 @@ definitions:
         description: period_start is the start of the new billing period
         type: string
     type: object
+  BillingPeriodConfig:
+    properties:
+      billing_anchor:
+        type: string
+      billing_cycle:
+        $ref: '#/definitions/types.BillingCycle'
+      billing_period_count:
+        type: integer
+      billing_period_unit:
+        $ref: '#/definitions/types.BillingPeriod'
+    type: object
   BillingPeriodInfo:
     properties:
       end_time:
@@ -3510,8 +3521,9 @@ definitions:
       overrides:
         additionalProperties:
           $ref: '#/definitions/types.EntityChangeBehaviour'
-        description: Overrides is keyed by addon_associations.id (instance), not catalogue
-          addon_id.
+        description: |-
+          Overrides is keyed by addon_associations.id (instance), not catalogue addon_id.
+          That is the id an EntityChangeResult reports as EntityID.
         type: object
     type: object
   EntityChangeResult:
@@ -3521,7 +3533,7 @@ definitions:
       entity_id:
         type: string
       entity_type:
-        $ref: '#/definitions/types.SubscriptionLineItemEntityType'
+        $ref: '#/definitions/types.SubscriptionChangeEntityType'
       reference_id:
         type: string
     type: object
@@ -5192,6 +5204,11 @@ definitions:
       price_id:
         type: string
     type: object
+  PriceFeatureResponse:
+    properties:
+      reporting_unit:
+        $ref: '#/definitions/types.ReportingUnit'
+    type: object
   PriceLookupResult:
     properties:
       error:
@@ -5262,6 +5279,8 @@ definitions:
       environment_id:
         description: EnvironmentID is the environment identifier for the price
         type: string
+      feature:
+        $ref: '#/definitions/PriceFeatureResponse'
       group:
         $ref: '#/definitions/GroupResponse'
       group_id:
@@ -5733,6 +5752,27 @@ definitions:
     required:
     - action
     type: object
+  SubscriptionChangeBillingPeriodResult:
+    properties:
+      behaviour:
+        $ref: '#/definitions/types.BillingPeriodBehaviour'
+      billing_anchor:
+        type: string
+      current_period_end:
+        type: string
+      current_period_start:
+        type: string
+    type: object
+  SubscriptionChangeConflictPolicies:
+    properties:
+      on_pending_schedule:
+        allOf:
+        - $ref: '#/definitions/types.OnPendingSchedulePolicy'
+        description: |-
+          OnPendingSchedule applies to a queued plan change only. A pending cancellation
+          or pause is still rejected outright: clearing those would mean un-cancelling or
+          auto-resuming the subscription.
+    type: object
   SubscriptionChangeEntityPolicies:
     properties:
       addons:
@@ -5889,6 +5929,14 @@ definitions:
     type: object
   SubscriptionChangeV2Request:
     properties:
+      billing_period_behaviour:
+        allOf:
+        - $ref: '#/definitions/types.BillingPeriodBehaviour'
+        description: |-
+          BillingPeriodBehaviour controls the billing anchor. Omitted means "unchanged":
+          the swap is priced as a prorated delta inside the running period.
+      billing_period_config:
+        $ref: '#/definitions/BillingPeriodConfig'
       change_at:
         allOf:
         - $ref: '#/definitions/types.ScheduleType'
@@ -5903,6 +5951,8 @@ definitions:
         additionalProperties:
           type: string
         type: object
+      on_conflict_policies:
+        $ref: '#/definitions/SubscriptionChangeConflictPolicies'
       proration_behavior:
         $ref: '#/definitions/types.ProrationBehavior'
       target_plan_id:
@@ -5913,6 +5963,8 @@ definitions:
     type: object
   SubscriptionChangeV2Response:
     properties:
+      billing_period:
+        $ref: '#/definitions/SubscriptionChangeBillingPeriodResult'
       change_type:
         $ref: '#/definitions/types.SubscriptionChangeType'
       changed_resources:
@@ -5940,6 +5992,13 @@ definitions:
         type: string
       subscription:
         $ref: '#/definitions/SubscriptionResponse'
+      superseded_schedules:
+        description: |-
+          SupersededSchedules lists the plan-change schedules this request cancelled under
+          on_conflict_policies.on_pending_schedule. Preview reports what execute would cancel.
+        items:
+          type: string
+        type: array
       to_plan:
         $ref: '#/definitions/PlanSummary'
       warnings:
@@ -9438,6 +9497,16 @@ definitions:
     - BILLING_PERIOD_QUARTER
     - BILLING_PERIOD_HALF_YEAR
     - BILLING_PERIOD_ONETIME
+  types.BillingPeriodBehaviour:
+    enum:
+    - unchanged
+    - anchor_at_effect
+    - anchor_at_config
+    type: string
+    x-enum-varnames:
+    - BillingPeriodBehaviourUnchanged
+    - BillingPeriodBehaviourAnchorAtEffect
+    - BillingPeriodBehaviourAnchorAtConfig
   types.BillingTier:
     enum:
     - VOLUME
@@ -9959,10 +10028,12 @@ definitions:
     enum:
     - carry
     - drop
+    - add
     type: string
     x-enum-varnames:
     - EntityChangeBehaviourCarry
     - EntityChangeBehaviourDrop
+    - EntityChangeBehaviourAdd
   types.EntitySyncConfig:
     properties:
       inbound:
@@ -10466,6 +10537,14 @@ definitions:
       subscription_id:
         type: string
     type: object
+  types.OnPendingSchedulePolicy:
+    enum:
+    - reject
+    - supersede
+    type: string
+    x-enum-varnames:
+    - OnPendingSchedulePolicyReject
+    - OnPendingSchedulePolicySupersede
   types.PaginationResponse:
     properties:
       limit:
@@ -11060,6 +11139,20 @@ definitions:
     - StatusPublished
     - StatusDeleted
     - StatusArchived
+  types.SubscriptionChangeEntityType:
+    enum:
+    - plan
+    - addon
+    - credit_grant
+    - entitlement
+    - entitlement_grant
+    type: string
+    x-enum-varnames:
+    - SubscriptionChangeEntityTypePlan
+    - SubscriptionChangeEntityTypeAddon
+    - SubscriptionChangeEntityTypeCreditGrant
+    - SubscriptionChangeEntityTypeEntitlement
+    - SubscriptionChangeEntityTypeEntitlementGrant
   types.SubscriptionChangeType:
     enum:
     - upgrade
@@ -17622,7 +17715,9 @@ paths:
 
         scheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away — inspect scheduled_at to see this.
 
-        Only one plan change may be pending per subscription; request a second one and this returns 400. Cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.
+        Only one plan change may be pending per subscription. By default (on_conflict_policies.on_pending_schedule = 'reject') a second request returns 400; cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.
+
+        Set on_conflict_policies.on_pending_schedule to 'supersede' to replace the queued change instead: the pending schedule is cancelled and this request applied in the same transaction, so both land or neither does. The cancelled schedule ids are returned in superseded_schedules, and preview reports the same list without writing.
       operationId: executeSubscriptionPlanChangeV2
       parameters:
       - description: Subscription ID

--- a/internal/api/dto/billing.go
+++ b/internal/api/dto/billing.go
@@ -169,12 +169,14 @@ func (p *CalculateChargesParams) Validate() error {
 
 // CreateInvoiceRequestForChargesParams holds inputs for CreateInvoiceRequestForCharges.
 type CreateInvoiceRequestForChargesParams struct {
-	Subscription *subscription.Subscription `validate:"required"`
-	Result       *BillingCalculationResult  // nil produces a zero-amount invoice
-	PeriodStart  time.Time                  `validate:"required"`
-	PeriodEnd    time.Time                  `validate:"required"`
-	Description  string
-	Metadata     types.Metadata
+	Subscription  *subscription.Subscription `validate:"required"`
+	Result        *BillingCalculationResult  // nil produces a zero-amount invoice
+	PeriodStart   time.Time                  `validate:"required"`
+	PeriodEnd     time.Time                  `validate:"required"`
+	Description   string
+	Metadata      types.Metadata
+	InvoiceType   types.InvoiceType
+	BillingReason types.InvoiceBillingReason
 }
 
 // Validate enforces struct tags.
@@ -206,4 +208,3 @@ type CalculateUsageChargesResult struct {
 	LineItems   []CreateInvoiceLineItemRequest
 	TotalAmount decimal.Decimal
 }
-

--- a/internal/api/dto/creditgrant.go
+++ b/internal/api/dto/creditgrant.go
@@ -50,6 +50,33 @@ type CreateCreditGrantRequest struct {
 	FirstPeriodProration *FirstPeriodProration `json:"-"`
 }
 
+// NewSubscriptionScopedCreditGrantRequest maps a plan-scoped credit grant to the
+// subscription-scoped request that materialises it. Subscription creation and plan
+// change both build the request here so the two paths cannot drift apart.
+func NewSubscriptionScopedCreditGrantRequest(
+	cg *CreditGrantResponse,
+	subscriptionID string,
+	planID string,
+) CreateCreditGrantRequest {
+	return CreateCreditGrantRequest{
+		Name:                   cg.Name,
+		Scope:                  types.CreditGrantScopeSubscription,
+		Credits:                cg.Credits,
+		Cadence:                cg.Cadence,
+		ExpirationType:         cg.ExpirationType,
+		Priority:               cg.Priority,
+		SubscriptionID:         lo.ToPtr(subscriptionID),
+		Period:                 cg.Period,
+		PlanID:                 lo.ToPtr(planID),
+		ExpirationDuration:     cg.ExpirationDuration,
+		ExpirationDurationUnit: cg.ExpirationDurationUnit,
+		Metadata:               cg.Metadata,
+		PeriodCount:            cg.PeriodCount,
+		ConversionRate:         cg.ConversionRate,
+		TopupConversionRate:    cg.TopupConversionRate,
+	}
+}
+
 // FirstPeriodProration describes the billing period a mid-cycle grant lands in.
 // It is consumed once, when the first credit grant application is created, and is
 // deliberately never persisted on the grant: every later period is a whole period

--- a/internal/api/dto/creditgrant.go
+++ b/internal/api/dto/creditgrant.go
@@ -499,6 +499,9 @@ type CancelFutureSubscriptionGrantsRequest struct {
 	// AddonID, when set, scopes cancellation to grants materialized from this addon
 	// (via addon_id provenance). Leave empty to cancel all of the subscription's grants.
 	AddonID *string `json:"addon_id,omitempty"`
+	// PlanID, when set, scopes cancellation to grants materialized from this plan
+	// (via plan_id provenance), so a plan swap leaves addon-sourced grants alone.
+	PlanID *string `json:"plan_id,omitempty"`
 }
 
 // Validate validates the cancel future subscription grants request

--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -121,9 +121,6 @@ func (p *EntityChangePolicy) BehaviourFor(referenceID string) types.EntityChange
 	return types.EntityChangeBehaviourCarry
 }
 
-// EntityChangeResult reports one entity the plan change carried, dropped or added.
-// ReferenceID identifies the affected record (addon association, credit grant,
-// entitlement); EntityID identifies what it came from (addon, plan).
 type EntityChangeResult struct {
 	EntityType  types.SubscriptionChangeEntityType `json:"entity_type"`
 	ReferenceID string                             `json:"reference_id"`
@@ -176,7 +173,7 @@ type SubscriptionChangeBillingPeriodResult struct {
 }
 
 // validateBillingPeriodBehaviour enforces the behaviour matrix. reset_at is rejected
-// outright rather than inferred as reset_at_effective: the enum already has a value that
+// outright rather than inferred as reset_at_effect: the enum already has a value that
 // says "reset at effective", so inferring one from the other would only hide a mistake.
 func (r *SubscriptionChangeV2Request) validateBillingPeriodBehaviour() error {
 	if err := r.BillingPeriodBehaviour.Validate(); err != nil {
@@ -185,13 +182,13 @@ func (r *SubscriptionChangeV2Request) validateBillingPeriodBehaviour() error {
 
 	if r.BillingPeriodConfig != nil {
 		return ierr.NewError("billing_period_config is not supported yet").
-			WithHint("Remove billing_period_config. Use billing_period_behaviour='reset_at_effective' to restart the term at the change instant.").
+			WithHint("Remove billing_period_config. Use billing_period_behaviour='reset_at_effect' to restart the term at the change instant.").
 			Mark(ierr.ErrValidation)
 	}
 
 	if r.BillingPeriodBehaviour == types.BillingPeriodBehaviourResetAt {
 		return ierr.NewError("billing_period_behaviour 'reset_at' is not supported yet").
-			WithHint("Use 'reset_at_effective' to restart the term at the change instant.").
+			WithHint("Use 'reset_at_effect' to restart the term at the change instant.").
 			WithReportableDetails(map[string]any{
 				"supported": []types.BillingPeriodBehaviour{
 					types.BillingPeriodBehaviourUnchanged,

--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -21,11 +21,40 @@ type SubscriptionChangeV2Request struct {
 
 	OnConflictPolicies *SubscriptionChangeConflictPolicies `json:"on_conflict_policies,omitempty"`
 
+	// BillingPeriodBehaviour controls the billing anchor. Omitted means "unchanged":
+	// the swap is priced as a prorated delta inside the running period.
+	BillingPeriodBehaviour types.BillingPeriodBehaviour `json:"billing_period_behaviour,omitempty"`
+	BillingPeriodConfig    *BillingPeriodConfig         `json:"billing_period_config,omitempty"`
+
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 func (r *SubscriptionChangeV2Request) IsDeferred() bool {
 	return r != nil && r.ChangeAt != nil && *r.ChangeAt == types.ScheduleTypePeriodEnd
+}
+
+// BillingPeriodConfig defines the billing period for any recurring entity.
+type BillingPeriodConfig struct {
+	BillingCycle       *types.BillingCycle  `json:"billing_cycle,omitempty"`
+	BillingPeriodUnit  *types.BillingPeriod `json:"billing_period_unit,omitempty"`
+	BillingPeriodCount *int                 `json:"billing_period_count,omitempty"`
+	BillingAnchor      *time.Time           `json:"billing_anchor,omitempty"`
+}
+
+// EffectiveBillingPeriodBehaviour resolves the omitted case, so the response never echoes
+// an empty behaviour back at the caller.
+func (r *SubscriptionChangeV2Request) EffectiveBillingPeriodBehaviour() types.BillingPeriodBehaviour {
+	if r == nil || r.BillingPeriodBehaviour == "" {
+		return types.BillingPeriodBehaviourUnchanged
+	}
+
+	return r.BillingPeriodBehaviour
+}
+
+// ResetsAnchorAtEffective reports whether the change restarts the term at the instant it
+// takes effect.
+func (r *SubscriptionChangeV2Request) ResetsAnchorAtEffective() bool {
+	return r != nil && r.BillingPeriodBehaviour == types.BillingPeriodBehaviourResetAtEffect
 }
 
 // SubscriptionChangeConflictPolicies decides how the change reacts to state that
@@ -127,9 +156,63 @@ func (r *SubscriptionChangeV2Request) Validate() error {
 		return err
 	}
 
+	if err := r.validateBillingPeriodBehaviour(); err != nil {
+		return err
+	}
+
 	if r.EntityPolicies != nil {
 		return r.EntityPolicies.Addons.Validate()
 	}
+	return nil
+}
+
+// SubscriptionChangeBillingPeriodResult is the anchor state after the change. For a
+// deferred change it is the state at request time: the boundary has not arrived yet.
+type SubscriptionChangeBillingPeriodResult struct {
+	Behaviour          types.BillingPeriodBehaviour `json:"behaviour"`
+	BillingAnchor      time.Time                    `json:"billing_anchor"`
+	CurrentPeriodStart time.Time                    `json:"current_period_start"`
+	CurrentPeriodEnd   time.Time                    `json:"current_period_end"`
+}
+
+// validateBillingPeriodBehaviour enforces the behaviour matrix. reset_at is rejected
+// outright rather than inferred as reset_at_effective: the enum already has a value that
+// says "reset at effective", so inferring one from the other would only hide a mistake.
+func (r *SubscriptionChangeV2Request) validateBillingPeriodBehaviour() error {
+	if err := r.BillingPeriodBehaviour.Validate(); err != nil {
+		return err
+	}
+
+	if r.BillingPeriodConfig != nil {
+		return ierr.NewError("billing_period_config is not supported yet").
+			WithHint("Remove billing_period_config. Use billing_period_behaviour='reset_at_effective' to restart the term at the change instant.").
+			Mark(ierr.ErrValidation)
+	}
+
+	if r.BillingPeriodBehaviour == types.BillingPeriodBehaviourResetAt {
+		return ierr.NewError("billing_period_behaviour 'reset_at' is not supported yet").
+			WithHint("Use 'reset_at_effective' to restart the term at the change instant.").
+			WithReportableDetails(map[string]any{
+				"supported": []types.BillingPeriodBehaviour{
+					types.BillingPeriodBehaviourUnchanged,
+					types.BillingPeriodBehaviourResetAtEffect,
+				},
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	if !r.ResetsAnchorAtEffective() {
+		return nil
+	}
+
+	// A reset settles the whole term in one close-out invoice, so a prorated delta on
+	// top of it would charge the new plan twice.
+	if r.ProrationBehavior == types.ProrationBehaviorCreateProrations {
+		return ierr.NewError("proration is not applicable when the billing period is reset").
+			WithHint("Set proration_behavior to 'none'. Resetting the anchor settles the outgoing period and bills the new plan in full.").
+			Mark(ierr.ErrValidation)
+	}
+
 	return nil
 }
 
@@ -152,7 +235,8 @@ type SubscriptionChangeV2Response struct {
 
 	// SupersededSchedules lists the plan-change schedules this request cancelled under
 	// on_conflict_policies.on_pending_schedule. Preview reports what execute would cancel.
-	SupersededSchedules []string `json:"superseded_schedules,omitempty"`
+	SupersededSchedules []string                              `json:"superseded_schedules,omitempty"`
+	BillingPeriod       SubscriptionChangeBillingPeriodResult `json:"billing_period"`
 
 	Warnings []string          `json:"warnings,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`

--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -92,11 +92,14 @@ func (p *EntityChangePolicy) BehaviourFor(referenceID string) types.EntityChange
 	return types.EntityChangeBehaviourCarry
 }
 
+// EntityChangeResult reports one entity the plan change carried, dropped or added.
+// ReferenceID identifies the affected record (addon association, credit grant,
+// entitlement); EntityID identifies what it came from (addon, plan).
 type EntityChangeResult struct {
-	EntityType  types.SubscriptionLineItemEntityType `json:"entity_type"`
-	ReferenceID string                               `json:"reference_id"`
-	EntityID    string                               `json:"entity_id"`
-	Behaviour   types.EntityChangeBehaviour          `json:"behaviour"`
+	EntityType  types.SubscriptionChangeEntityType `json:"entity_type"`
+	ReferenceID string                             `json:"reference_id"`
+	EntityID    string                             `json:"entity_id"`
+	Behaviour   types.EntityChangeBehaviour        `json:"behaviour"`
 }
 
 func (r *SubscriptionChangeV2Request) Validate() error {

--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -19,11 +19,36 @@ type SubscriptionChangeV2Request struct {
 	// it now; "end_of_period" schedules it at the subscription's current period end.
 	ChangeAt *types.ScheduleType `json:"change_at,omitempty"`
 
+	OnConflictPolicies *SubscriptionChangeConflictPolicies `json:"on_conflict_policies,omitempty"`
+
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
 func (r *SubscriptionChangeV2Request) IsDeferred() bool {
 	return r != nil && r.ChangeAt != nil && *r.ChangeAt == types.ScheduleTypePeriodEnd
+}
+
+// SubscriptionChangeConflictPolicies decides how the change reacts to state that
+// would otherwise block it.
+type SubscriptionChangeConflictPolicies struct {
+	// OnPendingSchedule applies to a queued plan change only. A pending cancellation
+	// or pause is still rejected outright: clearing those would mean un-cancelling or
+	// auto-resuming the subscription.
+	OnPendingSchedule types.OnPendingSchedulePolicy `json:"on_pending_schedule,omitempty"`
+}
+
+func (p *SubscriptionChangeConflictPolicies) Validate() error {
+	if p == nil {
+		return nil
+	}
+	return p.OnPendingSchedule.Validate()
+}
+
+// SupersedesPendingSchedule reports whether a queued plan change should be cancelled
+// in favour of this request.
+func (r *SubscriptionChangeV2Request) SupersedesPendingSchedule() bool {
+	return r != nil && r.OnConflictPolicies != nil &&
+		r.OnConflictPolicies.OnPendingSchedule == types.OnPendingSchedulePolicySupersede
 }
 
 type SubscriptionChangeEntityPolicies struct {
@@ -95,6 +120,10 @@ func (r *SubscriptionChangeV2Request) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
+	if err := r.OnConflictPolicies.Validate(); err != nil {
+		return err
+	}
+
 	if r.EntityPolicies != nil {
 		return r.EntityPolicies.Addons.Validate()
 	}
@@ -117,6 +146,10 @@ type SubscriptionChangeV2Response struct {
 	IsScheduled bool       `json:"is_scheduled"`
 	ScheduleID  *string    `json:"schedule_id,omitempty"`
 	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
+
+	// SupersededSchedules lists the plan-change schedules this request cancelled under
+	// on_conflict_policies.on_pending_schedule. Preview reports what execute would cancel.
+	SupersededSchedules []string `json:"superseded_schedules,omitempty"`
 
 	Warnings []string          `json:"warnings,omitempty"`
 	Metadata map[string]string `json:"metadata,omitempty"`

--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -54,7 +54,7 @@ func (r *SubscriptionChangeV2Request) EffectiveBillingPeriodBehaviour() types.Bi
 // ResetsAnchorAtEffective reports whether the change restarts the term at the instant it
 // takes effect.
 func (r *SubscriptionChangeV2Request) ResetsAnchorAtEffective() bool {
-	return r != nil && r.BillingPeriodBehaviour == types.BillingPeriodBehaviourResetAtEffect
+	return r != nil && r.BillingPeriodBehaviour == types.BillingPeriodBehaviourAnchorAtEffect
 }
 
 // SubscriptionChangeConflictPolicies decides how the change reacts to state that
@@ -186,13 +186,13 @@ func (r *SubscriptionChangeV2Request) validateBillingPeriodBehaviour() error {
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.BillingPeriodBehaviour == types.BillingPeriodBehaviourResetAt {
+	if r.BillingPeriodBehaviour == types.BillingPeriodBehaviourUpdateToConfig {
 		return ierr.NewError("billing_period_behaviour 'reset_at' is not supported yet").
 			WithHint("Use 'reset_at_effect' to restart the term at the change instant.").
 			WithReportableDetails(map[string]any{
 				"supported": []types.BillingPeriodBehaviour{
 					types.BillingPeriodBehaviourUnchanged,
-					types.BillingPeriodBehaviourResetAtEffect,
+					types.BillingPeriodBehaviourAnchorAtEffect,
 				},
 			}).
 			Mark(ierr.ErrValidation)

--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -51,9 +51,9 @@ func (r *SubscriptionChangeV2Request) EffectiveBillingPeriodBehaviour() types.Bi
 	return r.BillingPeriodBehaviour
 }
 
-// ResetsAnchorAtEffective reports whether the change restarts the term at the instant it
+// AnchorAtEffect reports whether the change restarts the term at the instant it
 // takes effect.
-func (r *SubscriptionChangeV2Request) ResetsAnchorAtEffective() bool {
+func (r *SubscriptionChangeV2Request) AnchorAtEffect() bool {
 	return r != nil && r.BillingPeriodBehaviour == types.BillingPeriodBehaviourAnchorAtEffect
 }
 
@@ -195,18 +195,6 @@ func (r *SubscriptionChangeV2Request) validateBillingPeriodBehaviour() error {
 					types.BillingPeriodBehaviourAnchorAtEffect,
 				},
 			}).
-			Mark(ierr.ErrValidation)
-	}
-
-	if !r.ResetsAnchorAtEffective() {
-		return nil
-	}
-
-	// A reset settles the whole term in one close-out invoice, so a prorated delta on
-	// top of it would charge the new plan twice.
-	if r.ProrationBehavior == types.ProrationBehaviorCreateProrations {
-		return ierr.NewError("proration is not applicable when the billing period is reset").
-			WithHint("Set proration_behavior to 'none'. Resetting the anchor settles the outgoing period and bills the new plan in full.").
 			Mark(ierr.ErrValidation)
 	}
 

--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"fmt"
 	"time"
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -182,13 +183,22 @@ func (r *SubscriptionChangeV2Request) validateBillingPeriodBehaviour() error {
 
 	if r.BillingPeriodConfig != nil {
 		return ierr.NewError("billing_period_config is not supported yet").
-			WithHint("Remove billing_period_config. Use billing_period_behaviour='reset_at_effect' to restart the term at the change instant.").
+			WithHint(fmt.Sprintf(
+				"Remove billing_period_config. Use billing_period_behaviour='%s' to restart the term at the change instant.",
+				types.BillingPeriodBehaviourAnchorAtEffect,
+			)).
 			Mark(ierr.ErrValidation)
 	}
 
-	if r.BillingPeriodBehaviour == types.BillingPeriodBehaviourUpdateToConfig {
-		return ierr.NewError("billing_period_behaviour 'reset_at' is not supported yet").
-			WithHint("Use 'reset_at_effect' to restart the term at the change instant.").
+	if r.BillingPeriodBehaviour == types.BillingPeriodBehaviourAnchorAtConfig {
+		return ierr.NewError(fmt.Sprintf(
+			"billing_period_behaviour '%s' is not supported yet",
+			types.BillingPeriodBehaviourAnchorAtConfig,
+		)).
+			WithHint(fmt.Sprintf(
+				"Use '%s' to restart the term at the change instant.",
+				types.BillingPeriodBehaviourAnchorAtEffect,
+			)).
 			WithReportableDetails(map[string]any{
 				"supported": []types.BillingPeriodBehaviour{
 					types.BillingPeriodBehaviourUnchanged,

--- a/internal/api/dto/subscription_change_v2.go
+++ b/internal/api/dto/subscription_change_v2.go
@@ -89,6 +89,7 @@ type EntityChangePolicy struct {
 	DefaultBehaviour types.EntityChangeBehaviour `json:"default_behaviour,omitempty"`
 
 	// Overrides is keyed by addon_associations.id (instance), not catalogue addon_id.
+	// That is the id an EntityChangeResult reports as EntityID.
 	Overrides map[string]types.EntityChangeBehaviour `json:"overrides,omitempty"`
 }
 
@@ -109,11 +110,11 @@ func (p *EntityChangePolicy) Validate() error {
 	return nil
 }
 
-func (p *EntityChangePolicy) BehaviourFor(referenceID string) types.EntityChangeBehaviour {
+func (p *EntityChangePolicy) BehaviourFor(entityID string) types.EntityChangeBehaviour {
 	if p == nil {
 		return types.EntityChangeBehaviourCarry
 	}
-	if d, ok := p.Overrides[referenceID]; ok && d != "" {
+	if d, ok := p.Overrides[entityID]; ok && d != "" {
 		return d
 	}
 	if p.DefaultBehaviour != "" {
@@ -122,6 +123,10 @@ func (p *EntityChangePolicy) BehaviourFor(referenceID string) types.EntityChange
 	return types.EntityChangeBehaviourCarry
 }
 
+// EntityChangeResult is one entity the change touched. EntityID identifies the entity
+// itself and is the id an addon override is keyed by; ReferenceID is what that entity
+// refers to — the catalogue addon, the plan a credit grant belongs to, the feature an
+// entitlement covers.
 type EntityChangeResult struct {
 	EntityType  types.SubscriptionChangeEntityType `json:"entity_type"`
 	ReferenceID string                             `json:"reference_id"`

--- a/internal/api/v1/subscription_plan_change.go
+++ b/internal/api/v1/subscription_plan_change.go
@@ -12,6 +12,8 @@ import (
 // @Summary Preview a plan change (v2, swap in place)
 // @ID previewSubscriptionPlanChangeV2
 // @Description Preview a subscription plan change without writing. Swap-in-place: subscription id, billing anchor and period bounds are preserved.
+// @Description
+// @Description With on_conflict_policies.on_pending_schedule = 'supersede', superseded_schedules lists the queued plan changes that execute would cancel. Preview writes nothing, so it does not reject on a pending schedule the way execute does.
 // @Tags Subscriptions
 // @Accept json
 // @Produce json
@@ -47,7 +49,9 @@ func (h *SubscriptionHandler) PreviewSubscriptionPlanChangeV2(c *gin.Context) {
 // @Description
 // @Description scheduled_at is resolved from the subscription's current period end at request time. If that period end is already in the past (a backdated start date, a resumed pause, or worker downtime can all leave a subscription behind), the change is due immediately and fires on the next billing scan rather than a period away — inspect scheduled_at to see this.
 // @Description
-// @Description Only one plan change may be pending per subscription; request a second one and this returns 400. Cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.
+// @Description Only one plan change may be pending per subscription. By default (on_conflict_policies.on_pending_schedule = 'reject') a second request returns 400; cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.
+// @Description
+// @Description Set on_conflict_policies.on_pending_schedule to 'supersede' to replace the queued change instead: the pending schedule is cancelled and this request applied in the same transaction, so both land or neither does. The cancelled schedule ids are returned in superseded_schedules, and preview reports the same list without writing.
 // @Tags Subscriptions
 // @Accept json
 // @Produce json

--- a/internal/api/v1/subscription_plan_change.go
+++ b/internal/api/v1/subscription_plan_change.go
@@ -52,6 +52,8 @@ func (h *SubscriptionHandler) PreviewSubscriptionPlanChangeV2(c *gin.Context) {
 // @Description Only one plan change may be pending per subscription. By default (on_conflict_policies.on_pending_schedule = 'reject') a second request returns 400; cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.
 // @Description
 // @Description Set on_conflict_policies.on_pending_schedule to 'supersede' to replace the queued change instead: the pending schedule is cancelled and this request applied in the same transaction, so both land or neither does. The cancelled schedule ids are returned in superseded_schedules, and preview reports the same list without writing.
+// @Description
+// @Description Plan-level credit grants are re-materialised: the outgoing plan's future grants are cancelled at the change instant and the target plan's are scheduled from it. Addon-sourced grants are untouched. Credits already granted are never clawed back — reclaiming spent credits would drive wallet balances negative — so a customer keeps what they have already received. Subscription-scoped entitlement overrides inherited from the outgoing plan are closed at the same instant, since after the swap they suppress nothing and would otherwise stack with the new plan's entitlement on the same feature. All of this is reported in entity_changes on both preview and execute.
 // @Tags Subscriptions
 // @Accept json
 // @Produce json

--- a/internal/api/v1/subscription_plan_change.go
+++ b/internal/api/v1/subscription_plan_change.go
@@ -12,8 +12,6 @@ import (
 // @Summary Preview a plan change (v2, swap in place)
 // @ID previewSubscriptionPlanChangeV2
 // @Description Preview a subscription plan change without writing. Swap-in-place: subscription id, billing anchor and period bounds are preserved.
-// @Description
-// @Description With on_conflict_policies.on_pending_schedule = 'supersede', superseded_schedules lists the queued plan changes that execute would cancel. Preview writes nothing, so it does not reject on a pending schedule the way execute does.
 // @Tags Subscriptions
 // @Accept json
 // @Produce json
@@ -52,8 +50,6 @@ func (h *SubscriptionHandler) PreviewSubscriptionPlanChangeV2(c *gin.Context) {
 // @Description Only one plan change may be pending per subscription. By default (on_conflict_policies.on_pending_schedule = 'reject') a second request returns 400; cancel the existing schedule via POST /subscriptions/schedules/{schedule_id}/cancel first. Pending schedules are listable via GET /subscriptions/{id}/schedules.
 // @Description
 // @Description Set on_conflict_policies.on_pending_schedule to 'supersede' to replace the queued change instead: the pending schedule is cancelled and this request applied in the same transaction, so both land or neither does. The cancelled schedule ids are returned in superseded_schedules, and preview reports the same list without writing.
-// @Description
-// @Description Plan-level credit grants are re-materialised: the outgoing plan's future grants are cancelled at the change instant and the target plan's are scheduled from it. Addon-sourced grants are untouched. Credits already granted are never clawed back — reclaiming spent credits would drive wallet balances negative — so a customer keeps what they have already received. Subscription-scoped entitlement overrides inherited from the outgoing plan are closed at the same instant, since after the swap they suppress nothing and would otherwise stack with the new plan's entitlement on the same feature. All of this is reported in entity_changes on both preview and execute.
 // @Tags Subscriptions
 // @Accept json
 // @Produce json

--- a/internal/domain/entitlement/builder.go
+++ b/internal/domain/entitlement/builder.go
@@ -1,0 +1,51 @@
+package entitlement
+
+import (
+	"time"
+)
+
+// entitlementBuilder copies an existing entitlement and applies field updates.
+type entitlementBuilder struct {
+	entitlement *Entitlement
+}
+
+// NewEntitlementBuilder returns a builder seeded from an existing entitlement.
+func NewEntitlementBuilder(e *Entitlement) *entitlementBuilder {
+	if e == nil {
+		return &entitlementBuilder{entitlement: &Entitlement{}}
+	}
+
+	copied := *e
+	if e.ConfigValue != nil {
+		copied.ConfigValue = make(map[string]interface{}, len(e.ConfigValue))
+		for k, v := range e.ConfigValue {
+			copied.ConfigValue[k] = v
+		}
+	}
+
+	return &entitlementBuilder{entitlement: &copied}
+}
+
+func (b *entitlementBuilder) WithEndDate(endDate time.Time) *entitlementBuilder {
+	if b == nil || b.entitlement == nil {
+		return b
+	}
+	b.entitlement.EndDate = &endDate
+	return b
+}
+
+func (b *entitlementBuilder) WithUpdatedBy(userID string) *entitlementBuilder {
+	if b == nil || b.entitlement == nil {
+		return b
+	}
+	b.entitlement.UpdatedBy = userID
+	b.entitlement.UpdatedAt = time.Now().UTC()
+	return b
+}
+
+func (b *entitlementBuilder) Build() *Entitlement {
+	if b == nil {
+		return nil
+	}
+	return b.entitlement
+}

--- a/internal/domain/subscription/schedule_builder.go
+++ b/internal/domain/subscription/schedule_builder.go
@@ -83,6 +83,35 @@ func (b *subscriptionScheduleBuilder) WithErrorMessage(message string) *subscrip
 	return b
 }
 
+func (b *subscriptionScheduleBuilder) WithCancelledAt(cancelledAt time.Time) *subscriptionScheduleBuilder {
+	if b == nil || b.schedule == nil {
+		return b
+	}
+	b.schedule.CancelledAt = &cancelledAt
+	b.schedule.UpdatedAt = cancelledAt
+	return b
+}
+
+func (b *subscriptionScheduleBuilder) WithUpdatedBy(userID string) *subscriptionScheduleBuilder {
+	if b == nil || b.schedule == nil {
+		return b
+	}
+	b.schedule.UpdatedBy = userID
+	return b
+}
+
+// WithMetadataEntry sets one key, leaving the rest of the metadata intact.
+func (b *subscriptionScheduleBuilder) WithMetadataEntry(key, value string) *subscriptionScheduleBuilder {
+	if b == nil || b.schedule == nil {
+		return b
+	}
+	if b.schedule.Metadata == nil {
+		b.schedule.Metadata = types.Metadata{}
+	}
+	b.schedule.Metadata[key] = value
+	return b
+}
+
 func (b *subscriptionScheduleBuilder) WithMetadata(metadata types.Metadata) *subscriptionScheduleBuilder {
 	if b == nil || b.schedule == nil {
 		return b

--- a/internal/domain/subscription/schedule_config.go
+++ b/internal/domain/subscription/schedule_config.go
@@ -155,11 +155,12 @@ func (s *SubscriptionSchedule) SetCancellationResult(result *CancellationResult)
 const PlanChangeConfigVersionV2 = "v2"
 
 type PlanChangeV2Configuration struct {
-	Version        string                      `json:"version"`
-	TargetPlanID   string                      `json:"target_plan_id"`
-	EntityPolicies *EntityChangePoliciesConfig `json:"entity_policies,omitempty"`
-	IdempotencyKey *string                     `json:"idempotency_key,omitempty"`
-	ChangeMetadata map[string]string           `json:"change_metadata,omitempty"`
+	Version                string                       `json:"version"`
+	TargetPlanID           string                       `json:"target_plan_id"`
+	EntityPolicies         *EntityChangePoliciesConfig  `json:"entity_policies,omitempty"`
+	IdempotencyKey         *string                      `json:"idempotency_key,omitempty"`
+	ChangeMetadata         map[string]string            `json:"change_metadata,omitempty"`
+	BillingPeriodBehaviour types.BillingPeriodBehaviour `json:"billing_period_behaviour,omitempty"`
 }
 
 type EntityChangePoliciesConfig struct {

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -1734,9 +1734,10 @@ func (s *billingService) ClassifyLineItems(
 		// Fixed, equal billing period: existing behavior (advance → both slices; arrear → CurrentPeriodArrear).
 		if item.InvoiceCadence == types.InvoiceCadenceAdvance {
 			result.CurrentPeriodAdvance = append(result.CurrentPeriodAdvance, item)
-			// Only include in next period if still active when that period starts.
-			// Ended items were already handled via proration invoices and must not be re-billed.
-			if item.EndDate.IsZero() || !item.EndDate.Before(nextPeriodStart) {
+			// Only include in next period if still active after that period starts.
+			// Ended items were already handled via proration invoices and must not be
+			// re-billed; an item ending exactly at nextPeriodStart covers nothing of it.
+			if item.EndDate.IsZero() || item.EndDate.After(nextPeriodStart) {
 				result.NextPeriodAdvance = append(result.NextPeriodAdvance, item)
 			}
 		}

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -2045,6 +2045,13 @@ func (s *billingService) CreateInvoiceRequestForCharges(
 		PreparedTaxRates: preparedTaxRates,
 	}
 
+	if params.InvoiceType != "" {
+		req.InvoiceType = params.InvoiceType
+	}
+	if params.BillingReason != "" {
+		req.BillingReason = params.BillingReason
+	}
+
 	return req, nil
 }
 

--- a/internal/ee/service/billing_next_period_advance_test.go
+++ b/internal/ee/service/billing_next_period_advance_test.go
@@ -1,0 +1,164 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/suite"
+)
+
+// Covers the NextPeriodAdvance boundary predicate: an item whose EndDate is exactly
+// the next period start covers none of that period and must never be billed in advance
+// for it. Every line item closed at a plan change lands on that exact boundary.
+type BillingNextPeriodAdvanceSuite struct {
+	testutil.BaseServiceTestSuite
+	service BillingService
+
+	jan1  time.Time
+	jan15 time.Time
+	feb1  time.Time
+	feb15 time.Time
+	mar1  time.Time
+
+	sub *subscription.Subscription
+}
+
+func TestBillingNextPeriodAdvance(t *testing.T) {
+	suite.Run(t, new(BillingNextPeriodAdvanceSuite))
+}
+
+func (s *BillingNextPeriodAdvanceSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.service = NewBillingService(ServiceParams{
+		Logger:                   s.GetLogger(),
+		Config:                   s.GetConfig(),
+		DB:                       s.GetDB(),
+		SubRepo:                  s.GetStores().SubscriptionRepo,
+		SubscriptionLineItemRepo: s.GetStores().SubscriptionLineItemRepo,
+		PlanRepo:                 s.GetStores().PlanRepo,
+		PriceRepo:                s.GetStores().PriceRepo,
+		MeterRepo:                s.GetStores().MeterRepo,
+		CustomerRepo:             s.GetStores().CustomerRepo,
+		InvoiceRepo:              s.GetStores().InvoiceRepo,
+		EnvironmentRepo:          s.GetStores().EnvironmentRepo,
+		TenantRepo:               s.GetStores().TenantRepo,
+	})
+
+	s.jan1 = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s.jan15 = time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	s.feb1 = time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	s.feb15 = time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+	s.mar1 = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	s.sub = &subscription.Subscription{
+		ID:                 "sub_npa",
+		PlanID:             "plan_npa",
+		CustomerID:         "cust_npa",
+		StartDate:          s.jan1,
+		BillingAnchor:      s.feb1,
+		CurrentPeriodStart: s.jan1,
+		CurrentPeriodEnd:   s.feb1,
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+	}
+}
+
+func (s *BillingNextPeriodAdvanceSuite) TearDownTest() {
+	s.BaseServiceTestSuite.TearDownTest()
+}
+
+func (s *BillingNextPeriodAdvanceSuite) lineItem(cadence types.InvoiceCadence, endDate time.Time) *subscription.SubscriptionLineItem {
+	return &subscription.SubscriptionLineItem{
+		ID:             "li_npa",
+		SubscriptionID: s.sub.ID,
+		CustomerID:     s.sub.CustomerID,
+		PriceID:        "price_npa",
+		PriceType:      types.PRICE_TYPE_FIXED,
+		BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+		InvoiceCadence: cadence,
+		Quantity:       decimal.NewFromInt(1),
+		Currency:       "usd",
+		StartDate:      s.jan1,
+		EndDate:        endDate,
+		BaseModel:      types.GetDefaultBaseModel(s.GetContext()),
+	}
+}
+
+func (s *BillingNextPeriodAdvanceSuite) TestClassify_AdvanceItemEndDateBoundary() {
+	tests := []struct {
+		name              string
+		endDate           time.Time
+		wantNextPeriod    bool
+		wantCurrentPeriod bool
+	}{
+		{
+			name:              "open ended item rolls into the next period",
+			endDate:           time.Time{},
+			wantNextPeriod:    true,
+			wantCurrentPeriod: true,
+		},
+		{
+			name:              "item ending exactly at the next period start is not billed in advance",
+			endDate:           s.feb1,
+			wantNextPeriod:    false,
+			wantCurrentPeriod: true,
+		},
+		{
+			name:              "item closed mid cycle is not billed in advance",
+			endDate:           s.jan15,
+			wantNextPeriod:    false,
+			wantCurrentPeriod: true,
+		},
+		{
+			name:              "item still active inside the next period is billed in advance",
+			endDate:           s.feb15,
+			wantNextPeriod:    true,
+			wantCurrentPeriod: true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.sub.LineItems = []*subscription.SubscriptionLineItem{s.lineItem(types.InvoiceCadenceAdvance, tt.endDate)}
+
+			result := s.service.(*billingService).ClassifyLineItems(&dto.ClassifyLineItemsParams{
+				Subscription:       s.sub,
+				CurrentPeriodStart: s.jan1,
+				CurrentPeriodEnd:   s.feb1,
+				NextPeriodStart:    s.feb1,
+				NextPeriodEnd:      s.mar1,
+			})
+
+			s.Len(result.NextPeriodAdvance, map[bool]int{true: 1, false: 0}[tt.wantNextPeriod])
+			s.Len(result.CurrentPeriodAdvance, map[bool]int{true: 1, false: 0}[tt.wantCurrentPeriod])
+			s.Empty(result.CurrentPeriodArrear)
+		})
+	}
+}
+
+// Arrear items never populate NextPeriodAdvance, so the predicate change cannot reach them.
+func (s *BillingNextPeriodAdvanceSuite) TestClassify_ArrearItemUnaffectedByBoundary() {
+	for _, endDate := range []time.Time{{}, s.feb1, s.feb15} {
+		s.sub.LineItems = []*subscription.SubscriptionLineItem{s.lineItem(types.InvoiceCadenceArrear, endDate)}
+
+		result := s.service.(*billingService).ClassifyLineItems(&dto.ClassifyLineItemsParams{
+			Subscription:       s.sub,
+			CurrentPeriodStart: s.jan1,
+			CurrentPeriodEnd:   s.feb1,
+			NextPeriodStart:    s.feb1,
+			NextPeriodEnd:      s.mar1,
+		})
+
+		s.Len(result.CurrentPeriodArrear, 1)
+		s.Empty(result.NextPeriodAdvance)
+		s.Empty(result.CurrentPeriodAdvance)
+	}
+}

--- a/internal/ee/service/creditgrant.go
+++ b/internal/ee/service/creditgrant.go
@@ -1334,14 +1334,18 @@ func (s *creditGrantService) CancelFutureSubscriptionGrants(ctx context.Context,
 		return err
 	}
 
-	// Get credit grants for this subscription. When AddonID is set, scope the
-	// cancellation to grants materialized from that addon (addon_id provenance),
-	// leaving plan-sourced and other-addon grants untouched.
+	// Get credit grants for this subscription. AddonID and PlanID scope the
+	// cancellation by provenance: an addon detach must leave plan-sourced grants
+	// alone, and a plan swap must leave addon-sourced grants alone. With neither
+	// set, every grant on the subscription is cancelled.
 	filter := types.NewNoLimitCreditGrantFilter()
 	filter.SubscriptionIDs = []string{req.SubscriptionID}
 	filter.WithStatus(types.StatusPublished)
 	if req.AddonID != nil && lo.FromPtr(req.AddonID) != "" {
 		filter.AddonIDs = []string{lo.FromPtr(req.AddonID)}
+	}
+	if req.PlanID != nil && lo.FromPtr(req.PlanID) != "" {
+		filter.PlanIDs = []string{lo.FromPtr(req.PlanID)}
 	}
 
 	creditGrants, err := s.CreditGrantRepo.List(ctx, filter)
@@ -1352,6 +1356,10 @@ func (s *creditGrantService) CancelFutureSubscriptionGrants(ctx context.Context,
 
 	if err := s.DB.WithTx(ctx, func(ctx context.Context) error {
 		for _, grant := range creditGrants {
+			if req.EffectiveDate != nil && grant.EndDate != nil && !grant.EndDate.After(lo.FromPtr(req.EffectiveDate)) {
+				continue
+			}
+
 			if err := s.DeleteCreditGrant(ctx, dto.DeleteCreditGrantRequest{CreditGrantID: grant.ID, EffectiveDate: req.EffectiveDate}); err != nil {
 				return err
 			}

--- a/internal/ee/service/entitlement_grant.go
+++ b/internal/ee/service/entitlement_grant.go
@@ -464,7 +464,7 @@ func (s *entitlementGrantService) computeGrantWindow(
 	// terminates after one grant per cycle (lastEnd == cycleEnd on the next pass).
 	if ec.GrantDurationUnit == types.EntitlementGrantDurationUnitSubscriptionPeriod {
 		s.Logger.Debug(ctx, "computed grant window (subscription_period)",
-			"validFrom", cycleStart, "validTo", cycleEnd)
+			"validFrom", coveredUntil, "validTo", cycleEnd)
 		return coveredUntil, cycleEnd, true, nil
 	}
 

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -373,23 +373,7 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 			s.Logger.Info(ctx, "plan has credit grants", "plan_id", plan.ID, "credit_grants_count", len(planCreditGrants.Items))
 			creditGrantRequests = make([]dto.CreateCreditGrantRequest, 0, len(planCreditGrants.Items))
 			for _, cg := range planCreditGrants.Items {
-				creditGrantRequests = append(creditGrantRequests, dto.CreateCreditGrantRequest{
-					Name:                   cg.Name,
-					Scope:                  types.CreditGrantScopeSubscription,
-					Credits:                cg.Credits,
-					Cadence:                cg.Cadence,
-					ExpirationType:         cg.ExpirationType,
-					Priority:               cg.Priority,
-					SubscriptionID:         lo.ToPtr(sub.ID),
-					Period:                 cg.Period,
-					PlanID:                 &plan.ID,
-					ExpirationDuration:     cg.ExpirationDuration,
-					ExpirationDurationUnit: cg.ExpirationDurationUnit,
-					Metadata:               cg.Metadata,
-					PeriodCount:            cg.PeriodCount,
-					ConversionRate:         cg.ConversionRate,
-					TopupConversionRate:    cg.TopupConversionRate,
-				})
+				creditGrantRequests = append(creditGrantRequests, PlanCreditGrantRequest(cg, sub.ID, plan.ID))
 			}
 		}
 	}
@@ -1604,6 +1588,30 @@ func (s *subscriptionService) addonCreditGrantProration(
 		ProrationDate: startDate,
 		Strategy:      types.StrategySecondBased,
 		Source:        "addon_attach",
+	}
+}
+
+func PlanCreditGrantRequest(
+	cg *dto.CreditGrantResponse,
+	subscriptionID string,
+	planID string,
+) dto.CreateCreditGrantRequest {
+	return dto.CreateCreditGrantRequest{
+		Name:                   cg.Name,
+		Scope:                  types.CreditGrantScopeSubscription,
+		Credits:                cg.Credits,
+		Cadence:                cg.Cadence,
+		ExpirationType:         cg.ExpirationType,
+		Priority:               cg.Priority,
+		SubscriptionID:         lo.ToPtr(subscriptionID),
+		Period:                 cg.Period,
+		PlanID:                 lo.ToPtr(planID),
+		ExpirationDuration:     cg.ExpirationDuration,
+		ExpirationDurationUnit: cg.ExpirationDurationUnit,
+		Metadata:               cg.Metadata,
+		PeriodCount:            cg.PeriodCount,
+		ConversionRate:         cg.ConversionRate,
+		TopupConversionRate:    cg.TopupConversionRate,
 	}
 }
 

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -373,7 +373,7 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 			s.Logger.Info(ctx, "plan has credit grants", "plan_id", plan.ID, "credit_grants_count", len(planCreditGrants.Items))
 			creditGrantRequests = make([]dto.CreateCreditGrantRequest, 0, len(planCreditGrants.Items))
 			for _, cg := range planCreditGrants.Items {
-				creditGrantRequests = append(creditGrantRequests, PlanCreditGrantRequest(cg, sub.ID, plan.ID))
+				creditGrantRequests = append(creditGrantRequests, dto.NewSubscriptionScopedCreditGrantRequest(cg, sub.ID, plan.ID))
 			}
 		}
 	}
@@ -1588,30 +1588,6 @@ func (s *subscriptionService) addonCreditGrantProration(
 		ProrationDate: startDate,
 		Strategy:      types.StrategySecondBased,
 		Source:        "addon_attach",
-	}
-}
-
-func PlanCreditGrantRequest(
-	cg *dto.CreditGrantResponse,
-	subscriptionID string,
-	planID string,
-) dto.CreateCreditGrantRequest {
-	return dto.CreateCreditGrantRequest{
-		Name:                   cg.Name,
-		Scope:                  types.CreditGrantScopeSubscription,
-		Credits:                cg.Credits,
-		Cadence:                cg.Cadence,
-		ExpirationType:         cg.ExpirationType,
-		Priority:               cg.Priority,
-		SubscriptionID:         lo.ToPtr(subscriptionID),
-		Period:                 cg.Period,
-		PlanID:                 lo.ToPtr(planID),
-		ExpirationDuration:     cg.ExpirationDuration,
-		ExpirationDurationUnit: cg.ExpirationDurationUnit,
-		Metadata:               cg.Metadata,
-		PeriodCount:            cg.PeriodCount,
-		ConversionRate:         cg.ConversionRate,
-		TopupConversionRate:    cg.TopupConversionRate,
 	}
 }
 

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -492,15 +492,11 @@ func (s *subscriptionService) ExecutePlanChange(
 		return nil, err
 	}
 
-	if err := s.checkNoPendingPlanChangeSchedule(ctx, subscriptionID); err != nil {
-		return nil, err
-	}
-
 	if req.IsDeferred() {
 		return s.schedulePlanChangeForPeriodEnd(ctx, subscriptionID, req)
 	}
 
-	return s.executePlanChangeAt(ctx, subscriptionID, req, effectiveAt)
+	return s.executePlanChangeAt(ctx, subscriptionID, req, effectiveAt, "")
 }
 
 func (s *subscriptionService) executePlanChangeAt(
@@ -508,12 +504,17 @@ func (s *subscriptionService) executePlanChangeAt(
 	subscriptionID string,
 	req dto.SubscriptionChangeV2Request,
 	effectiveAt time.Time,
+	executingScheduleID string,
 ) (*dto.SubscriptionChangeV2Response, error) {
 	var resp *dto.SubscriptionChangeV2Response
 
 	err := s.DB.WithTx(ctx, func(txCtx context.Context) error {
 		sub, err := s.loadSubscriptionForPlanChange(txCtx, subscriptionID, true)
 		if err != nil {
+			return err
+		}
+
+		if err := s.checkNoPendingPlanChangeSchedule(txCtx, subscriptionID, executingScheduleID); err != nil {
 			return err
 		}
 
@@ -915,7 +916,7 @@ func (s *subscriptionService) ExecuteScheduledPlanChangeV2(
 	}
 
 	resp, err := s.executePlanChangeAt(
-		ctx, schedule.SubscriptionID, PlanChangeV2RequestFromConfig(config), schedule.ScheduledAt,
+		ctx, schedule.SubscriptionID, PlanChangeV2RequestFromConfig(config), schedule.ScheduledAt, schedule.ID,
 	)
 	if err != nil {
 		if !IsTerminalPlanChangeError(err) {
@@ -972,14 +973,18 @@ func (s *subscriptionService) failPlanChangeSchedule(
 
 // checkNoPendingPlanChangeSchedule rejects a second plan change while one is already
 // queued.
-func (s *subscriptionService) checkNoPendingPlanChangeSchedule(ctx context.Context, subscriptionID string) error {
+func (s *subscriptionService) checkNoPendingPlanChangeSchedule(
+	ctx context.Context,
+	subscriptionID string,
+	executingScheduleID string,
+) error {
 	existing, err := s.SubScheduleRepo.GetPendingBySubscriptionAndType(
 		ctx, subscriptionID, types.SubscriptionScheduleChangeTypePlanChange,
 	)
 	if err != nil {
 		return err
 	}
-	if existing == nil {
+	if existing == nil || existing.ID == executingScheduleID {
 		return nil
 	}
 
@@ -1010,60 +1015,81 @@ func (s *subscriptionService) schedulePlanChangeForPeriodEnd(
 	subscriptionID string,
 	req dto.SubscriptionChangeV2Request,
 ) (*dto.SubscriptionChangeV2Response, error) {
-	sub, err := s.loadSubscriptionForPlanChange(ctx, subscriptionID, false)
-	if err != nil {
-		return nil, err
-	}
+	var (
+		resp       *dto.SubscriptionChangeV2Response
+		scheduleID string
+		changeType types.SubscriptionChangeType
+	)
 
-	scheduledAt := sub.CurrentPeriodEnd
-	r, err := s.resolvePlanChange(ctx, sub, req, scheduledAt)
-	if err != nil {
-		return nil, err
-	}
-
-	config := &subscription.PlanChangeV2Configuration{
-		TargetPlanID:   req.TargetPlanID,
-		IdempotencyKey: req.IdempotencyKey,
-		ChangeMetadata: req.Metadata,
-	}
-	if req.EntityPolicies != nil && req.EntityPolicies.Addons != nil {
-		config.EntityPolicies = &subscription.EntityChangePoliciesConfig{
-			Addons: &subscription.EntityChangePolicyConfig{
-				DefaultBehaviour: req.EntityPolicies.Addons.DefaultBehaviour,
-				Overrides:        req.EntityPolicies.Addons.Overrides,
-			},
+	err := s.DB.WithTx(ctx, func(txCtx context.Context) error {
+		sub, err := s.loadSubscriptionForPlanChange(txCtx, subscriptionID, true)
+		if err != nil {
+			return err
 		}
-	}
-	schedule := subscription.NewPendingScheduleBuilder(
-		ctx, sub, types.SubscriptionScheduleChangeTypePlanChange, scheduledAt,
-	).Build()
-	if err := schedule.SetPlanChangeV2Config(config); err != nil {
-		return nil, ierr.WithError(err).
-			WithHint("Failed to serialize the plan change configuration").
-			Mark(ierr.ErrInternal)
-	}
 
-	if err := s.SubScheduleRepo.Create(ctx, schedule); err != nil {
-		if ierr.IsAlreadyExists(err) {
-			return nil, ierr.WithError(err).
-				WithHint("A plan change is already scheduled for this subscription. Cancel it before requesting another one.").
-				WithReportableDetails(map[string]any{"subscription_id": subscriptionID}).
-				Mark(ierr.ErrValidation)
+		if err := s.checkNoPendingPlanChangeSchedule(txCtx, subscriptionID, ""); err != nil {
+			return err
 		}
+
+		scheduledAt := sub.CurrentPeriodEnd
+		r, err := s.resolvePlanChange(txCtx, sub, req, scheduledAt)
+		if err != nil {
+			return err
+		}
+
+		config := &subscription.PlanChangeV2Configuration{
+			TargetPlanID:   req.TargetPlanID,
+			IdempotencyKey: req.IdempotencyKey,
+			ChangeMetadata: req.Metadata,
+		}
+		if req.EntityPolicies != nil && req.EntityPolicies.Addons != nil {
+			config.EntityPolicies = &subscription.EntityChangePoliciesConfig{
+				Addons: &subscription.EntityChangePolicyConfig{
+					DefaultBehaviour: req.EntityPolicies.Addons.DefaultBehaviour,
+					Overrides:        req.EntityPolicies.Addons.Overrides,
+				},
+			}
+		}
+
+		schedule := subscription.NewPendingScheduleBuilder(
+			txCtx, sub, types.SubscriptionScheduleChangeTypePlanChange, scheduledAt,
+		).Build()
+		if err := schedule.SetPlanChangeV2Config(config); err != nil {
+			return ierr.WithError(err).
+				WithHint("Failed to serialize the plan change configuration").
+				Mark(ierr.ErrInternal)
+		}
+
+		if err := s.SubScheduleRepo.Create(txCtx, schedule); err != nil {
+			if ierr.IsAlreadyExists(err) {
+				return ierr.WithError(err).
+					WithHint("A plan change is already scheduled for this subscription. Cancel it before requesting another one.").
+					WithReportableDetails(map[string]any{"subscription_id": subscriptionID}).
+					Mark(ierr.ErrValidation)
+			}
+			return err
+		}
+
+		scheduleID = schedule.ID
+		changeType = r.changeType
+
+		resp = buildPlanChangeResponse(r, sub, req)
+		resp.ChangedResources.LineItems = planChangeChangedLineItems(r)
+		resp.IsScheduled = true
+		resp.ScheduleID = &schedule.ID
+		resp.ScheduledAt = &schedule.ScheduledAt
+		return nil
+	})
+	if err != nil {
 		return nil, err
 	}
 
 	s.Logger.Info(ctx, "plan change scheduled for period end",
 		"subscription_id", subscriptionID,
-		"schedule_id", schedule.ID,
-		"scheduled_at", schedule.ScheduledAt,
+		"schedule_id", scheduleID,
+		"scheduled_at", *resp.ScheduledAt,
 		"target_plan_id", req.TargetPlanID,
-		"change_type", r.changeType)
+		"change_type", changeType)
 
-	resp := buildPlanChangeResponse(r, sub, req)
-	resp.ChangedResources.LineItems = planChangeChangedLineItems(r)
-	resp.IsScheduled = true
-	resp.ScheduleID = &schedule.ID
-	resp.ScheduledAt = &schedule.ScheduledAt
 	return resp, nil
 }

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/addonassociation"
+	"github.com/flexprice/flexprice/internal/domain/creditgrant"
+	"github.com/flexprice/flexprice/internal/domain/entitlement"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
@@ -43,10 +45,27 @@ type planChangeRequest struct {
 	closing []*lineItemChange
 	opening []*lineItemChange
 
+	grants         *planChangeGrants
+	staleOverrides []*entitlement.Entitlement
+
 	changes  []*dto.EntityChangeResult
 	warnings []string
 
 	changeType types.SubscriptionChangeType
+}
+
+// planChangeGrants is the credit-grant migration a plan change performs. Plan-level
+// grants are materialised per subscription at creation time.
+type planChangeGrants struct {
+	// cancel holds the subscription's grants materialised from the outgoing plan.
+	cancel []*creditgrant.CreditGrant
+
+	// create holds the target plan's grants mapped to subscription-scoped requests.
+	create []dto.CreateCreditGrantRequest
+
+	// createdFrom keeps the target plan grant behind each create entry, so preview can
+	// name what it would materialise before any row exists.
+	createdFrom []*creditgrant.CreditGrant
 }
 
 func (s *subscriptionService) resolvePlanChange(
@@ -116,7 +135,190 @@ func (s *subscriptionService) resolvePlanChange(
 	r.changes = addonsChanges
 	r.warnings = addonsWarnings
 	r.changeType = planChangeType(r)
+
+	if err := s.resolveCreditGrantMigration(ctx, r); err != nil {
+		return nil, err
+	}
+
+	if err := s.resolveStaleEntitlementOverrides(ctx, r); err != nil {
+		return nil, err
+	}
+
 	return r, nil
+}
+
+// resolveCreditGrantMigration works out which grants leave with the old plan and which
+// arrive with the new one. Preview and execute both call it; only execute applies it.
+func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r *planChangeRequest) error {
+	filter := types.NewNoLimitCreditGrantFilter()
+	filter.SubscriptionIDs = []string{r.sub.ID}
+	filter.PlanIDs = []string{r.fromPlan.ID}
+	filter.WithStatus(types.StatusPublished)
+
+	outgoing, err := s.CreditGrantRepo.List(ctx, filter)
+	if err != nil {
+		return err
+	}
+
+	targetGrants, err := NewCreditGrantService(s.ServiceParams).GetCreditGrantsByPlan(ctx, r.toPlan.ID)
+	if err != nil {
+		return err
+	}
+
+	grants := &planChangeGrants{}
+	for _, cg := range outgoing {
+		// Already closed at or before the change instant: nothing future to cancel.
+		if cg.EndDate != nil && !cg.EndDate.After(r.effectiveAt) {
+			continue
+		}
+		grants.cancel = append(grants.cancel, cg)
+	}
+
+	for _, cg := range targetGrants.Items {
+		if cg == nil || cg.CreditGrant == nil {
+			continue
+		}
+		grants.create = append(grants.create, PlanCreditGrantRequest(cg, r.sub.ID, r.toPlan.ID))
+		grants.createdFrom = append(grants.createdFrom, cg.CreditGrant)
+	}
+	r.grants = grants
+
+	for _, cg := range grants.cancel {
+		r.changes = append(r.changes, &dto.EntityChangeResult{
+			EntityType:  types.SubscriptionChangeEntityTypeCreditGrant,
+			ReferenceID: cg.ID,
+			EntityID:    r.fromPlan.ID,
+			Behaviour:   types.EntityChangeBehaviourDrop,
+		})
+	}
+
+	for _, cg := range grants.createdFrom {
+		r.changes = append(r.changes, &dto.EntityChangeResult{
+			EntityType:  types.SubscriptionChangeEntityTypeCreditGrant,
+			ReferenceID: cg.ID,
+			EntityID:    r.toPlan.ID,
+			Behaviour:   types.EntityChangeBehaviourAdd,
+		})
+	}
+
+	return nil
+}
+
+// resolveStaleEntitlementOverrides finds subscription-scoped entitlements whose parent is
+// an entitlement of the outgoing plan. After the swap they suppress nothing and stack with
+// the new plan's entitlement on the same feature, so they must be closed.
+func (s *subscriptionService) resolveStaleEntitlementOverrides(ctx context.Context, r *planChangeRequest) error {
+	entitlementSvc := NewEntitlementService(s.ServiceParams)
+
+	fromPlanEnts, err := entitlementSvc.ListEntitlements(ctx, types.NewNoLimitEntitlementFilter().
+		WithEntityIDs([]string{r.fromPlan.ID}).
+		WithEntityType(types.ENTITLEMENT_ENTITY_TYPE_PLAN).
+		WithStatus(types.StatusPublished))
+	if err != nil {
+		return err
+	}
+	if len(fromPlanEnts.Items) == 0 {
+		return nil
+	}
+
+	fromPlanEntIDs := make(map[string]bool, len(fromPlanEnts.Items))
+	for _, ent := range fromPlanEnts.Items {
+		if ent != nil {
+			fromPlanEntIDs[ent.ID] = true
+		}
+	}
+
+	subEnts, err := entitlementSvc.ListEntitlements(ctx, types.NewNoLimitEntitlementFilter().
+		WithEntityIDs([]string{r.sub.ID}).
+		WithEntityType(types.ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION).
+		WithStatus(types.StatusPublished))
+	if err != nil {
+		return err
+	}
+
+	for _, ent := range subEnts.Items {
+		if ent == nil || ent.Entitlement == nil {
+			continue
+		}
+		if !fromPlanEntIDs[lo.FromPtr(ent.ParentEntitlementID)] {
+			continue
+		}
+		// Already closed at or before the change instant: nothing left to suppress.
+		if ent.EndDate != nil && !ent.EndDate.After(r.effectiveAt) {
+			continue
+		}
+
+		r.staleOverrides = append(r.staleOverrides, ent.Entitlement)
+		r.changes = append(r.changes, &dto.EntityChangeResult{
+			EntityType:  types.SubscriptionChangeEntityTypeEntitlement,
+			ReferenceID: ent.ID,
+			EntityID:    ent.FeatureID,
+			Behaviour:   types.EntityChangeBehaviourDrop,
+		})
+	}
+
+	return nil
+}
+
+// migrateCreditGrants cancels the outgoing plan's grants and materialises the target
+// plan's, both dated at the change instant.
+//
+// TODO: a change landing mid-period under the default billing_period_behaviour
+// ("unchanged") grants the target plan's first period in full even though only part of
+// that period remains. addonCreditGrantProration (subscription.go) already solves this
+// exact shape for addons and is the intended reuse.
+func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planChangeRequest) error {
+	if r.grants == nil {
+		return nil
+	}
+
+	if len(r.grants.cancel) > 0 {
+		if err := NewCreditGrantService(s.ServiceParams).CancelFutureSubscriptionGrants(ctx, dto.CancelFutureSubscriptionGrantsRequest{
+			SubscriptionID: r.sub.ID,
+			PlanID:         lo.ToPtr(r.fromPlan.ID),
+			EffectiveDate:  lo.ToPtr(r.effectiveAt),
+		}); err != nil {
+			return err
+		}
+	}
+
+	if err := s.handleCreditGrantsWithStart(ctx, r.sub, r.grants.create, r.effectiveAt, nil, nil); err != nil {
+		return err
+	}
+
+	s.Logger.Info(ctx, "migrated credit grants for plan change",
+		"subscription_id", r.sub.ID,
+		"from_plan_id", r.fromPlan.ID,
+		"to_plan_id", r.toPlan.ID,
+		"cancelled_grants", len(r.grants.cancel),
+		"created_grants", len(r.grants.create),
+		"effective_at", r.effectiveAt)
+
+	return nil
+}
+
+// closeStaleEntitlementOverrides end-dates the overrides resolved above at the change
+// instant.
+func (s *subscriptionService) closeStaleEntitlementOverrides(ctx context.Context, r *planChangeRequest) error {
+	for _, ent := range r.staleOverrides {
+		closed := entitlement.NewEntitlementBuilder(ent).
+			WithEndDate(r.effectiveAt).
+			WithUpdatedBy(types.GetUserID(ctx)).
+			Build()
+
+		if _, err := s.EntitlementRepo.Update(ctx, closed); err != nil {
+			return err
+		}
+
+		s.Logger.Info(ctx, "closed stale subscription entitlement override on plan change",
+			"subscription_id", r.sub.ID,
+			"entitlement_id", closed.ID,
+			"feature_id", closed.FeatureID,
+			"from_plan_id", r.fromPlan.ID,
+			"effective_at", r.effectiveAt)
+	}
+
+	return nil
 }
 
 func (s *subscriptionService) checkPlanChangePreconditions(
@@ -308,7 +510,7 @@ func (s *subscriptionService) resolveAddonChanges(
 
 		behaviour := policy.BehaviourFor(association.ID)
 		changes = append(changes, &dto.EntityChangeResult{
-			EntityType:  types.SubscriptionLineItemEntityTypeAddon,
+			EntityType:  types.SubscriptionChangeEntityTypeAddon,
 			ReferenceID: association.ID,
 			EntityID:    association.AddonID,
 			Behaviour:   behaviour,
@@ -545,6 +747,14 @@ func (s *subscriptionService) executePlanChangeAt(
 
 		swapped, err := s.applyPlanSwap(txCtx, r)
 		if err != nil {
+			return err
+		}
+
+		if err := s.migrateCreditGrants(txCtx, r); err != nil {
+			return err
+		}
+
+		if err := s.closeStaleEntitlementOverrides(txCtx, r); err != nil {
 			return err
 		}
 

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -47,8 +47,8 @@ type planChangeRequest struct {
 	closing []*lineItemChange
 	opening []*lineItemChange
 
-	grants         *planChangeGrants
-	staleOverrides []*entitlement.Entitlement
+	grants           *planChangeGrants
+	closingOverrides []*entitlement.Entitlement
 
 	resetAnchor bool
 
@@ -69,12 +69,8 @@ type planChangeGrants struct {
 	// cancel holds the subscription's grants materialised from the outgoing plan.
 	cancel []*creditgrant.CreditGrant
 
-	// create holds the target plan's grants mapped to subscription-scoped requests.
-	create []dto.CreateCreditGrantRequest
-
-	// createdFrom keeps the target plan grant behind each create entry, so preview can
-	// name what it would materialise before any row exists.
-	createdFrom []*creditgrant.CreditGrant
+	// opening holds the target plan's grants.
+	opening []*dto.CreditGrantResponse
 }
 
 func (s *subscriptionService) resolvePlanChange(
@@ -171,7 +167,7 @@ func (s *subscriptionService) resolvePlanChange(
 		return nil, err
 	}
 
-	if err := s.resolveStaleEntitlementOverrides(ctx, r); err != nil {
+	if err := s.resolveClosingEntitlementOverrides(ctx, r); err != nil {
 		return nil, err
 	}
 
@@ -209,9 +205,7 @@ func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r
 		if cg == nil || cg.CreditGrant == nil {
 			continue
 		}
-
-		grants.create = append(grants.create, dto.NewSubscriptionScopedCreditGrantRequest(cg, r.currentSub.ID, r.toPlan.ID))
-		grants.createdFrom = append(grants.createdFrom, cg.CreditGrant)
+		grants.opening = append(grants.opening, cg)
 	}
 	r.grants = grants
 
@@ -224,7 +218,7 @@ func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r
 		})
 	}
 
-	for _, cg := range grants.createdFrom {
+	for _, cg := range grants.opening {
 		r.changes = append(r.changes, &dto.EntityChangeResult{
 			EntityType:  types.SubscriptionChangeEntityTypeCreditGrant,
 			ReferenceID: cg.ID,
@@ -236,10 +230,10 @@ func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r
 	return nil
 }
 
-// resolveStaleEntitlementOverrides finds subscription-scoped entitlements whose parent is
+// resolveClosingEntitlementOverrides finds subscription-scoped entitlements whose parent is
 // an entitlement of the outgoing plan. After the swap they suppress nothing and stack with
 // the new plan's entitlement on the same feature, so they must be closed.
-func (s *subscriptionService) resolveStaleEntitlementOverrides(ctx context.Context, r *planChangeRequest) error {
+func (s *subscriptionService) resolveClosingEntitlementOverrides(ctx context.Context, r *planChangeRequest) error {
 	entitlementSvc := NewEntitlementService(s.ServiceParams)
 
 	fromPlanEnts, err := entitlementSvc.ListEntitlements(ctx, types.NewNoLimitEntitlementFilter().
@@ -280,7 +274,7 @@ func (s *subscriptionService) resolveStaleEntitlementOverrides(ctx context.Conte
 			continue
 		}
 
-		r.staleOverrides = append(r.staleOverrides, ent.Entitlement)
+		r.closingOverrides = append(r.closingOverrides, ent.Entitlement)
 		r.changes = append(r.changes, &dto.EntityChangeResult{
 			EntityType:  types.SubscriptionChangeEntityTypeEntitlement,
 			ReferenceID: ent.ID,
@@ -314,7 +308,12 @@ func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planCh
 		}
 	}
 
-	if err := s.handleCreditGrantsWithStart(ctx, r.updatedSub, r.grants.create, r.effectiveAt, nil, nil); err != nil {
+	create := make([]dto.CreateCreditGrantRequest, 0, len(r.grants.opening))
+	for _, cg := range r.grants.opening {
+		create = append(create, dto.NewSubscriptionScopedCreditGrantRequest(cg, r.currentSub.ID, r.toPlan.ID))
+	}
+
+	if err := s.handleCreditGrantsWithStart(ctx, r.updatedSub, create, r.effectiveAt, nil, nil); err != nil {
 		return err
 	}
 
@@ -323,16 +322,15 @@ func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planCh
 		"from_plan_id", r.fromPlan.ID,
 		"to_plan_id", r.toPlan.ID,
 		"cancelled_grants", len(r.grants.cancel),
-		"created_grants", len(r.grants.create),
+		"created_grants", len(r.grants.opening),
 		"effective_at", r.effectiveAt)
 
 	return nil
 }
 
-// closeStaleEntitlementOverrides end-dates the overrides resolved above at the change
-// instant.
-func (s *subscriptionService) closeStaleEntitlementOverrides(ctx context.Context, r *planChangeRequest) error {
-	for _, ent := range r.staleOverrides {
+// closeEntitlementOverrides end-dates the overrides resolved above at the change instant.
+func (s *subscriptionService) closeEntitlementOverrides(ctx context.Context, r *planChangeRequest) error {
+	for _, ent := range r.closingOverrides {
 		closed := entitlement.NewEntitlementBuilder(ent).
 			WithEndDate(r.effectiveAt).
 			WithUpdatedBy(types.GetUserID(ctx)).
@@ -342,7 +340,7 @@ func (s *subscriptionService) closeStaleEntitlementOverrides(ctx context.Context
 			return err
 		}
 
-		s.Logger.Info(ctx, "closed stale subscription entitlement override on plan change",
+		s.Logger.Info(ctx, "closed subscription entitlement override on plan change",
 			"subscription_id", r.currentSub.ID,
 			"entitlement_id", closed.ID,
 			"feature_id", closed.FeatureID,
@@ -780,7 +778,7 @@ func (s *subscriptionService) executePlanChangeAt(
 			return err
 		}
 
-		if err := s.closeStaleEntitlementOverrides(txCtx, r); err != nil {
+		if err := s.closeEntitlementOverrides(txCtx, r); err != nil {
 			return err
 		}
 
@@ -940,7 +938,7 @@ func (s *subscriptionService) applyAnchorReset(
 }
 
 // projectSubscriptionAfterChange is the subscription the change would leave behind,
-// computed without writing anything. Under reset_at_effective the term restarts at
+// computed without writing anything. Under reset_at_effect the term restarts at
 // effectiveAt, so the new period is a full period and never the remainder of the old one.
 func projectSubscriptionAfterChange(r *planChangeRequest) (*subscription.Subscription, error) {
 	projected := *r.currentSub

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -34,7 +34,9 @@ func (c lineItemChange) isAddon() bool {
 }
 
 type planChangeRequest struct {
-	sub            *subscription.Subscription
+	currentSub *subscription.Subscription
+	updatedSub *subscription.Subscription
+
 	fromPlan       *plan.Plan
 	toPlan         *plan.Plan
 	effectiveAt    time.Time
@@ -47,6 +49,13 @@ type planChangeRequest struct {
 
 	grants         *planChangeGrants
 	staleOverrides []*entitlement.Entitlement
+
+	resetAnchor bool
+
+	// outgoingUsage bills the outgoing plan's usage and is set only under a reset; settlementQuote is
+	// the net of credits against charges, nil when the change settles no money.
+	outgoingUsage   *dto.CreateInvoiceRequest
+	settlementQuote *LineItemProrationSummary
 
 	changes  []*dto.EntityChangeResult
 	warnings []string
@@ -111,13 +120,20 @@ func (s *subscriptionService) resolvePlanChange(
 	}
 
 	r := &planChangeRequest{
-		sub:            sub,
+		currentSub:     sub,
 		fromPlan:       fromPlan.Plan,
 		toPlan:         toPlan.Plan,
 		effectiveAt:    effectiveAt,
 		behavior:       req.ProrationBehavior,
 		idempotencyKey: lo.FromPtr(req.IdempotencyKey),
+		resetAnchor:    req.ResetsAnchorAtEffective() && !req.IsDeferred(),
 	}
+
+	updatedSub, err := projectSubscriptionAfterChange(r)
+	if err != nil {
+		return nil, err
+	}
+	r.updatedSub = updatedSub
 
 	carried, opening, closing, err := s.resolveLineItems(ctx, sub, targetPrices, toPlan, effectiveAt)
 	if err != nil {
@@ -136,6 +152,21 @@ func (s *subscriptionService) resolvePlanChange(
 	r.warnings = addonsWarnings
 	r.changeType = planChangeType(r)
 
+	// The settlement is resolved here, before any write, so preview and execute quote the
+	// same documents and settling them is order-independent.
+	if r.resetAnchor {
+		if r.outgoingUsage, err = s.outgoingUsageInvoiceRequest(ctx, r); err != nil {
+			return nil, err
+		}
+		if r.settlementQuote, err = s.resetQuote(ctx, r); err != nil {
+			return nil, err
+		}
+	} else if r.behavior == types.ProrationBehaviorCreateProrations {
+		if r.settlementQuote, err = s.computePlanChange(ctx, r); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := s.resolveCreditGrantMigration(ctx, r); err != nil {
 		return nil, err
 	}
@@ -151,7 +182,7 @@ func (s *subscriptionService) resolvePlanChange(
 // arrive with the new one. Preview and execute both call it; only execute applies it.
 func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r *planChangeRequest) error {
 	filter := types.NewNoLimitCreditGrantFilter()
-	filter.SubscriptionIDs = []string{r.sub.ID}
+	filter.SubscriptionIDs = []string{r.currentSub.ID}
 	filter.PlanIDs = []string{r.fromPlan.ID}
 	filter.WithStatus(types.StatusPublished)
 
@@ -178,7 +209,8 @@ func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r
 		if cg == nil || cg.CreditGrant == nil {
 			continue
 		}
-		grants.create = append(grants.create, PlanCreditGrantRequest(cg, r.sub.ID, r.toPlan.ID))
+
+		grants.create = append(grants.create, dto.NewSubscriptionScopedCreditGrantRequest(cg, r.currentSub.ID, r.toPlan.ID))
 		grants.createdFrom = append(grants.createdFrom, cg.CreditGrant)
 	}
 	r.grants = grants
@@ -229,7 +261,7 @@ func (s *subscriptionService) resolveStaleEntitlementOverrides(ctx context.Conte
 	}
 
 	subEnts, err := entitlementSvc.ListEntitlements(ctx, types.NewNoLimitEntitlementFilter().
-		WithEntityIDs([]string{r.sub.ID}).
+		WithEntityIDs([]string{r.currentSub.ID}).
 		WithEntityType(types.ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION).
 		WithStatus(types.StatusPublished))
 	if err != nil {
@@ -274,7 +306,7 @@ func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planCh
 
 	if len(r.grants.cancel) > 0 {
 		if err := NewCreditGrantService(s.ServiceParams).CancelFutureSubscriptionGrants(ctx, dto.CancelFutureSubscriptionGrantsRequest{
-			SubscriptionID: r.sub.ID,
+			SubscriptionID: r.currentSub.ID,
 			PlanID:         lo.ToPtr(r.fromPlan.ID),
 			EffectiveDate:  lo.ToPtr(r.effectiveAt),
 		}); err != nil {
@@ -282,12 +314,12 @@ func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planCh
 		}
 	}
 
-	if err := s.handleCreditGrantsWithStart(ctx, r.sub, r.grants.create, r.effectiveAt, nil, nil); err != nil {
+	if err := s.handleCreditGrantsWithStart(ctx, r.updatedSub, r.grants.create, r.effectiveAt, nil, nil); err != nil {
 		return err
 	}
 
 	s.Logger.Info(ctx, "migrated credit grants for plan change",
-		"subscription_id", r.sub.ID,
+		"subscription_id", r.currentSub.ID,
 		"from_plan_id", r.fromPlan.ID,
 		"to_plan_id", r.toPlan.ID,
 		"cancelled_grants", len(r.grants.cancel),
@@ -311,7 +343,7 @@ func (s *subscriptionService) closeStaleEntitlementOverrides(ctx context.Context
 		}
 
 		s.Logger.Info(ctx, "closed stale subscription entitlement override on plan change",
-			"subscription_id", r.sub.ID,
+			"subscription_id", r.currentSub.ID,
 			"entitlement_id", closed.ID,
 			"feature_id", closed.FeatureID,
 			"from_plan_id", r.fromPlan.ID,
@@ -358,6 +390,12 @@ func (s *subscriptionService) checkPlanChangePreconditions(
 		return fail("subscription has a pending cancellation",
 			"Clear the pending cancellation before changing plan",
 			map[string]any{"subscription_id": sub.ID})
+	}
+
+	if req.ResetsAnchorAtEffective() && sub.BillingCycle == types.BillingCycleCalendar {
+		return fail("the billing period cannot be reset on a calendar-aligned subscription",
+			"Calendar billing keeps every period on a calendar boundary. Use billing_period_behaviour='unchanged', or move the subscription to anniversary billing.",
+			map[string]any{"subscription_id": sub.ID, "billing_cycle": sub.BillingCycle})
 	}
 
 	// TODO: Handle mixed billing periods correctly.
@@ -612,7 +650,7 @@ func (s *subscriptionService) applyDroppedAddons(ctx context.Context, r *planCha
 		// KNOWN LIMITATION: grants are tagged by addon_id only, so concurrent
 		// attachments of the same addon cannot be cancelled independently.
 		if err := NewCreditGrantService(s.ServiceParams).CancelFutureSubscriptionGrants(ctx, dto.CancelFutureSubscriptionGrantsRequest{
-			SubscriptionID: r.sub.ID,
+			SubscriptionID: r.currentSub.ID,
 			AddonID:        lo.ToPtr(association.AddonID),
 			EffectiveDate:  lo.ToPtr(r.effectiveAt),
 		}); err != nil {
@@ -627,25 +665,17 @@ func (s *subscriptionService) computePlanChange(
 	ctx context.Context,
 	r *planChangeRequest,
 ) (*LineItemProrationSummary, error) {
-	entries := make([]LineItemProrationEntry, 0, len(r.closing)+len(r.opening))
-	for _, move := range r.closing {
-		entries = append(entries, LineItemProrationEntry{
-			LineItem: move.lineItem,
-			Price:    move.price,
-			Action:   types.ProrationActionRemoveItem,
-		})
-	}
-	for _, move := range r.opening {
-		entries = append(entries, LineItemProrationEntry{
-			LineItem:    move.lineItem,
-			Price:       move.price,
-			Action:      types.ProrationActionAddItem,
-			NewQuantity: move.lineItem.Quantity,
-		})
+	entries := append(
+		prorationEntries(types.ProrationActionRemoveItem, r.closing),
+		prorationEntries(types.ProrationActionAddItem, r.opening)...,
+	)
+
+	if len(entries) == 0 {
+		return emptyProrationSummary(r.currentSub), nil
 	}
 
 	return NewLineItemProrationService(s.ServiceParams).Compute(ctx, LineItemProrationRequest{
-		Subscription:  r.sub,
+		Subscription:  r.currentSub,
 		Entries:       entries,
 		EffectiveDate: r.effectiveAt,
 		Behavior:      r.behavior,
@@ -668,12 +698,7 @@ func (s *subscriptionService) PreviewPlanChange(
 		return nil, err
 	}
 
-	quote, err := s.computePlanChange(ctx, r)
-	if err != nil {
-		return nil, err
-	}
-
-	preview, err := s.previewPlanChangeSettlement(ctx, r, quote)
+	preview, err := s.settlePlanChange(ctx, r, true)
 	if err != nil {
 		return nil, err
 	}
@@ -683,7 +708,7 @@ func (s *subscriptionService) PreviewPlanChange(
 		return nil, err
 	}
 
-	resp := buildPlanChangeResponse(r, r.sub, req)
+	resp := buildPlanChangeResponse(r, r.updatedSub, req)
 	resp.ChangedResources.LineItems = planChangeChangedLineItems(r)
 	resp.ChangedResources.Invoices = preview
 	resp.SupersededSchedules = superseded
@@ -722,17 +747,12 @@ func (s *subscriptionService) executePlanChangeAt(
 			return err
 		}
 
-		r, err := s.resolvePlanChange(txCtx, sub, req, effectiveAt)
-		if err != nil {
-			return err
-		}
-
-		quote, err := s.computePlanChange(txCtx, r)
-		if err != nil {
-			return err
-		}
-
 		superseded, err := s.resolvePendingPlanChangeSchedule(txCtx, subscriptionID, req, executingScheduleID)
+		if err != nil {
+			return err
+		}
+
+		r, err := s.resolvePlanChange(txCtx, sub, req, effectiveAt)
 		if err != nil {
 			return err
 		}
@@ -745,10 +765,16 @@ func (s *subscriptionService) executePlanChangeAt(
 			return err
 		}
 
-		swapped, err := s.applyPlanSwap(txCtx, r)
+		swappedSub, err := s.applyPlanSwap(txCtx, r)
 		if err != nil {
 			return err
 		}
+
+		anchoredSub, err := s.applyAnchorReset(txCtx, r, swappedSub)
+		if err != nil {
+			return err
+		}
+		r.updatedSub = anchoredSub
 
 		if err := s.migrateCreditGrants(txCtx, r); err != nil {
 			return err
@@ -758,12 +784,12 @@ func (s *subscriptionService) executePlanChangeAt(
 			return err
 		}
 
-		changedInvoices, err := s.settlePlanChange(txCtx, r, quote)
+		changedInvoices, err := s.settlePlanChange(txCtx, r, false)
 		if err != nil {
 			return err
 		}
 
-		resp = buildPlanChangeResponse(r, swapped, req)
+		resp = buildPlanChangeResponse(r, anchoredSub, req)
 		resp.ChangedResources.LineItems = planChangeChangedLineItems(r)
 		resp.ChangedResources.Invoices = changedInvoices
 		resp.SupersededSchedules = superseded
@@ -865,7 +891,7 @@ func (s *subscriptionService) applyPlanSwap(
 	ctx context.Context,
 	r *planChangeRequest,
 ) (*subscription.Subscription, error) {
-	if err := s.SubRepo.UpdatePlan(ctx, r.sub.ID, r.toPlan.ID); err != nil {
+	if err := s.SubRepo.UpdatePlan(ctx, r.currentSub.ID, r.toPlan.ID); err != nil {
 		return nil, err
 	}
 
@@ -874,53 +900,284 @@ func (s *subscriptionService) applyPlanSwap(
 		return nil, err
 	}
 
-	if err := s.PlanPriceSyncRepo.ReanchorSubSyncedSequence(ctx, r.sub.ID, targetSeq); err != nil {
+	if err := s.PlanPriceSyncRepo.ReanchorSubSyncedSequence(ctx, r.currentSub.ID, targetSeq); err != nil {
 		return nil, err
 	}
 
-	swapped := *r.sub
+	swapped := *r.updatedSub
 	swapped.PlanID = r.toPlan.ID
 	swapped.SyncedPriceSequence = targetSeq
 	return &swapped, nil
 }
 
-// Net charge → one invoice (credits as lines); net credit → wallet (invoice totals can't go negative).
-func (s *subscriptionService) settlePlanChange(
+func (s *subscriptionService) applyAnchorReset(
 	ctx context.Context,
 	r *planChangeRequest,
-	quote *LineItemProrationSummary,
-) ([]dto.ChangedInvoice, error) {
-	if r.behavior != types.ProrationBehaviorCreateProrations {
+	swapped *subscription.Subscription,
+) (*subscription.Subscription, error) {
+	if !r.resetAnchor {
+		return swapped, nil
+	}
+
+	reset := *swapped
+	reset.BillingAnchor = r.updatedSub.BillingAnchor
+	reset.CurrentPeriodStart = r.updatedSub.CurrentPeriodStart
+	reset.CurrentPeriodEnd = r.updatedSub.CurrentPeriodEnd
+
+	if err := s.SubRepo.Update(ctx, &reset); err != nil {
+		return nil, err
+	}
+
+	s.Logger.Info(ctx, "reset subscription billing anchor on plan change",
+		"subscription_id", reset.ID,
+		"billing_anchor", reset.BillingAnchor,
+		"current_period_start", reset.CurrentPeriodStart,
+		"current_period_end", reset.CurrentPeriodEnd,
+		"previous_period_start", r.currentSub.CurrentPeriodStart,
+		"previous_period_end", r.currentSub.CurrentPeriodEnd)
+
+	return &reset, nil
+}
+
+// projectSubscriptionAfterChange is the subscription the change would leave behind,
+// computed without writing anything. Under reset_at_effective the term restarts at
+// effectiveAt, so the new period is a full period and never the remainder of the old one.
+func projectSubscriptionAfterChange(r *planChangeRequest) (*subscription.Subscription, error) {
+	projected := *r.currentSub
+	projected.PlanID = r.toPlan.ID
+
+	if !r.resetAnchor {
+		return &projected, nil
+	}
+
+	periodEnd, err := types.NextBillingDate(&types.NextBillingDateParams{
+		CurrentPeriodStart:  r.effectiveAt,
+		BillingAnchor:       r.effectiveAt,
+		Unit:                projected.BillingPeriodCount,
+		Period:              projected.BillingPeriod,
+		SubscriptionEndDate: projected.EndDate,
+		Timezone:            projected.Timezone,
+	})
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to calculate the new billing period end after resetting the anchor").
+			WithReportableDetails(map[string]any{
+				"subscription_id": projected.ID,
+				"effective_at":    r.effectiveAt,
+			}).
+			Mark(ierr.ErrSystem)
+	}
+
+	projected.BillingAnchor = r.effectiveAt
+	projected.CurrentPeriodStart = r.effectiveAt
+	projected.CurrentPeriodEnd = periodEnd
+	return &projected, nil
+}
+
+// resetQuote prices the term restart against both snapshots: removals against the period
+// the change interrupts (credit for time paid for but no longer covered), additions
+// against the period it opens (a full period, because effectiveAt is its start).
+func (s *subscriptionService) resetQuote(
+	ctx context.Context,
+	r *planChangeRequest,
+) (*LineItemProrationSummary, error) {
+	prorationSvc := NewLineItemProrationService(s.ServiceParams)
+
+	credit, err := prorationSvc.Compute(ctx, LineItemProrationRequest{
+		Subscription:  r.currentSub,
+		Entries:       prorationEntries(types.ProrationActionRemoveItem, r.closing, r.carried),
+		EffectiveDate: r.effectiveAt,
+		Behavior:      types.ProrationBehaviorCreateProrations,
+		Reason:        "plan change with billing period reset",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	charge, err := prorationSvc.Compute(ctx, LineItemProrationRequest{
+		Subscription:  r.updatedSub,
+		Entries:       prorationEntries(types.ProrationActionAddItem, r.opening, r.carried),
+		EffectiveDate: r.effectiveAt,
+		Behavior:      types.ProrationBehaviorCreateProrations,
+		Reason:        "plan change with billing period reset",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	merged := emptyProrationSummary(r.currentSub)
+	summaries := []*LineItemProrationSummary{credit, charge}
+	for _, summary := range summaries {
+		if summary == nil {
+			continue
+		}
+
+		merged.Results = append(merged.Results, summary.Results...)
+		merged.ChargeLineItems = append(merged.ChargeLineItems, summary.ChargeLineItems...)
+		merged.CreditLineItems = append(merged.CreditLineItems, summary.CreditLineItems...)
+		merged.TotalChargeAmount = merged.TotalChargeAmount.Add(summary.TotalChargeAmount)
+		merged.TotalCreditAmount = merged.TotalCreditAmount.Add(summary.TotalCreditAmount)
+	}
+
+	return merged, nil
+}
+
+func prorationEntries(
+	action types.ProrationAction,
+	moves ...[]*lineItemChange,
+) []LineItemProrationEntry {
+	entries := make([]LineItemProrationEntry, 0)
+	for _, group := range moves {
+		for _, move := range group {
+			entry := LineItemProrationEntry{
+				LineItem: move.lineItem,
+				Price:    move.price,
+				Action:   action,
+			}
+			if action == types.ProrationActionAddItem {
+				entry.NewQuantity = move.lineItem.Quantity
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
+}
+
+// outgoingUsageInvoiceRequest bills the usage consumed on the outgoing plan before the
+// reset cut its period short. Without it that usage is never invoiced: the period never
+// reaches its boundary, and the next roll's window starts at effectiveAt.
+func (s *subscriptionService) outgoingUsageInvoiceRequest(
+	ctx context.Context,
+	r *planChangeRequest,
+) (*dto.CreateInvoiceRequest, error) {
+	billingSvc := NewBillingService(s.ServiceParams)
+
+	prepared, err := billingSvc.PrepareSubscriptionInvoiceRequest(ctx, &dto.PrepareSubscriptionInvoiceRequestParams{
+		Subscription:   r.currentSub,
+		PeriodStart:    r.currentSub.CurrentPeriodStart,
+		PeriodEnd:      r.effectiveAt,
+		ReferencePoint: types.ReferencePointCancel,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	usageCharges := lo.Filter(prepared.LineItems, func(line dto.CreateInvoiceLineItemRequest, _ int) bool {
+		return lo.FromPtr(line.PriceType) == string(types.PRICE_TYPE_USAGE)
+	})
+	if len(usageCharges) == 0 {
 		return nil, nil
 	}
 
-	switch {
-	case quote.NetAmount().GreaterThan(decimal.Zero):
-		inv, err := NewInvoiceService(s.ServiceParams).CreateInvoice(ctx, planChangeInvoiceRequest(r, quote))
-		if err != nil {
-			return nil, err
+	usageChargesTotal := decimal.Zero
+	for _, charge := range usageCharges {
+		usageChargesTotal = usageChargesTotal.Add(charge.Amount)
+	}
+
+	req, err := billingSvc.CreateInvoiceRequestForCharges(ctx, &dto.CreateInvoiceRequestForChargesParams{
+		Subscription:  r.currentSub,
+		Result:        &dto.BillingCalculationResult{UsageCharges: usageCharges, TotalAmount: usageChargesTotal, Currency: r.currentSub.Currency},
+		PeriodStart:   r.currentSub.CurrentPeriodStart,
+		PeriodEnd:     r.effectiveAt,
+		Description:   "Usage on the previous plan up to the change",
+		Metadata:      types.Metadata{},
+		InvoiceType:   types.InvoiceTypeOneOff,
+		BillingReason: types.InvoiceBillingReasonSubscriptionUpdate,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !req.Total.IsPositive() {
+		return nil, nil
+	}
+
+	req.IdempotencyKey = lo.ToPtr(planChangeIdempotencyKey(r, "outgoing_usage"))
+	return req, nil
+}
+
+// settlePlanChange raises the settlement resolved for this change: the outgoing plan's
+// usage as its own invoice, and the net of credits against charges as either an invoice or
+// a wallet credit. With preview set it quotes the same documents without writing, so the
+// two cannot describe different outcomes.
+func (s *subscriptionService) settlePlanChange(
+	ctx context.Context,
+	r *planChangeRequest,
+	preview bool,
+) ([]dto.ChangedInvoice, error) {
+	invoiceSvc := NewInvoiceService(s.ServiceParams)
+	changed := make([]dto.ChangedInvoice, 0, 2)
+
+	raiseInvoice := func(req dto.CreateInvoiceRequest) error {
+		if preview {
+			inv, err := invoiceSvc.CreatePreviewInvoice(ctx, req)
+			if err != nil {
+				return err
+			}
+
+			changed = append(changed, dto.ChangedInvoice{
+				Action:  dto.ChangedInvoiceActionCreated,
+				Status:  dto.ChangedInvoiceStatusPreview,
+				Invoice: inv,
+			})
+			return nil
 		}
 
-		return []dto.ChangedInvoice{{
+		inv, err := invoiceSvc.CreateInvoice(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		changed = append(changed, dto.ChangedInvoice{
 			ID:      inv.ID,
 			Action:  dto.ChangedInvoiceActionCreated,
 			Status:  dto.ChangedInvoiceStatusFromPaymentStatus(inv.PaymentStatus),
 			Invoice: inv,
-		}}, nil
+		})
+		return nil
+	}
 
-	case quote.NetAmount().LessThan(decimal.Zero):
-		walletSvc := NewWalletService(s.ServiceParams)
-		txn, err := walletSvc.TopUpWalletForProratedCharge(
-			ctx, r.sub.GetInvoicingCustomerID(), quote.NetAmount().Abs(), r.sub.Currency, planChangeIdempotencyKey(r),
+	if r.outgoingUsage != nil {
+		if err := raiseInvoice(*r.outgoingUsage); err != nil {
+			return nil, err
+		}
+	}
+
+	if r.settlementQuote == nil {
+		return changed, nil
+	}
+
+	net := r.settlementQuote.NetAmount()
+	switch {
+	case net.IsPositive():
+		if err := raiseInvoice(planChangeInvoiceRequest(r, r.settlementQuote)); err != nil {
+			return nil, err
+		}
+
+	// A net credit is paid to the wallet, never invoiced.
+	case net.IsNegative() && preview:
+		changed = append(changed, walletCreditChangedInvoice(&dto.WalletTransactionResponse{
+			Transaction: &wallet.Transaction{
+				CustomerID:        r.currentSub.GetInvoicingCustomerID(),
+				Amount:            net.Abs(),
+				Currency:          r.currentSub.Currency,
+				TransactionReason: types.TransactionReasonSubscriptionCredit,
+			},
+		}, dto.ChangedInvoiceStatusPreview))
+
+	case net.IsNegative():
+		txn, err := NewWalletService(s.ServiceParams).TopUpWalletForProratedCharge(
+			ctx, r.currentSub.GetInvoicingCustomerID(), net.Abs(), r.currentSub.Currency,
+			planChangeIdempotencyKey(r, ""),
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		return []dto.ChangedInvoice{walletCreditChangedInvoice(txn, dto.ChangedInvoiceStatusWalletIssued)}, nil
-	default:
-		return nil, nil
+		changed = append(changed, walletCreditChangedInvoice(txn, dto.ChangedInvoiceStatusWalletIssued))
 	}
+
+	return changed, nil
 }
 
 // One request, two uses: CreateInvoice raises it on execute, CreatePreviewInvoice
@@ -931,15 +1188,15 @@ func planChangeInvoiceRequest(r *planChangeRequest, quote *LineItemProrationSumm
 	lineItems = append(lineItems, quote.ChargeLineItems...)
 	lineItems = append(lineItems, quote.CreditLineItems...)
 
-	billingPeriod := string(r.sub.BillingPeriod)
-	periodEnd := r.sub.CurrentPeriodEnd
-	idempotencyKey := planChangeIdempotencyKey(r)
+	billingPeriod := string(r.updatedSub.BillingPeriod)
+	periodEnd := r.updatedSub.CurrentPeriodEnd
+	idempotencyKey := planChangeIdempotencyKey(r, "")
 
 	return dto.CreateInvoiceRequest{
-		CustomerID:     r.sub.GetInvoicingCustomerID(),
-		SubscriptionID: &r.sub.ID,
+		CustomerID:     r.currentSub.GetInvoicingCustomerID(),
+		SubscriptionID: &r.currentSub.ID,
 		InvoiceType:    types.InvoiceTypeOneOff,
-		Currency:       r.sub.Currency,
+		Currency:       r.currentSub.Currency,
 		BillingReason:  types.InvoiceBillingReasonSubscriptionUpdate,
 		AmountDue:      quote.NetAmount(),
 		Total:          quote.NetAmount(),
@@ -963,7 +1220,12 @@ func buildPlanChangeResponse(
 		EffectiveAt:  r.effectiveAt,
 		FromPlan:     planChangeSummary(r.fromPlan),
 		ToPlan:       planChangeSummary(r.toPlan),
-
+		BillingPeriod: dto.SubscriptionChangeBillingPeriodResult{
+			Behaviour:          req.EffectiveBillingPeriodBehaviour(),
+			BillingAnchor:      sub.BillingAnchor,
+			CurrentPeriodStart: sub.CurrentPeriodStart,
+			CurrentPeriodEnd:   sub.CurrentPeriodEnd,
+		},
 		EntityChanges: r.changes,
 		Warnings:      r.warnings,
 		Metadata:      req.Metadata,
@@ -1035,52 +1297,24 @@ func planChangeChangedLineItems(r *planChangeRequest) []dto.ChangedLineItem {
 	return items
 }
 
-// previewPlanChangeSettlement quotes what settlePlanChange would do, through the
-// same request and the same two branches, so preview and execute cannot drift.
-func (s *subscriptionService) previewPlanChangeSettlement(
-	ctx context.Context,
-	r *planChangeRequest,
-	quote *LineItemProrationSummary,
-) ([]dto.ChangedInvoice, error) {
-	if r.behavior != types.ProrationBehaviorCreateProrations || quote.NetAmount().IsZero() {
-		return nil, nil
-	}
-
-	// A net credit is paid to the wallet, never invoiced.
-	if quote.NetAmount().IsNegative() {
-		return []dto.ChangedInvoice{walletCreditChangedInvoice(&dto.WalletTransactionResponse{
-			Transaction: &wallet.Transaction{
-				CustomerID:        r.sub.GetInvoicingCustomerID(),
-				Amount:            quote.NetAmount().Abs(),
-				Currency:          r.sub.Currency,
-				TransactionReason: types.TransactionReasonSubscriptionCredit,
-			},
-		}, dto.ChangedInvoiceStatusPreview)}, nil
-	}
-
-	inv, err := NewInvoiceService(s.ServiceParams).CreatePreviewInvoice(ctx, planChangeInvoiceRequest(r, quote))
-	if err != nil {
-		return nil, err
-	}
-
-	return []dto.ChangedInvoice{{
-		Action:  dto.ChangedInvoiceActionCreated,
-		Status:  dto.ChangedInvoiceStatusPreview,
-		Invoice: inv,
-	}}, nil
-}
-
-func planChangeIdempotencyKey(r *planChangeRequest) string {
+// The key is what stops a retry double-billing: CreateInvoice returns an existing draft
+// under the same key and rejects an existing finalized one, so two documents sharing a key
+// would make the second fail as already-existing.
+func planChangeIdempotencyKey(r *planChangeRequest, document string) string {
 	inputs := map[string]interface{}{
-		"subscription_id": r.sub.ID,
+		"subscription_id": r.currentSub.ID,
 		"target_plan_id":  r.toPlan.ID,
+	}
+
+	if document != "" {
+		inputs["document"] = document
 	}
 
 	if r.idempotencyKey != "" {
 		inputs["client_key"] = r.idempotencyKey
 	} else {
-		inputs["subscription_version"] = r.sub.Version
-		inputs["subscription_updated_at"] = r.sub.UpdatedAt.UTC().Format(time.RFC3339Nano)
+		inputs["subscription_version"] = r.currentSub.Version
+		inputs["subscription_updated_at"] = r.currentSub.UpdatedAt.UTC().Format(time.RFC3339Nano)
 	}
 
 	return idempotency.NewGenerator().GenerateKey(idempotency.ScopePlanChange, inputs)
@@ -1091,9 +1325,11 @@ func PlanChangeV2RequestFromConfig(config *subscription.PlanChangeV2Configuratio
 		TargetPlanID: config.TargetPlanID,
 		// Pinned, not replayed from the blob: a deferred change is only ever
 		// accepted with none, and the boundary invoice already bills the new plan.
-		ProrationBehavior: types.ProrationBehaviorNone,
-		IdempotencyKey:    config.IdempotencyKey,
-		Metadata:          config.ChangeMetadata,
+		ProrationBehavior:      types.ProrationBehaviorNone,
+		IdempotencyKey:         config.IdempotencyKey,
+		Metadata:               config.ChangeMetadata,
+		BillingPeriodBehaviour: config.BillingPeriodBehaviour,
+		ChangeAt:               lo.ToPtr(types.ScheduleTypePeriodEnd),
 	}
 
 	if config.EntityPolicies != nil && config.EntityPolicies.Addons != nil {
@@ -1297,21 +1533,22 @@ func (s *subscriptionService) schedulePlanChangeForPeriodEnd(
 			return err
 		}
 
+		superseded, err := s.resolvePendingPlanChangeSchedule(txCtx, subscriptionID, req, "")
+		if err != nil {
+			return err
+		}
+
 		scheduledAt := sub.CurrentPeriodEnd
 		r, err := s.resolvePlanChange(txCtx, sub, req, scheduledAt)
 		if err != nil {
 			return err
 		}
 
-		superseded, err := s.resolvePendingPlanChangeSchedule(txCtx, subscriptionID, req, "")
-		if err != nil {
-			return err
-		}
-
 		config := &subscription.PlanChangeV2Configuration{
-			TargetPlanID:   req.TargetPlanID,
-			IdempotencyKey: req.IdempotencyKey,
-			ChangeMetadata: req.Metadata,
+			TargetPlanID:           req.TargetPlanID,
+			IdempotencyKey:         req.IdempotencyKey,
+			ChangeMetadata:         req.Metadata,
+			BillingPeriodBehaviour: req.BillingPeriodBehaviour,
 		}
 		if req.EntityPolicies != nil && req.EntityPolicies.Addons != nil {
 			config.EntityPolicies = &subscription.EntityChangePoliciesConfig{

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -476,9 +476,15 @@ func (s *subscriptionService) PreviewPlanChange(
 		return nil, err
 	}
 
+	superseded, err := s.previewPendingScheduleSupersede(ctx, subscriptionID, req)
+	if err != nil {
+		return nil, err
+	}
+
 	resp := buildPlanChangeResponse(r, r.sub, req)
 	resp.ChangedResources.LineItems = planChangeChangedLineItems(r)
 	resp.ChangedResources.Invoices = preview
+	resp.SupersededSchedules = superseded
 	return resp, nil
 }
 
@@ -514,16 +520,17 @@ func (s *subscriptionService) executePlanChangeAt(
 			return err
 		}
 
-		if err := s.checkNoPendingPlanChangeSchedule(txCtx, subscriptionID, executingScheduleID); err != nil {
-			return err
-		}
-
 		r, err := s.resolvePlanChange(txCtx, sub, req, effectiveAt)
 		if err != nil {
 			return err
 		}
 
 		quote, err := s.computePlanChange(txCtx, r)
+		if err != nil {
+			return err
+		}
+
+		superseded, err := s.resolvePendingPlanChangeSchedule(txCtx, subscriptionID, req, executingScheduleID)
 		if err != nil {
 			return err
 		}
@@ -549,6 +556,7 @@ func (s *subscriptionService) executePlanChangeAt(
 		resp = buildPlanChangeResponse(r, swapped, req)
 		resp.ChangedResources.LineItems = planChangeChangedLineItems(r)
 		resp.ChangedResources.Invoices = changedInvoices
+		resp.SupersededSchedules = superseded
 		return nil
 	})
 	if err != nil {
@@ -971,31 +979,83 @@ func (s *subscriptionService) failPlanChangeSchedule(
 	}
 }
 
-// checkNoPendingPlanChangeSchedule rejects a second plan change while one is already
-// queued.
-func (s *subscriptionService) checkNoPendingPlanChangeSchedule(
+func (s *subscriptionService) conflictingPlanChangeSchedule(
 	ctx context.Context,
 	subscriptionID string,
 	executingScheduleID string,
-) error {
+) (*subscription.SubscriptionSchedule, error) {
 	existing, err := s.SubScheduleRepo.GetPendingBySubscriptionAndType(
 		ctx, subscriptionID, types.SubscriptionScheduleChangeTypePlanChange,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if existing == nil || existing.ID == executingScheduleID {
-		return nil
+		return nil, nil
 	}
 
-	return ierr.NewError("a plan change is already scheduled for this subscription").
-		WithHint("Cancel the existing schedule before requesting another one.").
-		WithReportableDetails(map[string]any{
-			"subscription_id": subscriptionID,
-			"schedule_id":     existing.ID,
-			"scheduled_at":    existing.ScheduledAt,
-		}).
-		Mark(ierr.ErrValidation)
+	return existing, nil
+}
+
+func (s *subscriptionService) resolvePendingPlanChangeSchedule(
+	ctx context.Context,
+	subscriptionID string,
+	req dto.SubscriptionChangeV2Request,
+	executingScheduleID string,
+) ([]string, error) {
+	existing, err := s.conflictingPlanChangeSchedule(ctx, subscriptionID, executingScheduleID)
+	if err != nil || existing == nil {
+		return nil, err
+	}
+
+	if !req.SupersedesPendingSchedule() {
+		return nil, ierr.NewError("a plan change is already scheduled for this subscription").
+			WithHint("Cancel the existing schedule first, or set on_conflict_policies.on_pending_schedule to 'supersede' to replace it with this request.").
+			WithReportableDetails(map[string]any{
+				"subscription_id": subscriptionID,
+				"schedule_id":     existing.ID,
+				"scheduled_at":    existing.ScheduledAt,
+				"policy_field":    "on_conflict_policies.on_pending_schedule",
+				"policy_value":    types.OnPendingSchedulePolicySupersede.String(),
+			}).
+			Mark(ierr.ErrValidation)
+	}
+
+	superseded := subscription.NewSubscriptionScheduleBuilder(existing).
+		WithStatus(types.ScheduleStatusCancelled).
+		WithCancelledAt(time.Now().UTC()).
+		WithUpdatedBy(types.GetUserID(ctx)).
+		Build()
+
+	if err := s.SubScheduleRepo.Update(ctx, superseded); err != nil {
+		return nil, err
+	}
+
+	s.Logger.Info(ctx, "cancelled pending plan change superseded by a newer request",
+		"subscription_id", subscriptionID,
+		"schedule_id", superseded.ID,
+		"scheduled_at", superseded.ScheduledAt,
+		"target_plan_id", req.TargetPlanID)
+
+	return []string{superseded.ID}, nil
+}
+
+// previewPendingScheduleSupersede reports what execute would cancel, without writing.
+func (s *subscriptionService) previewPendingScheduleSupersede(
+	ctx context.Context,
+	subscriptionID string,
+	req dto.SubscriptionChangeV2Request,
+) ([]string, error) {
+	if !req.SupersedesPendingSchedule() {
+		return nil, nil
+	}
+
+	existing, err := s.conflictingPlanChangeSchedule(ctx, subscriptionID, "")
+	if err != nil || existing == nil {
+		return nil, err
+	}
+
+	return []string{existing.ID}, nil
 }
 
 // resolveEffectiveAt is the instant a request would take effect: the period boundary
@@ -1027,12 +1087,13 @@ func (s *subscriptionService) schedulePlanChangeForPeriodEnd(
 			return err
 		}
 
-		if err := s.checkNoPendingPlanChangeSchedule(txCtx, subscriptionID, ""); err != nil {
+		scheduledAt := sub.CurrentPeriodEnd
+		r, err := s.resolvePlanChange(txCtx, sub, req, scheduledAt)
+		if err != nil {
 			return err
 		}
 
-		scheduledAt := sub.CurrentPeriodEnd
-		r, err := s.resolvePlanChange(txCtx, sub, req, scheduledAt)
+		superseded, err := s.resolvePendingPlanChangeSchedule(txCtx, subscriptionID, req, "")
 		if err != nil {
 			return err
 		}
@@ -1078,6 +1139,8 @@ func (s *subscriptionService) schedulePlanChangeForPeriodEnd(
 		resp.IsScheduled = true
 		resp.ScheduleID = &schedule.ID
 		resp.ScheduledAt = &schedule.ScheduledAt
+		resp.SupersededSchedules = superseded
+
 		return nil
 	})
 	if err != nil {

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/addonassociation"
 	"github.com/flexprice/flexprice/internal/domain/creditgrant"
 	"github.com/flexprice/flexprice/internal/domain/entitlement"
+	"github.com/flexprice/flexprice/internal/domain/entitlementgrant"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
@@ -43,12 +44,13 @@ type planChangeRequest struct {
 	behavior       types.ProrationBehavior
 	idempotencyKey string
 
-	carried []*lineItemChange
-	closing []*lineItemChange
-	opening []*lineItemChange
+	carriedLineItems []*lineItemChange
+	closingLineItems []*lineItemChange
+	openingLineItems []*lineItemChange
 
-	grants           *planChangeGrants
-	closingOverrides []*entitlement.Entitlement
+	grants                      *planChangeGrants
+	closingEntitlementOverrides []*entitlement.Entitlement
+	closingEntitlementGrants    []*entitlementgrant.EntitlementGrant
 
 	resetAnchor bool
 
@@ -129,6 +131,9 @@ func (s *subscriptionService) resolvePlanChange(
 	if err != nil {
 		return nil, err
 	}
+	if updatedSub.SyncedPriceSequence, err = s.PlanPriceSyncRepo.CurrentPlanSequence(ctx, r.toPlan.ID); err != nil {
+		return nil, err
+	}
 	r.updatedSub = updatedSub
 
 	carried, opening, closing, err := s.resolveLineItems(ctx, sub, targetPrices, toPlan, effectiveAt)
@@ -141,9 +146,9 @@ func (s *subscriptionService) resolvePlanChange(
 		return nil, err
 	}
 
-	r.carried = carried
-	r.opening = opening
-	r.closing = append(closing, addonsClosing...)
+	r.carriedLineItems = carried
+	r.openingLineItems = opening
+	r.closingLineItems = append(closing, addonsClosing...)
 	r.changes = addonsChanges
 	r.warnings = addonsWarnings
 	r.changeType = planChangeType(r)
@@ -167,7 +172,7 @@ func (s *subscriptionService) resolvePlanChange(
 		return nil, err
 	}
 
-	if err := s.resolveClosingEntitlementOverrides(ctx, r); err != nil {
+	if err := s.resolveClosingEntitlements(ctx, r); err != nil {
 		return nil, err
 	}
 
@@ -230,10 +235,11 @@ func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r
 	return nil
 }
 
-// resolveClosingEntitlementOverrides finds subscription-scoped entitlements whose parent is
-// an entitlement of the outgoing plan. After the swap they suppress nothing and stack with
-// the new plan's entitlement on the same feature, so they must be closed.
-func (s *subscriptionService) resolveClosingEntitlementOverrides(ctx context.Context, r *planChangeRequest) error {
+// resolveClosingEntitlements finds what the outgoing plan leaves behind on the subscription:
+// subscription-scoped entitlements whose parent is one of its entitlements, and the grant
+// windows opened from either. After the swap they suppress nothing and stack with the new
+// plan's entitlement on the same feature, so they must be closed.
+func (s *subscriptionService) resolveClosingEntitlements(ctx context.Context, r *planChangeRequest) error {
 	entitlementSvc := NewEntitlementService(s.ServiceParams)
 
 	fromPlanEnts, err := entitlementSvc.ListEntitlements(ctx, types.NewNoLimitEntitlementFilter().
@@ -274,11 +280,52 @@ func (s *subscriptionService) resolveClosingEntitlementOverrides(ctx context.Con
 			continue
 		}
 
-		r.closingOverrides = append(r.closingOverrides, ent.Entitlement)
+		r.closingEntitlementOverrides = append(r.closingEntitlementOverrides, ent.Entitlement)
 		r.changes = append(r.changes, &dto.EntityChangeResult{
 			EntityType:  types.SubscriptionChangeEntityTypeEntitlement,
 			ReferenceID: ent.ID,
 			EntityID:    ent.FeatureID,
+			Behaviour:   types.EntityChangeBehaviourDrop,
+		})
+	}
+
+	return s.resolveClosingEntitlementGrants(ctx, r, fromPlanEntIDs)
+}
+
+// resolveClosingEntitlementGrants collects the subscription's grant windows still open at the
+// change instant whose config is an outgoing-plan entitlement or an override closing with it.
+func (s *subscriptionService) resolveClosingEntitlementGrants(
+	ctx context.Context,
+	r *planChangeRequest,
+	fromPlanEntIDs map[string]bool,
+) error {
+	// Grants key off the entitlement the subscription actually resolves to, which is the
+	// override where one is active and the plan entitlement otherwise.
+	configIDs := lo.Keys(fromPlanEntIDs)
+	for _, ent := range r.closingEntitlementOverrides {
+		configIDs = append(configIDs, ent.ID)
+	}
+
+	filter := types.NewNoLimitEntitlementGrantFilter().
+		WithSubscriptionIDs(r.currentSub.ID).
+		WithEntitlementConfigIDs(configIDs...)
+	filter.ValidToAfter = &r.effectiveAt
+
+	grants, err := s.EntitlementGrantRepo.List(ctx, filter)
+	if err != nil {
+		return err
+	}
+
+	for _, g := range grants {
+		if g == nil {
+			continue
+		}
+
+		r.closingEntitlementGrants = append(r.closingEntitlementGrants, g)
+		r.changes = append(r.changes, &dto.EntityChangeResult{
+			EntityType:  types.SubscriptionChangeEntityTypeEntitlementGrant,
+			ReferenceID: g.ID,
+			EntityID:    g.FeatureID(),
 			Behaviour:   types.EntityChangeBehaviourDrop,
 		})
 	}
@@ -330,7 +377,7 @@ func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planCh
 
 // closeEntitlementOverrides end-dates the overrides resolved above at the change instant.
 func (s *subscriptionService) closeEntitlementOverrides(ctx context.Context, r *planChangeRequest) error {
-	for _, ent := range r.closingOverrides {
+	for _, ent := range r.closingEntitlementOverrides {
 		closed := entitlement.NewEntitlementBuilder(ent).
 			WithEndDate(r.effectiveAt).
 			WithUpdatedBy(types.GetUserID(ctx)).
@@ -346,6 +393,37 @@ func (s *subscriptionService) closeEntitlementOverrides(ctx context.Context, r *
 			"feature_id", closed.FeatureID,
 			"from_plan_id", r.fromPlan.ID,
 			"effective_at", r.effectiveAt)
+	}
+
+	return nil
+}
+
+// closeEntitlementGrants ends the outgoing plan's open grant windows at the change instant.
+// Closing shrinks valid_to, which the evaluator treats as a window owed one final usage
+// refresh, so events landing before the swap still reach the billing reads.
+func (s *subscriptionService) closeEntitlementGrants(ctx context.Context, r *planChangeRequest) error {
+	for _, g := range r.closingEntitlementGrants {
+		// A window opening after the swap has nothing to keep; close it empty rather than inverted.
+		closeAt := r.effectiveAt
+		if closeAt.Before(g.ValidFrom) {
+			closeAt = g.ValidFrom
+		}
+
+		closed := entitlementgrant.NewEntitlementGrantBuilder(g).
+			WithWindow(g.ValidFrom, closeAt).
+			Build()
+
+		if _, err := s.EntitlementGrantRepo.Update(ctx, closed); err != nil {
+			return err
+		}
+
+		s.Logger.Info(ctx, "closed entitlement grant window on plan change",
+			"subscription_id", r.currentSub.ID,
+			"grant_id", closed.ID,
+			"entitlement_config_id", closed.EntitlementConfigID,
+			"feature_id", closed.FeatureID(),
+			"from_plan_id", r.fromPlan.ID,
+			"valid_to", closeAt)
 	}
 
 	return nil
@@ -501,13 +579,13 @@ func buildPlanChangeLineItem(
 // Uses recurring amounts (not prorated net) so timing/proration don't change the type.
 func planChangeType(r *planChangeRequest) types.SubscriptionChangeType {
 	oldTotal, newTotal := decimal.Zero, decimal.Zero
-	for _, move := range r.closing {
+	for _, move := range r.closingLineItems {
 		if move.isAddon() {
 			continue
 		}
 		oldTotal = oldTotal.Add(move.price.Amount.Mul(move.lineItem.Quantity))
 	}
-	for _, move := range r.opening {
+	for _, move := range r.openingLineItems {
 		newTotal = newTotal.Add(move.price.Amount.Mul(move.lineItem.Quantity))
 	}
 
@@ -632,7 +710,7 @@ func (s *subscriptionService) addonLineItemsToClose(
 
 func (s *subscriptionService) applyDroppedAddons(ctx context.Context, r *planChangeRequest) error {
 	closed := make(map[string]bool)
-	for _, change := range r.closing {
+	for _, change := range r.closingLineItems {
 		if !change.isAddon() || closed[change.association.ID] {
 			continue
 		}
@@ -664,8 +742,8 @@ func (s *subscriptionService) computePlanChange(
 	r *planChangeRequest,
 ) (*LineItemProrationSummary, error) {
 	entries := append(
-		prorationEntries(types.ProrationActionRemoveItem, r.closing),
-		prorationEntries(types.ProrationActionAddItem, r.opening)...,
+		prorationEntries(types.ProrationActionRemoveItem, r.closingLineItems),
+		prorationEntries(types.ProrationActionAddItem, r.openingLineItems)...,
 	)
 
 	if len(entries) == 0 {
@@ -691,6 +769,11 @@ func (s *subscriptionService) PreviewPlanChange(
 		return nil, err
 	}
 
+	superseded, err := s.planChangeScheduleToSupersede(ctx, subscriptionID, req, "")
+	if err != nil {
+		return nil, err
+	}
+
 	r, err := s.resolvePlanChange(ctx, sub, req, resolveEffectiveAt(sub, req))
 	if err != nil {
 		return nil, err
@@ -701,15 +784,25 @@ func (s *subscriptionService) PreviewPlanChange(
 		return nil, err
 	}
 
-	superseded, err := s.previewPendingScheduleSupersede(ctx, subscriptionID, req)
-	if err != nil {
-		return nil, err
+	// A deferred request only records a schedule, so the subscription it leaves behind
+	// is the untouched one and nothing settles until the boundary.
+	responseSub := r.updatedSub
+	if req.IsDeferred() {
+		responseSub = sub
 	}
 
-	resp := buildPlanChangeResponse(r, r.updatedSub, req)
+	resp := buildPlanChangeResponse(r, responseSub, req)
 	resp.ChangedResources.LineItems = planChangeChangedLineItems(r)
 	resp.ChangedResources.Invoices = preview
-	resp.SupersededSchedules = superseded
+	if superseded != nil {
+		resp.SupersededSchedules = []string{superseded.ID}
+	}
+
+	if req.IsDeferred() {
+		resp.IsScheduled = true
+		resp.ScheduledAt = lo.ToPtr(r.effectiveAt)
+	}
+
 	return resp, nil
 }
 
@@ -779,6 +872,10 @@ func (s *subscriptionService) executePlanChangeAt(
 		}
 
 		if err := s.closeEntitlementOverrides(txCtx, r); err != nil {
+			return err
+		}
+
+		if err := s.closeEntitlementGrants(txCtx, r); err != nil {
 			return err
 		}
 
@@ -854,7 +951,7 @@ func (s *subscriptionService) loadSubscriptionForPlanChange(
 }
 
 func (s *subscriptionService) applyPlanChangeLineItems(ctx context.Context, r *planChangeRequest) error {
-	for _, move := range r.carried {
+	for _, move := range r.carriedLineItems {
 		updated := subscription.NewSubscriptionLineItemBuilder(move.lineItem).
 			WithPlan(r.toPlan.ID, r.toPlan.Name).
 			WithPrice(move.price).
@@ -865,7 +962,7 @@ func (s *subscriptionService) applyPlanChangeLineItems(ctx context.Context, r *p
 		}
 	}
 
-	for _, move := range r.closing {
+	for _, move := range r.closingLineItems {
 		ended := subscription.NewSubscriptionLineItemBuilder(move.lineItem).
 			WithEndDate(r.effectiveAt).
 			Build()
@@ -875,11 +972,11 @@ func (s *subscriptionService) applyPlanChangeLineItems(ctx context.Context, r *p
 		}
 	}
 
-	if len(r.opening) == 0 {
+	if len(r.openingLineItems) == 0 {
 		return nil
 	}
-	toCreate := make([]*subscription.SubscriptionLineItem, 0, len(r.opening))
-	for _, move := range r.opening {
+	toCreate := make([]*subscription.SubscriptionLineItem, 0, len(r.openingLineItems))
+	for _, move := range r.openingLineItems {
 		toCreate = append(toCreate, move.lineItem)
 	}
 	return s.SubscriptionLineItemRepo.CreateBulk(ctx, toCreate)
@@ -893,18 +990,13 @@ func (s *subscriptionService) applyPlanSwap(
 		return nil, err
 	}
 
-	targetSeq, err := s.PlanPriceSyncRepo.CurrentPlanSequence(ctx, r.toPlan.ID)
-	if err != nil {
-		return nil, err
-	}
-
+	targetSeq := r.updatedSub.SyncedPriceSequence
 	if err := s.PlanPriceSyncRepo.ReanchorSubSyncedSequence(ctx, r.currentSub.ID, targetSeq); err != nil {
 		return nil, err
 	}
 
 	swapped := *r.updatedSub
 	swapped.PlanID = r.toPlan.ID
-	swapped.SyncedPriceSequence = targetSeq
 	return &swapped, nil
 }
 
@@ -983,7 +1075,7 @@ func (s *subscriptionService) resetQuote(
 
 	credit, err := prorationSvc.Compute(ctx, LineItemProrationRequest{
 		Subscription:  r.currentSub,
-		Entries:       prorationEntries(types.ProrationActionRemoveItem, r.closing, r.carried),
+		Entries:       prorationEntries(types.ProrationActionRemoveItem, r.closingLineItems, r.carriedLineItems),
 		EffectiveDate: r.effectiveAt,
 		Behavior:      types.ProrationBehaviorCreateProrations,
 		Reason:        "plan change with billing period reset",
@@ -994,7 +1086,7 @@ func (s *subscriptionService) resetQuote(
 
 	charge, err := prorationSvc.Compute(ctx, LineItemProrationRequest{
 		Subscription:  r.updatedSub,
-		Entries:       prorationEntries(types.ProrationActionAddItem, r.opening, r.carried),
+		Entries:       prorationEntries(types.ProrationActionAddItem, r.openingLineItems, r.carriedLineItems),
 		EffectiveDate: r.effectiveAt,
 		Behavior:      types.ProrationBehaviorCreateProrations,
 		Reason:        "plan change with billing period reset",
@@ -1259,8 +1351,8 @@ func walletCreditChangedInvoice(txn *dto.WalletTransactionResponse, status dto.C
 }
 
 func planChangeChangedLineItems(r *planChangeRequest) []dto.ChangedLineItem {
-	items := make([]dto.ChangedLineItem, 0, len(r.carried)+len(r.closing)+len(r.opening))
-	for _, move := range r.carried {
+	items := make([]dto.ChangedLineItem, 0, len(r.carriedLineItems)+len(r.closingLineItems)+len(r.openingLineItems))
+	for _, move := range r.carriedLineItems {
 		items = append(items, dto.ChangedLineItem{
 			ID:           move.lineItem.ID,
 			PriceID:      move.price.ID,
@@ -1270,7 +1362,7 @@ func planChangeChangedLineItems(r *planChangeRequest) []dto.ChangedLineItem {
 		})
 	}
 
-	for _, move := range r.closing {
+	for _, move := range r.closingLineItems {
 		endDate := r.effectiveAt
 		items = append(items, dto.ChangedLineItem{
 			ID:           move.lineItem.ID,
@@ -1282,7 +1374,7 @@ func planChangeChangedLineItems(r *planChangeRequest) []dto.ChangedLineItem {
 		})
 	}
 
-	for _, move := range r.opening {
+	for _, move := range r.openingLineItems {
 		startDate := move.lineItem.StartDate
 		items = append(items, dto.ChangedLineItem{
 			ID:           move.lineItem.ID,
@@ -1441,12 +1533,14 @@ func (s *subscriptionService) conflictingPlanChangeSchedule(
 	return existing, nil
 }
 
-func (s *subscriptionService) resolvePendingPlanChangeSchedule(
+// planChangeScheduleToSupersede returns the pending plan-change schedule this request has to
+// clear, or the conflict error when the policy does not allow clearing it.
+func (s *subscriptionService) planChangeScheduleToSupersede(
 	ctx context.Context,
 	subscriptionID string,
 	req dto.SubscriptionChangeV2Request,
 	executingScheduleID string,
-) ([]string, error) {
+) (*subscription.SubscriptionSchedule, error) {
 	existing, err := s.conflictingPlanChangeSchedule(ctx, subscriptionID, executingScheduleID)
 	if err != nil || existing == nil {
 		return nil, err
@@ -1463,6 +1557,20 @@ func (s *subscriptionService) resolvePendingPlanChangeSchedule(
 				"policy_value":    types.OnPendingSchedulePolicySupersede.String(),
 			}).
 			Mark(ierr.ErrValidation)
+	}
+
+	return existing, nil
+}
+
+func (s *subscriptionService) resolvePendingPlanChangeSchedule(
+	ctx context.Context,
+	subscriptionID string,
+	req dto.SubscriptionChangeV2Request,
+	executingScheduleID string,
+) ([]string, error) {
+	existing, err := s.planChangeScheduleToSupersede(ctx, subscriptionID, req, executingScheduleID)
+	if err != nil || existing == nil {
+		return nil, err
 	}
 
 	superseded := subscription.NewSubscriptionScheduleBuilder(existing).
@@ -1482,24 +1590,6 @@ func (s *subscriptionService) resolvePendingPlanChangeSchedule(
 		"target_plan_id", req.TargetPlanID)
 
 	return []string{superseded.ID}, nil
-}
-
-// previewPendingScheduleSupersede reports what execute would cancel, without writing.
-func (s *subscriptionService) previewPendingScheduleSupersede(
-	ctx context.Context,
-	subscriptionID string,
-	req dto.SubscriptionChangeV2Request,
-) ([]string, error) {
-	if !req.SupersedesPendingSchedule() {
-		return nil, nil
-	}
-
-	existing, err := s.conflictingPlanChangeSchedule(ctx, subscriptionID, "")
-	if err != nil || existing == nil {
-		return nil, err
-	}
-
-	return []string{existing.ID}, nil
 }
 
 // resolveEffectiveAt is the instant a request would take effect: the period boundary

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -48,7 +48,7 @@ type planChangeRequest struct {
 	closingLineItems []*lineItemChange
 	openingLineItems []*lineItemChange
 
-	grants                      *planChangeGrants
+	creditGrants                *planChangeCreditGrants
 	closingEntitlementOverrides []*entitlement.Entitlement
 	closingEntitlementGrants    []*entitlementgrant.EntitlementGrant
 
@@ -65,9 +65,9 @@ type planChangeRequest struct {
 	changeType types.SubscriptionChangeType
 }
 
-// planChangeGrants is the credit-grant migration a plan change performs. Plan-level
+// planChangeCreditGrants is the credit-grant migration a plan change performs. Plan-level
 // grants are materialised per subscription at creation time.
-type planChangeGrants struct {
+type planChangeCreditGrants struct {
 	// cancel holds the subscription's grants materialised from the outgoing plan.
 	cancel []*creditgrant.CreditGrant
 
@@ -197,7 +197,7 @@ func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r
 		return err
 	}
 
-	grants := &planChangeGrants{}
+	grants := &planChangeCreditGrants{}
 	for _, cg := range outgoing {
 		// Already closed at or before the change instant: nothing future to cancel.
 		if cg.EndDate != nil && !cg.EndDate.After(r.effectiveAt) {
@@ -212,13 +212,13 @@ func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r
 		}
 		grants.opening = append(grants.opening, cg)
 	}
-	r.grants = grants
+	r.creditGrants = grants
 
 	for _, cg := range grants.cancel {
 		r.changes = append(r.changes, &dto.EntityChangeResult{
 			EntityType:  types.SubscriptionChangeEntityTypeCreditGrant,
-			ReferenceID: cg.ID,
-			EntityID:    r.fromPlan.ID,
+			ReferenceID: r.fromPlan.ID,
+			EntityID:    cg.ID,
 			Behaviour:   types.EntityChangeBehaviourDrop,
 		})
 	}
@@ -226,8 +226,8 @@ func (s *subscriptionService) resolveCreditGrantMigration(ctx context.Context, r
 	for _, cg := range grants.opening {
 		r.changes = append(r.changes, &dto.EntityChangeResult{
 			EntityType:  types.SubscriptionChangeEntityTypeCreditGrant,
-			ReferenceID: cg.ID,
-			EntityID:    r.toPlan.ID,
+			ReferenceID: r.toPlan.ID,
+			EntityID:    cg.ID,
 			Behaviour:   types.EntityChangeBehaviourAdd,
 		})
 	}
@@ -283,8 +283,8 @@ func (s *subscriptionService) resolveClosingEntitlements(ctx context.Context, r 
 		r.closingEntitlementOverrides = append(r.closingEntitlementOverrides, ent.Entitlement)
 		r.changes = append(r.changes, &dto.EntityChangeResult{
 			EntityType:  types.SubscriptionChangeEntityTypeEntitlement,
-			ReferenceID: ent.ID,
-			EntityID:    ent.FeatureID,
+			ReferenceID: ent.FeatureID,
+			EntityID:    ent.ID,
 			Behaviour:   types.EntityChangeBehaviourDrop,
 		})
 	}
@@ -301,6 +301,13 @@ func (s *subscriptionService) resolveClosingEntitlementGrants(
 ) error {
 	// Grants key off the entitlement the subscription actually resolves to, which is the
 	// override where one is active and the plan entitlement otherwise.
+
+	// NOTE: This logic doesnot close entitlement grants that are additive and derived from
+	// some entities which are not being closed like addon. There is no way to be certain on
+	// what qouta had been used in that grant and associate it to different constituent grant qoutas.
+	// If needed, later on a prorated handling could be added to close the existing grant and open a
+	// new one with prorated qouta.
+
 	configIDs := lo.Keys(fromPlanEntIDs)
 	for _, ent := range r.closingEntitlementOverrides {
 		configIDs = append(configIDs, ent.ID)
@@ -324,8 +331,8 @@ func (s *subscriptionService) resolveClosingEntitlementGrants(
 		r.closingEntitlementGrants = append(r.closingEntitlementGrants, g)
 		r.changes = append(r.changes, &dto.EntityChangeResult{
 			EntityType:  types.SubscriptionChangeEntityTypeEntitlementGrant,
-			ReferenceID: g.ID,
-			EntityID:    g.FeatureID(),
+			ReferenceID: g.FeatureID(),
+			EntityID:    g.ID,
 			Behaviour:   types.EntityChangeBehaviourDrop,
 		})
 	}
@@ -341,11 +348,11 @@ func (s *subscriptionService) resolveClosingEntitlementGrants(
 // that period remains. addonCreditGrantProration (subscription.go) already solves this
 // exact shape for addons and is the intended reuse.
 func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planChangeRequest) error {
-	if r.grants == nil {
+	if r.creditGrants == nil {
 		return nil
 	}
 
-	if len(r.grants.cancel) > 0 {
+	if len(r.creditGrants.cancel) > 0 {
 		if err := NewCreditGrantService(s.ServiceParams).CancelFutureSubscriptionGrants(ctx, dto.CancelFutureSubscriptionGrantsRequest{
 			SubscriptionID: r.currentSub.ID,
 			PlanID:         lo.ToPtr(r.fromPlan.ID),
@@ -355,8 +362,8 @@ func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planCh
 		}
 	}
 
-	create := make([]dto.CreateCreditGrantRequest, 0, len(r.grants.opening))
-	for _, cg := range r.grants.opening {
+	create := make([]dto.CreateCreditGrantRequest, 0, len(r.creditGrants.opening))
+	for _, cg := range r.creditGrants.opening {
 		create = append(create, dto.NewSubscriptionScopedCreditGrantRequest(cg, r.currentSub.ID, r.toPlan.ID))
 	}
 
@@ -368,8 +375,8 @@ func (s *subscriptionService) migrateCreditGrants(ctx context.Context, r *planCh
 		"subscription_id", r.currentSub.ID,
 		"from_plan_id", r.fromPlan.ID,
 		"to_plan_id", r.toPlan.ID,
-		"cancelled_grants", len(r.grants.cancel),
-		"created_grants", len(r.grants.opening),
+		"cancelled_grants", len(r.creditGrants.cancel),
+		"created_grants", len(r.creditGrants.opening),
 		"effective_at", r.effectiveAt)
 
 	return nil
@@ -625,8 +632,8 @@ func (s *subscriptionService) resolveAddonChanges(
 		behaviour := policy.BehaviourFor(association.ID)
 		changes = append(changes, &dto.EntityChangeResult{
 			EntityType:  types.SubscriptionChangeEntityTypeAddon,
-			ReferenceID: association.ID,
-			EntityID:    association.AddonID,
+			ReferenceID: association.AddonID,
+			EntityID:    association.ID,
 			Behaviour:   behaviour,
 		})
 
@@ -643,10 +650,10 @@ func (s *subscriptionService) resolveAddonChanges(
 
 	// Stale override keys (e.g. preview→execute race) warn instead of failing.
 	if policy != nil {
-		for referenceID := range policy.Overrides {
-			if !seen[referenceID] {
+		for entityID := range policy.Overrides {
+			if !seen[entityID] {
 				warnings = append(warnings,
-					"ignored addon behaviour for unknown or inactive association "+referenceID)
+					"ignored addon behaviour for unknown or inactive association "+entityID)
 			}
 		}
 	}

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -52,7 +52,7 @@ type planChangeRequest struct {
 	closingEntitlementOverrides []*entitlement.Entitlement
 	closingEntitlementGrants    []*entitlementgrant.EntitlementGrant
 
-	resetAnchor bool
+	anchorAtEffect bool
 
 	// outgoingUsage bills the outgoing plan's usage and is set only under a reset; settlementQuote is
 	// the net of credits against charges, nil when the change settles no money.
@@ -124,7 +124,7 @@ func (s *subscriptionService) resolvePlanChange(
 		effectiveAt:    effectiveAt,
 		behavior:       req.ProrationBehavior,
 		idempotencyKey: lo.FromPtr(req.IdempotencyKey),
-		resetAnchor:    req.ResetsAnchorAtEffective() && !req.IsDeferred(),
+		anchorAtEffect: req.AnchorAtEffect() && !req.IsDeferred(),
 	}
 
 	updatedSub, err := projectSubscriptionAfterChange(r)
@@ -155,7 +155,7 @@ func (s *subscriptionService) resolvePlanChange(
 
 	// The settlement is resolved here, before any write, so preview and execute quote the
 	// same documents and settling them is order-independent.
-	if r.resetAnchor {
+	if r.anchorAtEffect {
 		if r.outgoingUsage, err = s.outgoingUsageInvoiceRequest(ctx, r); err != nil {
 			return nil, err
 		}
@@ -468,7 +468,7 @@ func (s *subscriptionService) checkPlanChangePreconditions(
 			map[string]any{"subscription_id": sub.ID})
 	}
 
-	if req.ResetsAnchorAtEffective() && sub.BillingCycle == types.BillingCycleCalendar {
+	if req.AnchorAtEffect() && sub.BillingCycle == types.BillingCycleCalendar {
 		return fail("the billing period cannot be reset on a calendar-aligned subscription",
 			"Calendar billing keeps every period on a calendar boundary. Use billing_period_behaviour='unchanged', or move the subscription to anniversary billing.",
 			map[string]any{"subscription_id": sub.ID, "billing_cycle": sub.BillingCycle})
@@ -1005,7 +1005,7 @@ func (s *subscriptionService) applyAnchorReset(
 	r *planChangeRequest,
 	swapped *subscription.Subscription,
 ) (*subscription.Subscription, error) {
-	if !r.resetAnchor {
+	if !r.anchorAtEffect {
 		return swapped, nil
 	}
 
@@ -1036,7 +1036,7 @@ func projectSubscriptionAfterChange(r *planChangeRequest) (*subscription.Subscri
 	projected := *r.currentSub
 	projected.PlanID = r.toPlan.ID
 
-	if !r.resetAnchor {
+	if !r.anchorAtEffect {
 		return &projected, nil
 	}
 
@@ -1073,15 +1073,19 @@ func (s *subscriptionService) resetQuote(
 ) (*LineItemProrationSummary, error) {
 	prorationSvc := NewLineItemProrationService(s.ServiceParams)
 
-	credit, err := prorationSvc.Compute(ctx, LineItemProrationRequest{
-		Subscription:  r.currentSub,
-		Entries:       prorationEntries(types.ProrationActionRemoveItem, r.closingLineItems, r.carriedLineItems),
-		EffectiveDate: r.effectiveAt,
-		Behavior:      types.ProrationBehaviorCreateProrations,
-		Reason:        "plan change with billing period reset",
-	})
-	if err != nil {
-		return nil, err
+	var credit *LineItemProrationSummary
+	if r.behavior == types.ProrationBehaviorCreateProrations {
+		var err error
+		credit, err = prorationSvc.Compute(ctx, LineItemProrationRequest{
+			Subscription:  r.currentSub,
+			Entries:       prorationEntries(types.ProrationActionRemoveItem, r.closingLineItems, r.carriedLineItems),
+			EffectiveDate: r.effectiveAt,
+			Behavior:      types.ProrationBehaviorCreateProrations,
+			Reason:        "plan change with billing period reset",
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	charge, err := prorationSvc.Compute(ctx, LineItemProrationRequest{

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -1030,7 +1030,7 @@ func (s *subscriptionService) applyAnchorReset(
 }
 
 // projectSubscriptionAfterChange is the subscription the change would leave behind,
-// computed without writing anything. Under reset_at_effect the term restarts at
+// computed without writing anything. Under anchor_at_effect the term restarts at
 // effectiveAt, so the new period is a full period and never the remainder of the old one.
 func projectSubscriptionAfterChange(r *planChangeRequest) (*subscription.Subscription, error) {
 	projected := *r.currentSub

--- a/internal/ee/service/subscription_change_v2_conflict_test.go
+++ b/internal/ee/service/subscription_change_v2_conflict_test.go
@@ -69,9 +69,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_SupersedeReplacesPendingSchedule
 	cancelled := s.scheduleByID(*scheduled.ScheduleID)
 	s.Require().NotNil(cancelled)
 	s.Equal(types.ScheduleStatusCancelled, cancelled.Status)
-	s.Require().NotNil(cancelled.CancelledAt)
-	s.Equal(scheduleSupersededReason, cancelled.Metadata[scheduleCancellationReasonKey],
-		"the row records why it was cancelled, not just that it was")
+	s.Require().NotNil(cancelled.CancelledAt, "the row records when it was cancelled")
 }
 
 // Replacing a queued change with another queued change is the same operation.
@@ -186,8 +184,8 @@ func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_DoesNotSupersedeItsOw
 	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()))
 
 	s.Equal(s.td.pro.ID, s.currentSub().PlanID)
-	s.NotEqual(scheduleSupersededReason, s.scheduleByID(sched.ID).Metadata[scheduleCancellationReasonKey],
-		"the executed schedule was not marked as superseded by its own execution")
+	s.Equal(types.ScheduleStatusExecuted, s.scheduleByID(sched.ID).Status,
+		"the schedule executed rather than being cancelled by its own execution")
 }
 
 // The policy covers queued plan changes only. A pending cancellation means un-cancelling

--- a/internal/ee/service/subscription_change_v2_conflict_test.go
+++ b/internal/ee/service/subscription_change_v2_conflict_test.go
@@ -1,0 +1,223 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	cockroachErrors "github.com/cockroachdb/errors"
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+)
+
+// errorDetails reads an ierr error's reportable details the way the HTTP error handler
+// does (middleware/errhandler.go), so assertions see the payload a client receives.
+func (s *SubscriptionChangeV2Suite) errorDetails(err error) map[string]any {
+	const jsonDetailsPrefix = "__json__:"
+	for _, sdp := range cockroachErrors.GetAllSafeDetails(err) {
+		for _, payload := range sdp.SafeDetails {
+			if !strings.HasPrefix(payload, jsonDetailsPrefix) {
+				continue
+			}
+			var details map[string]any
+			if json.Unmarshal([]byte(payload[len(jsonDetailsPrefix):]), &details) == nil {
+				return details
+			}
+		}
+	}
+	s.Failf("no reportable details", "error carried no JSON details: %v", err)
+	return nil
+}
+
+func (s *SubscriptionChangeV2Suite) withSupersede(req dto.SubscriptionChangeV2Request) dto.SubscriptionChangeV2Request {
+	req.OnConflictPolicies = &dto.SubscriptionChangeConflictPolicies{
+		OnPendingSchedule: types.OnPendingSchedulePolicySupersede,
+	}
+	return req
+}
+
+func (s *SubscriptionChangeV2Suite) scheduleByID(id string) *subscription.SubscriptionSchedule {
+	schedules, err := s.GetStores().SubscriptionScheduleRepo.GetBySubscriptionID(s.GetContext(), s.td.sub.ID)
+	s.Require().NoError(err)
+	for _, sched := range schedules {
+		if sched.ID == id {
+			return sched
+		}
+	}
+	return nil
+}
+
+// An immediate change replaces the queued one instead of forcing a cancel-then-change.
+func (s *SubscriptionChangeV2Suite) TestExecute_SupersedeReplacesPendingScheduleWithImmediateChange() {
+	ctx := s.GetContext()
+
+	scheduled, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+	s.Require().NotNil(scheduled.ScheduleID)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.withSupersede(s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)), time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.Equal([]string{*scheduled.ScheduleID}, resp.SupersededSchedules)
+	s.Equal(s.td.pro.ID, s.currentSub().PlanID, "the immediate change applied")
+	s.Nil(s.pendingPlanChange(), "no plan change is queued any more")
+
+	cancelled := s.scheduleByID(*scheduled.ScheduleID)
+	s.Require().NotNil(cancelled)
+	s.Equal(types.ScheduleStatusCancelled, cancelled.Status)
+	s.Require().NotNil(cancelled.CancelledAt)
+	s.Equal(scheduleSupersededReason, cancelled.Metadata[scheduleCancellationReasonKey],
+		"the row records why it was cancelled, not just that it was")
+}
+
+// Replacing a queued change with another queued change is the same operation.
+func (s *SubscriptionChangeV2Suite) TestExecute_SupersedeReplacesPendingScheduleWithDeferredChange() {
+	ctx := s.GetContext()
+
+	first, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+	s.Require().NotNil(first.ScheduleID)
+
+	lateral := s.createPlan("Lateral", "lateral")
+	s.createFixedPrice(lateral.ID, "base_fee", 20)
+
+	second, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.withSupersede(s.deferredRequest(lateral.ID)), time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.Equal([]string{*first.ScheduleID}, second.SupersededSchedules)
+	s.Require().NotNil(second.ScheduleID)
+	s.NotEqual(*first.ScheduleID, *second.ScheduleID)
+
+	pending := s.pendingPlanChange()
+	s.Require().NotNil(pending)
+	s.Equal(*second.ScheduleID, pending.ID, "exactly one schedule is pending, and it is the new one")
+
+	config, err := pending.GetPlanChangeV2Config()
+	s.Require().NoError(err)
+	s.Equal(lateral.ID, config.TargetPlanID)
+
+	s.Equal(types.ScheduleStatusCancelled, s.scheduleByID(*first.ScheduleID).Status)
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID, "a deferred change still swaps nothing now")
+}
+
+// The default is unchanged: reject, naming the schedule and the field that would allow it.
+func (s *SubscriptionChangeV2Suite) TestExecute_RejectIsTheDefaultAndNamesTheEscapeHatch() {
+	ctx := s.GetContext()
+
+	scheduled, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	for _, req := range []dto.SubscriptionChangeV2Request{
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone),
+		{
+			TargetPlanID:      s.td.pro.ID,
+			ProrationBehavior: types.ProrationBehaviorNone,
+			OnConflictPolicies: &dto.SubscriptionChangeConflictPolicies{
+				OnPendingSchedule: types.OnPendingSchedulePolicyReject,
+			},
+		},
+	} {
+		_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
+		s.Require().Error(err)
+		s.True(ierr.IsValidation(err))
+
+		details := s.errorDetails(err)
+		s.Equal(*scheduled.ScheduleID, details["schedule_id"])
+		s.Equal("on_conflict_policies.on_pending_schedule", details["policy_field"])
+		s.Equal(types.OnPendingSchedulePolicySupersede.String(), details["policy_value"])
+		s.NotNil(details["scheduled_at"])
+	}
+
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID)
+	s.Require().NotNil(s.pendingPlanChange(), "a rejected request leaves the queued change alone")
+}
+
+func (s *SubscriptionChangeV2Suite) TestPreview_ReportsWhatExecuteWouldSupersede() {
+	ctx := s.GetContext()
+
+	scheduled, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID,
+		s.withSupersede(s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)))
+	s.Require().NoError(err)
+	s.Equal([]string{*scheduled.ScheduleID}, preview.SupersededSchedules)
+
+	pending := s.pendingPlanChange()
+	s.Require().NotNil(pending, "preview writes nothing")
+	s.Equal(types.ScheduleStatusPending, pending.Status)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.withSupersede(s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)), time.Now().UTC())
+	s.Require().NoError(err)
+	s.Equal(preview.SupersededSchedules, resp.SupersededSchedules, "preview quoted what execute did")
+}
+
+// Nothing to supersede is not an error, and the response must not claim otherwise.
+func (s *SubscriptionChangeV2Suite) TestExecute_SupersedeWithoutAPendingScheduleReportsNothing() {
+	ctx := s.GetContext()
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.withSupersede(s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)), time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.Empty(resp.SupersededSchedules)
+	s.Equal(s.td.pro.ID, s.currentSub().PlanID)
+}
+
+// The executor must still ignore its own pending row rather than superseding it.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_DoesNotSupersedeItsOwnPendingRow() {
+	ctx := s.GetContext()
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	sched := s.pendingPlanChange()
+	s.Require().NotNil(sched)
+	config, err := sched.GetPlanChangeV2Config()
+	s.Require().NoError(err)
+
+	s.rollPeriodTo(*resp.ScheduledAt, resp.ScheduledAt.AddDate(0, 0, 30))
+	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()))
+
+	s.Equal(s.td.pro.ID, s.currentSub().PlanID)
+	s.NotEqual(scheduleSupersededReason, s.scheduleByID(sched.ID).Metadata[scheduleCancellationReasonKey],
+		"the executed schedule was not marked as superseded by its own execution")
+}
+
+// The policy covers queued plan changes only. A pending cancellation means un-cancelling
+// the subscription, which is a different decision and stays a hard rejection.
+func (s *SubscriptionChangeV2Suite) TestExecute_SupersedeDoesNotClearAPendingCancellation() {
+	ctx := s.GetContext()
+
+	sub := s.currentSub()
+	sub.CancelAtPeriodEnd = true
+	sub.CancelAt = lo.ToPtr(s.td.periodEnd)
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.withSupersede(s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)), time.Now().UTC())
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+	s.Contains(err.Error(), "pending cancellation")
+
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID)
+	s.True(s.currentSub().CancelAtPeriodEnd, "the cancellation is untouched")
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecute_RejectsAnUnknownConflictPolicy() {
+	ctx := s.GetContext()
+
+	req := s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)
+	req.OnConflictPolicies = &dto.SubscriptionChangeConflictPolicies{OnPendingSchedule: "queue_after"}
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID)
+}

--- a/internal/ee/service/subscription_change_v2_conflict_test.go
+++ b/internal/ee/service/subscription_change_v2_conflict_test.go
@@ -47,6 +47,10 @@ func (s *SubscriptionChangeV2Suite) scheduleByID(id string) *subscription.Subscr
 			return sched
 		}
 	}
+
+	// Callers dereference the result, so a miss must fail the assertion rather than
+	// panic the whole suite.
+	s.Require().Failf("schedule not found", "no schedule with id %s on subscription %s", id, s.td.sub.ID)
 	return nil
 }
 

--- a/internal/ee/service/subscription_change_v2_conflict_test.go
+++ b/internal/ee/service/subscription_change_v2_conflict_test.go
@@ -223,3 +223,29 @@ func (s *SubscriptionChangeV2Suite) TestExecute_RejectsAnUnknownConflictPolicy()
 	s.True(ierr.IsValidation(err))
 	s.Equal(s.td.starter.ID, s.currentSub().PlanID)
 }
+
+// Preview is only useful as a rehearsal if it refuses on the same grounds execute will.
+func (s *SubscriptionChangeV2Suite) TestPreview_RejectsTheConflictExecuteWouldReject() {
+	ctx := s.GetContext()
+
+	scheduled, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.deferredRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	req := s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)
+
+	_, previewErr := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, req)
+	s.Require().Error(previewErr)
+	s.True(ierr.IsValidation(previewErr))
+
+	_, executeErr := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
+	s.Require().Error(executeErr)
+	s.Equal(executeErr.Error(), previewErr.Error(), "both refuse for the same stated reason")
+
+	details := s.errorDetails(previewErr)
+	s.Equal(*scheduled.ScheduleID, details["schedule_id"])
+	s.Equal("on_conflict_policies.on_pending_schedule", details["policy_field"])
+
+	pending := s.pendingPlanChange()
+	s.Require().NotNil(pending, "a refused preview leaves the queued change alone")
+	s.Equal(types.ScheduleStatusPending, pending.Status)
+}

--- a/internal/ee/service/subscription_change_v2_deferred_test.go
+++ b/internal/ee/service/subscription_change_v2_deferred_test.go
@@ -148,8 +148,15 @@ func (s *SubscriptionChangeV2Suite) TestPreview_DeferredPricesAtTheBoundary() {
 	s.True(resp.EffectiveAt.Equal(s.td.periodEnd),
 		"preview must report the instant it actually priced, not now")
 	s.Empty(resp.ChangedResources.Invoices, "proration none quotes no money")
-	s.False(resp.IsScheduled, "preview writes nothing")
-	s.Nil(s.pendingPlanChange())
+
+	// Mirrors what execute would return, without the write: the schedule id is the one
+	// thing preview cannot know, because the row does not exist yet.
+	s.True(resp.IsScheduled, "a deferred request is reported as scheduled")
+	s.Require().NotNil(resp.ScheduledAt)
+	s.True(resp.ScheduledAt.Equal(s.td.periodEnd))
+	s.Nil(resp.ScheduleID)
+	s.Equal(s.td.starter.ID, resp.Subscription.PlanID, "nothing has moved off the current plan yet")
+	s.Nil(s.pendingPlanChange(), "preview writes nothing")
 
 	for _, item := range resp.ChangedResources.LineItems {
 		switch item.ChangeAction {

--- a/internal/ee/service/subscription_change_v2_grants_test.go
+++ b/internal/ee/service/subscription_change_v2_grants_test.go
@@ -105,7 +105,7 @@ func (s *SubscriptionChangeV2Suite) materialisePlanGrants(planID string) []*cred
 
 	created := make([]*creditgrant.CreditGrant, 0, len(planGrants.Items))
 	for _, pg := range planGrants.Items {
-		req := PlanCreditGrantRequest(pg, s.td.sub.ID, planID)
+		req := dto.NewSubscriptionScopedCreditGrantRequest(pg, s.td.sub.ID, planID)
 		cg := &creditgrant.CreditGrant{
 			ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT),
 			Name:           req.Name,

--- a/internal/ee/service/subscription_change_v2_grants_test.go
+++ b/internal/ee/service/subscription_change_v2_grants_test.go
@@ -1,0 +1,310 @@
+package service
+
+import (
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/creditgrant"
+	"github.com/flexprice/flexprice/internal/domain/entitlement"
+	"github.com/flexprice/flexprice/internal/domain/feature"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+func (s *SubscriptionChangeV2Suite) createPlanGrant(planID, name string, credits int64) *creditgrant.CreditGrant {
+	ctx := s.GetContext()
+	cg := &creditgrant.CreditGrant{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT),
+		Name:           name,
+		Scope:          types.CreditGrantScopePlan,
+		PlanID:         lo.ToPtr(planID),
+		Credits:        decimal.NewFromInt(credits),
+		Cadence:        types.CreditGrantCadenceRecurring,
+		Period:         lo.ToPtr(types.CREDIT_GRANT_PERIOD_MONTHLY),
+		PeriodCount:    lo.ToPtr(1),
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().CreditGrantRepo.Create(ctx, cg)
+	s.Require().NoError(err)
+	return cg
+}
+
+// subscriptionGrants returns the subscription-scoped grants, keyed by their source plan.
+func (s *SubscriptionChangeV2Suite) subscriptionGrants() []*creditgrant.CreditGrant {
+	filter := types.NewNoLimitCreditGrantFilter()
+	filter.SubscriptionIDs = []string{s.td.sub.ID}
+	filter.WithStatus(types.StatusPublished)
+	grants, err := s.GetStores().CreditGrantRepo.List(s.GetContext(), filter)
+	s.Require().NoError(err)
+	return grants
+}
+
+func (s *SubscriptionChangeV2Suite) liveGrantsForPlan(planID string, at time.Time) []*creditgrant.CreditGrant {
+	live := make([]*creditgrant.CreditGrant, 0)
+	for _, g := range s.subscriptionGrants() {
+		if lo.FromPtr(g.PlanID) != planID {
+			continue
+		}
+		if g.EndDate != nil && !g.EndDate.After(at) {
+			continue
+		}
+		live = append(live, g)
+	}
+	return live
+}
+
+func (s *SubscriptionChangeV2Suite) grantChanges(resp *dto.SubscriptionChangeV2Response) []*dto.EntityChangeResult {
+	return lo.Filter(resp.EntityChanges, func(c *dto.EntityChangeResult, _ int) bool {
+		return c.EntityType == types.SubscriptionChangeEntityTypeCreditGrant
+	})
+}
+
+// The defect this phase exists for: without migration the customer keeps receiving the
+// old plan's credits forever and never receives the new plan's.
+func (s *SubscriptionChangeV2Suite) TestExecute_MigratesCreditGrantsToTheTargetPlan() {
+	ctx := s.GetContext()
+
+	s.createPlanGrant(s.td.starter.ID, "starter credits", 100)
+	s.createPlanGrant(s.td.pro.ID, "pro credits", 500)
+
+	// Materialise the starter grant on the subscription the way creation does.
+	starterSubGrant := s.materialisePlanGrants(s.td.starter.ID)
+	s.Require().Len(starterSubGrant, 1)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	at := resp.EffectiveAt
+	s.Empty(s.liveGrantsForPlan(s.td.starter.ID, at), "the outgoing plan's grants stop at the change")
+
+	proGrants := s.liveGrantsForPlan(s.td.pro.ID, at)
+	s.Require().Len(proGrants, 1, "the target plan's grants are materialised")
+	s.Equal(decimal.NewFromInt(500), proGrants[0].Credits)
+	s.Require().NotNil(proGrants[0].StartDate)
+	s.True(proGrants[0].StartDate.Equal(at), "the new grant starts at the change instant")
+
+	// The old grant row survives, end-dated — already-granted credits are not clawed back.
+	ended := lo.Filter(s.subscriptionGrants(), func(g *creditgrant.CreditGrant, _ int) bool {
+		return lo.FromPtr(g.PlanID) == s.td.starter.ID
+	})
+	s.Require().Len(ended, 1)
+	s.Require().NotNil(ended[0].EndDate)
+	s.True(ended[0].EndDate.Equal(at))
+	s.Equal(types.StatusPublished, ended[0].Status, "the grant is closed, not deleted")
+}
+
+// materialisePlanGrants creates the subscription-scoped grants a plan would produce at
+// subscription creation, through the same mapping the service uses.
+func (s *SubscriptionChangeV2Suite) materialisePlanGrants(planID string) []*creditgrant.CreditGrant {
+	ctx := s.GetContext()
+	planGrants, err := NewCreditGrantService(s.serviceParams()).GetCreditGrantsByPlan(ctx, planID)
+	s.Require().NoError(err)
+
+	created := make([]*creditgrant.CreditGrant, 0, len(planGrants.Items))
+	for _, pg := range planGrants.Items {
+		req := PlanCreditGrantRequest(pg, s.td.sub.ID, planID)
+		cg := &creditgrant.CreditGrant{
+			ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT),
+			Name:           req.Name,
+			Scope:          req.Scope,
+			PlanID:         req.PlanID,
+			SubscriptionID: req.SubscriptionID,
+			Credits:        req.Credits,
+			Cadence:        req.Cadence,
+			Period:         req.Period,
+			PeriodCount:    req.PeriodCount,
+			ExpirationType: req.ExpirationType,
+			StartDate:      lo.ToPtr(s.td.periodStart),
+			BaseModel:      types.GetDefaultBaseModel(ctx),
+		}
+		_, err := s.GetStores().CreditGrantRepo.Create(ctx, cg)
+		s.Require().NoError(err)
+		created = append(created, cg)
+	}
+	return created
+}
+
+// Addon grants have their own provenance and must outlive a plan swap.
+func (s *SubscriptionChangeV2Suite) TestExecute_AddonGrantsSurviveAPlanChange() {
+	ctx := s.GetContext()
+
+	addonEntity, _, _ := s.attachAddon("extra", 10)
+	s.createPlanGrant(s.td.starter.ID, "starter credits", 100)
+	s.materialisePlanGrants(s.td.starter.ID)
+
+	addonGrant := &creditgrant.CreditGrant{
+		ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT),
+		Name:           "addon credits",
+		Scope:          types.CreditGrantScopeSubscription,
+		SubscriptionID: lo.ToPtr(s.td.sub.ID),
+		AddonID:        lo.ToPtr(addonEntity.ID),
+		Credits:        decimal.NewFromInt(25),
+		Cadence:        types.CreditGrantCadenceRecurring,
+		Period:         lo.ToPtr(types.CREDIT_GRANT_PERIOD_MONTHLY),
+		PeriodCount:    lo.ToPtr(1),
+		ExpirationType: types.CreditGrantExpiryTypeNever,
+		StartDate:      lo.ToPtr(s.td.periodStart),
+		BaseModel:      types.GetDefaultBaseModel(ctx),
+	}
+	_, createErr := s.GetStores().CreditGrantRepo.Create(ctx, addonGrant)
+	s.Require().NoError(createErr)
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	stored, err := s.GetStores().CreditGrantRepo.Get(ctx, addonGrant.ID)
+	s.Require().NoError(err)
+	s.Nil(stored.EndDate, "the addon's grant is untouched by the plan swap")
+}
+
+func (s *SubscriptionChangeV2Suite) TestPreview_ReportsGrantMigrationWithoutWriting() {
+	ctx := s.GetContext()
+
+	s.createPlanGrant(s.td.starter.ID, "starter credits", 100)
+	proGrant := s.createPlanGrant(s.td.pro.ID, "pro credits", 500)
+	materialised := s.materialisePlanGrants(s.td.starter.ID)
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone))
+	s.Require().NoError(err)
+
+	changes := s.grantChanges(preview)
+	s.Require().Len(changes, 2)
+
+	dropped, added := changes[0], changes[1]
+	s.Equal(types.EntityChangeBehaviourDrop, dropped.Behaviour)
+	s.Equal(materialised[0].ID, dropped.ReferenceID)
+	s.Equal(s.td.starter.ID, dropped.EntityID)
+
+	s.Equal(types.EntityChangeBehaviourAdd, added.Behaviour)
+	s.Equal(proGrant.ID, added.ReferenceID, "preview names the plan grant it would materialise")
+	s.Equal(s.td.pro.ID, added.EntityID)
+
+	s.Require().Len(s.subscriptionGrants(), 1, "preview created nothing")
+	s.Nil(s.subscriptionGrants()[0].EndDate, "preview cancelled nothing")
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_MigratesGrantsLikeAnImmediateChange() {
+	ctx := s.GetContext()
+	boundary := s.td.periodEnd
+
+	s.createPlanGrant(s.td.starter.ID, "starter credits", 100)
+	s.createPlanGrant(s.td.pro.ID, "pro credits", 500)
+	s.materialisePlanGrants(s.td.starter.ID)
+
+	sched, config := s.createV2Schedule(s.td.pro.ID, boundary)
+	s.rollPeriodTo(boundary, boundary.AddDate(0, 0, 30))
+	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()))
+
+	s.Empty(s.liveGrantsForPlan(s.td.starter.ID, boundary))
+	proGrants := s.liveGrantsForPlan(s.td.pro.ID, boundary)
+	s.Require().Len(proGrants, 1)
+	s.True(proGrants[0].StartDate.Equal(boundary), "the scheduled path anchors grants at the boundary")
+}
+
+func (s *SubscriptionChangeV2Suite) createFeature(name string) *feature.Feature {
+	ctx := s.GetContext()
+	f := &feature.Feature{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_FEATURE),
+		Name:      name,
+		Type:      types.FeatureTypeMetered,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().FeatureRepo.Create(ctx, f))
+	return f
+}
+
+func (s *SubscriptionChangeV2Suite) createPlanEntitlement(planID, featureID string, limit int64) *entitlement.Entitlement {
+	ctx := s.GetContext()
+	e := &entitlement.Entitlement{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENTITLEMENT),
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_PLAN,
+		EntityID:         planID,
+		FeatureID:        featureID,
+		FeatureType:      types.FeatureTypeMetered,
+		IsEnabled:        true,
+		UsageLimit:       lo.ToPtr(limit),
+		UsageResetPeriod: types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY,
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(ctx, e)
+	s.Require().NoError(err)
+	return e
+}
+
+func (s *SubscriptionChangeV2Suite) createSubscriptionOverride(parent *entitlement.Entitlement, limit int64) *entitlement.Entitlement {
+	ctx := s.GetContext()
+	e := &entitlement.Entitlement{
+		ID:                  types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENTITLEMENT),
+		EntityType:          types.ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION,
+		EntityID:            s.td.sub.ID,
+		FeatureID:           parent.FeatureID,
+		FeatureType:         parent.FeatureType,
+		IsEnabled:           true,
+		UsageLimit:          lo.ToPtr(limit),
+		UsageResetPeriod:    parent.UsageResetPeriod,
+		ParentEntitlementID: lo.ToPtr(parent.ID),
+		StartDate:           lo.ToPtr(s.td.periodStart),
+		BaseModel:           types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().EntitlementRepo.Create(ctx, e)
+	s.Require().NoError(err)
+	return e
+}
+
+// A v1-era override whose parent belongs to the outgoing plan suppresses nothing after
+// the swap and would otherwise stack with the new plan's entitlement on the same feature.
+func (s *SubscriptionChangeV2Suite) TestExecute_ClosesStaleEntitlementOverrides() {
+	ctx := s.GetContext()
+
+	f := s.createFeature("api_calls")
+	starterEnt := s.createPlanEntitlement(s.td.starter.ID, f.ID, 1000)
+	proEnt := s.createPlanEntitlement(s.td.pro.ID, f.ID, 5000)
+	override := s.createSubscriptionOverride(starterEnt, 2000)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	stored, err := s.GetStores().EntitlementRepo.Get(ctx, override.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(stored.EndDate, "the stale override is closed")
+	s.True(stored.EndDate.Equal(resp.EffectiveAt))
+
+	// Plan entitlements are rows on the plan, shared by every subscription on it.
+	for _, planEnt := range []*entitlement.Entitlement{starterEnt, proEnt} {
+		live, err := s.GetStores().EntitlementRepo.Get(ctx, planEnt.ID)
+		s.Require().NoError(err)
+		s.Nil(live.EndDate, "plan entitlements must never be end-dated by a plan change")
+		s.Equal(types.StatusPublished, live.Status)
+	}
+
+	reported := lo.Filter(resp.EntityChanges, func(c *dto.EntityChangeResult, _ int) bool {
+		return c.EntityType == types.SubscriptionChangeEntityTypeEntitlement
+	})
+	s.Require().Len(reported, 1)
+	s.Equal(override.ID, reported[0].ReferenceID)
+	s.Equal(f.ID, reported[0].EntityID)
+	s.Equal(types.EntityChangeBehaviourDrop, reported[0].Behaviour)
+}
+
+// An override parented to a plan the subscription is not leaving is none of our business.
+func (s *SubscriptionChangeV2Suite) TestExecute_LeavesUnrelatedOverridesAlone() {
+	ctx := s.GetContext()
+
+	f := s.createFeature("api_calls")
+	proEnt := s.createPlanEntitlement(s.td.pro.ID, f.ID, 5000)
+	override := s.createSubscriptionOverride(proEnt, 2000)
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	stored, err := s.GetStores().EntitlementRepo.Get(ctx, override.ID)
+	s.Require().NoError(err)
+	s.Nil(stored.EndDate)
+}

--- a/internal/ee/service/subscription_change_v2_grants_test.go
+++ b/internal/ee/service/subscription_change_v2_grants_test.go
@@ -183,12 +183,12 @@ func (s *SubscriptionChangeV2Suite) TestPreview_ReportsGrantMigrationWithoutWrit
 
 	dropped, added := changes[0], changes[1]
 	s.Equal(types.EntityChangeBehaviourDrop, dropped.Behaviour)
-	s.Equal(materialised[0].ID, dropped.ReferenceID)
-	s.Equal(s.td.starter.ID, dropped.EntityID)
+	s.Equal(materialised[0].ID, dropped.EntityID)
+	s.Equal(s.td.starter.ID, dropped.ReferenceID)
 
 	s.Equal(types.EntityChangeBehaviourAdd, added.Behaviour)
-	s.Equal(proGrant.ID, added.ReferenceID, "preview names the plan grant it would materialise")
-	s.Equal(s.td.pro.ID, added.EntityID)
+	s.Equal(proGrant.ID, added.EntityID, "preview names the plan grant it would materialise")
+	s.Equal(s.td.pro.ID, added.ReferenceID)
 
 	s.Require().Len(s.subscriptionGrants(), 1, "preview created nothing")
 	s.Nil(s.subscriptionGrants()[0].EndDate, "preview cancelled nothing")
@@ -301,8 +301,8 @@ func (s *SubscriptionChangeV2Suite) TestExecute_ClosesStaleEntitlementOverrides(
 		return c.EntityType == types.SubscriptionChangeEntityTypeEntitlement
 	})
 	s.Require().Len(reported, 1)
-	s.Equal(override.ID, reported[0].ReferenceID)
-	s.Equal(f.ID, reported[0].EntityID)
+	s.Equal(override.ID, reported[0].EntityID)
+	s.Equal(f.ID, reported[0].ReferenceID)
 	s.Equal(types.EntityChangeBehaviourDrop, reported[0].Behaviour)
 }
 
@@ -384,8 +384,8 @@ func (s *SubscriptionChangeV2Suite) TestExecute_ClosesEntitlementGrantsFromTheOu
 		return c.EntityType == types.SubscriptionChangeEntityTypeEntitlementGrant
 	})
 	s.Require().Len(reported, 1)
-	s.Equal(closing.ID, reported[0].ReferenceID)
-	s.Equal(f.ID, reported[0].EntityID)
+	s.Equal(closing.ID, reported[0].EntityID)
+	s.Equal(f.ID, reported[0].ReferenceID)
 	s.Equal(types.EntityChangeBehaviourDrop, reported[0].Behaviour)
 }
 
@@ -463,7 +463,7 @@ func (s *SubscriptionChangeV2Suite) TestPreview_ReportsGrantClosureWithoutWritin
 		return c.EntityType == types.SubscriptionChangeEntityTypeEntitlementGrant
 	})
 	s.Require().Len(reported, 1)
-	s.Equal(grant.ID, reported[0].ReferenceID)
+	s.Equal(grant.ID, reported[0].EntityID)
 
 	s.True(s.storedGrant(grant.ID).ValidTo.Equal(s.td.periodEnd), "preview closed nothing")
 }

--- a/internal/ee/service/subscription_change_v2_grants_test.go
+++ b/internal/ee/service/subscription_change_v2_grants_test.go
@@ -101,13 +101,17 @@ func (s *SubscriptionChangeV2Suite) TestExecute_MigratesCreditGrantsToTheTargetP
 // materialisePlanGrants creates the subscription-scoped grants a plan would produce at
 // subscription creation, through the same mapping the service uses.
 func (s *SubscriptionChangeV2Suite) materialisePlanGrants(planID string) []*creditgrant.CreditGrant {
+	return s.materialisePlanGrantsFor(s.td.sub, planID)
+}
+
+func (s *SubscriptionChangeV2Suite) materialisePlanGrantsFor(sub *subscription.Subscription, planID string) []*creditgrant.CreditGrant {
 	ctx := s.GetContext()
 	planGrants, err := NewCreditGrantService(s.serviceParams()).GetCreditGrantsByPlan(ctx, planID)
 	s.Require().NoError(err)
 
 	created := make([]*creditgrant.CreditGrant, 0, len(planGrants.Items))
 	for _, pg := range planGrants.Items {
-		req := dto.NewSubscriptionScopedCreditGrantRequest(pg, s.td.sub.ID, planID)
+		req := dto.NewSubscriptionScopedCreditGrantRequest(pg, sub.ID, planID)
 		cg := &creditgrant.CreditGrant{
 			ID:             types.GenerateUUIDWithPrefix(types.UUID_PREFIX_CREDIT_GRANT),
 			Name:           req.Name,

--- a/internal/ee/service/subscription_change_v2_grants_test.go
+++ b/internal/ee/service/subscription_change_v2_grants_test.go
@@ -6,7 +6,9 @@ import (
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/creditgrant"
 	"github.com/flexprice/flexprice/internal/domain/entitlement"
+	"github.com/flexprice/flexprice/internal/domain/entitlementgrant"
 	"github.com/flexprice/flexprice/internal/domain/feature"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
@@ -237,11 +239,19 @@ func (s *SubscriptionChangeV2Suite) createPlanEntitlement(planID, featureID stri
 }
 
 func (s *SubscriptionChangeV2Suite) createSubscriptionOverride(parent *entitlement.Entitlement, limit int64) *entitlement.Entitlement {
+	return s.createSubscriptionOverrideFor(s.td.sub, parent, limit)
+}
+
+func (s *SubscriptionChangeV2Suite) createSubscriptionOverrideFor(
+	sub *subscription.Subscription,
+	parent *entitlement.Entitlement,
+	limit int64,
+) *entitlement.Entitlement {
 	ctx := s.GetContext()
 	e := &entitlement.Entitlement{
 		ID:                  types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENTITLEMENT),
 		EntityType:          types.ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION,
-		EntityID:            s.td.sub.ID,
+		EntityID:            sub.ID,
 		FeatureID:           parent.FeatureID,
 		FeatureType:         parent.FeatureType,
 		IsEnabled:           true,
@@ -307,4 +317,149 @@ func (s *SubscriptionChangeV2Suite) TestExecute_LeavesUnrelatedOverridesAlone() 
 	stored, err := s.GetStores().EntitlementRepo.Get(ctx, override.ID)
 	s.Require().NoError(err)
 	s.Nil(stored.EndDate)
+}
+
+func (s *SubscriptionChangeV2Suite) createEntitlementGrant(
+	sub *subscription.Subscription,
+	configID, featureID string,
+	validFrom, validTo time.Time,
+) *entitlementgrant.EntitlementGrant {
+	ctx := s.GetContext()
+	g := &entitlementgrant.EntitlementGrant{
+		ID:                  types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENTITLEMENT_GRANT),
+		EntitlementConfigID: configID,
+		CustomerID:          sub.CustomerID,
+		SubscriptionID:      sub.ID,
+		ScopeEntityType:     types.EntitlementGrantScopeFeature,
+		ScopeEntityID:       featureID,
+		Measure:             types.EntitlementGrantMeasureQuantity,
+		Quota:               decimal.NewFromInt(1000),
+		Usage:               decimal.Zero,
+		ValidFrom:           validFrom,
+		ValidTo:             validTo,
+		GrantStatus:         types.EntitlementGrantStatusActive,
+		EnvironmentID:       types.GetEnvironmentID(ctx),
+		BaseModel:           types.GetDefaultBaseModel(ctx),
+	}
+	_, err := s.GetStores().EntitlementGrantRepo.Create(ctx, g)
+	s.Require().NoError(err)
+	return g
+}
+
+func (s *SubscriptionChangeV2Suite) storedGrant(id string) *entitlementgrant.EntitlementGrant {
+	g, err := s.GetStores().EntitlementGrantRepo.Get(s.GetContext(), id)
+	s.Require().NoError(err)
+	return g
+}
+
+// A window left open keeps granting the outgoing plan's quota after the swap, and billing
+// reads its overage as [quota_crossed_at, valid_to] — so it would charge overage on the old
+// plan's terms for time already spent on the new one.
+func (s *SubscriptionChangeV2Suite) TestExecute_ClosesEntitlementGrantsFromTheOutgoingPlan() {
+	ctx := s.GetContext()
+
+	f := s.createFeature("api_calls")
+	starterEnt := s.createPlanEntitlement(s.td.starter.ID, f.ID, 1000)
+	proEnt := s.createPlanEntitlement(s.td.pro.ID, f.ID, 5000)
+
+	closing := s.createEntitlementGrant(s.td.sub, starterEnt.ID, f.ID, s.td.periodStart, s.td.periodEnd)
+	surviving := s.createEntitlementGrant(s.td.sub, proEnt.ID, f.ID, s.td.periodStart, s.td.periodEnd)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	closed := s.storedGrant(closing.ID)
+	s.True(closed.ValidTo.Equal(resp.EffectiveAt), "the outgoing plan's window ends at the swap")
+	s.True(closed.ValidFrom.Equal(s.td.periodStart), "closing must not move the window start")
+
+	untouched := s.storedGrant(surviving.ID)
+	s.True(untouched.ValidTo.Equal(s.td.periodEnd), "a window on the target plan's config is not ours to close")
+
+	reported := lo.Filter(resp.EntityChanges, func(c *dto.EntityChangeResult, _ int) bool {
+		return c.EntityType == types.SubscriptionChangeEntityTypeEntitlementGrant
+	})
+	s.Require().Len(reported, 1)
+	s.Equal(closing.ID, reported[0].ReferenceID)
+	s.Equal(f.ID, reported[0].EntityID)
+	s.Equal(types.EntityChangeBehaviourDrop, reported[0].Behaviour)
+}
+
+// Grants key off whichever entitlement the subscription actually resolves to, so an
+// overridden feature's window carries the override's id rather than the plan entitlement's.
+func (s *SubscriptionChangeV2Suite) TestExecute_ClosesGrantsKeyedByAClosingOverride() {
+	ctx := s.GetContext()
+
+	f := s.createFeature("api_calls")
+	starterEnt := s.createPlanEntitlement(s.td.starter.ID, f.ID, 1000)
+	override := s.createSubscriptionOverride(starterEnt, 2000)
+	grant := s.createEntitlementGrant(s.td.sub, override.ID, f.ID, s.td.periodStart, s.td.periodEnd)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.True(s.storedGrant(grant.ID).ValidTo.Equal(resp.EffectiveAt))
+}
+
+// Grant windows are per subscription, and so is the close.
+func (s *SubscriptionChangeV2Suite) TestExecute_LeavesAnotherSubscriptionsGrantsAlone() {
+	ctx := s.GetContext()
+
+	f := s.createFeature("api_calls")
+	starterEnt := s.createPlanEntitlement(s.td.starter.ID, f.ID, 1000)
+
+	other := s.createSubscription(s.td.starter.ID)
+	otherGrant := s.createEntitlementGrant(other, starterEnt.ID, f.ID, s.td.periodStart, s.td.periodEnd)
+	otherOverride := s.createSubscriptionOverrideFor(other, starterEnt, 2000)
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.True(s.storedGrant(otherGrant.ID).ValidTo.Equal(s.td.periodEnd),
+		"another subscription on the same outgoing plan keeps its window")
+
+	stored, err := s.GetStores().EntitlementRepo.Get(ctx, otherOverride.ID)
+	s.Require().NoError(err)
+	s.Nil(stored.EndDate, "and keeps its override")
+}
+
+// A window that already ended before the change has nothing left to close.
+func (s *SubscriptionChangeV2Suite) TestExecute_IgnoresAlreadyClosedGrantWindows() {
+	ctx := s.GetContext()
+
+	f := s.createFeature("api_calls")
+	starterEnt := s.createPlanEntitlement(s.td.starter.ID, f.ID, 1000)
+	expiredAt := s.td.periodStart.AddDate(0, 0, 1)
+	expired := s.createEntitlementGrant(s.td.sub, starterEnt.ID, f.ID, s.td.periodStart, expiredAt)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	s.True(s.storedGrant(expired.ID).ValidTo.Equal(expiredAt))
+	s.Empty(lo.Filter(resp.EntityChanges, func(c *dto.EntityChangeResult, _ int) bool {
+		return c.EntityType == types.SubscriptionChangeEntityTypeEntitlementGrant
+	}))
+}
+
+func (s *SubscriptionChangeV2Suite) TestPreview_ReportsGrantClosureWithoutWriting() {
+	ctx := s.GetContext()
+
+	f := s.createFeature("api_calls")
+	starterEnt := s.createPlanEntitlement(s.td.starter.ID, f.ID, 1000)
+	grant := s.createEntitlementGrant(s.td.sub, starterEnt.ID, f.ID, s.td.periodStart, s.td.periodEnd)
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone))
+	s.Require().NoError(err)
+
+	reported := lo.Filter(preview.EntityChanges, func(c *dto.EntityChangeResult, _ int) bool {
+		return c.EntityType == types.SubscriptionChangeEntityTypeEntitlementGrant
+	})
+	s.Require().Len(reported, 1)
+	s.Equal(grant.ID, reported[0].ReferenceID)
+
+	s.True(s.storedGrant(grant.ID).ValidTo.Equal(s.td.periodEnd), "preview closed nothing")
 }

--- a/internal/ee/service/subscription_change_v2_internal_test.go
+++ b/internal/ee/service/subscription_change_v2_internal_test.go
@@ -61,7 +61,7 @@ func TestPlanChangeType_CountsQuantity(t *testing.T) {
 
 func planChangeKeyRequest(sub *subscription.Subscription, clientKey string) *planChangeRequest {
 	return &planChangeRequest{
-		sub:            sub,
+		currentSub:     sub,
 		toPlan:         &plan.Plan{ID: "plan_pro"},
 		effectiveAt:    time.Now().UTC(),
 		idempotencyKey: clientKey,
@@ -76,28 +76,33 @@ func TestPlanChangeIdempotencyKey(t *testing.T) {
 	sub := &subscription.Subscription{ID: "subs_1", Version: 3}
 	sub.UpdatedAt = readAt
 
-	first := planChangeIdempotencyKey(planChangeKeyRequest(sub, ""))
+	first := planChangeIdempotencyKey(planChangeKeyRequest(sub, ""), "")
 	require.NotEmpty(t, first)
 
 	t.Run("stable across retries of the same attempt", func(t *testing.T) {
 		retry := planChangeKeyRequest(sub, "")
 		retry.effectiveAt = retry.effectiveAt.Add(time.Minute) // a later wall clock
-		assert.Equal(t, first, planChangeIdempotencyKey(retry))
+		assert.Equal(t, first, planChangeIdempotencyKey(retry, ""))
 	})
 
 	t.Run("moves once the subscription has been written", func(t *testing.T) {
 		changed := *sub
 		changed.UpdatedAt = readAt.Add(time.Hour)
-		assert.NotEqual(t, first, planChangeIdempotencyKey(planChangeKeyRequest(&changed, "")))
+		assert.NotEqual(t, first, planChangeIdempotencyKey(planChangeKeyRequest(&changed, ""), ""))
+	})
+
+	t.Run("each document a change raises gets its own key", func(t *testing.T) {
+		// Two documents sharing a key would make the second fail as already-existing.
+		assert.NotEqual(t, first, planChangeIdempotencyKey(planChangeKeyRequest(sub, ""), "outgoing_usage"))
 	})
 
 	t.Run("a client key replaces the derived one", func(t *testing.T) {
-		withKey := planChangeIdempotencyKey(planChangeKeyRequest(sub, "caller-supplied"))
+		withKey := planChangeIdempotencyKey(planChangeKeyRequest(sub, "caller-supplied"), "")
 		assert.NotEqual(t, first, withKey)
 
 		later := *sub
 		later.UpdatedAt = readAt.Add(time.Hour)
-		assert.Equal(t, withKey, planChangeIdempotencyKey(planChangeKeyRequest(&later, "caller-supplied")),
+		assert.Equal(t, withKey, planChangeIdempotencyKey(planChangeKeyRequest(&later, "caller-supplied"), ""),
 			"the caller's key is the whole identity of the attempt")
 	})
 }

--- a/internal/ee/service/subscription_change_v2_internal_test.go
+++ b/internal/ee/service/subscription_change_v2_internal_test.go
@@ -53,7 +53,7 @@ func TestPlanChangeType_CountsQuantity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := planChangeType(&planChangeRequest{closing: tt.closing, opening: tt.opening})
+			got := planChangeType(&planChangeRequest{closingLineItems: tt.closing, openingLineItems: tt.opening})
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/ee/service/subscription_change_v2_parity_test.go
+++ b/internal/ee/service/subscription_change_v2_parity_test.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+// planChangeFingerprint is everything a caller decides on: what kind of change this is,
+// what money moves and in which direction, which lines move, what else the change
+// touches, and what it warns about. Ids and timestamps are deliberately absent — preview
+// mints none of them, so they are the one thing that must differ.
+type planChangeFingerprint struct {
+	ChangeType    types.SubscriptionChangeType
+	IsScheduled   bool
+	Documents     []string
+	LineItems     []string
+	EntityChanges []string
+	Warnings      []string
+}
+
+func fingerprintPlanChange(resp *dto.SubscriptionChangeV2Response) planChangeFingerprint {
+	fp := planChangeFingerprint{
+		ChangeType:    resp.ChangeType,
+		IsScheduled:   resp.IsScheduled,
+		Documents:     []string{},
+		LineItems:     []string{},
+		EntityChanges: []string{},
+		Warnings:      append([]string{}, resp.Warnings...),
+	}
+
+	for _, doc := range resp.ChangedResources.Invoices {
+		amount := decimal.Zero
+		switch {
+		case doc.Invoice != nil:
+			amount = doc.Invoice.AmountDue
+		case doc.WalletTransaction != nil:
+			amount = doc.WalletTransaction.Amount
+		}
+		fp.Documents = append(fp.Documents, fmt.Sprintf("%s:%s", doc.Action, amount.String()))
+	}
+	for _, li := range resp.ChangedResources.LineItems {
+		fp.LineItems = append(fp.LineItems, string(li.ChangeAction))
+	}
+	for _, c := range resp.EntityChanges {
+		fp.EntityChanges = append(fp.EntityChanges, fmt.Sprintf("%s:%s", c.EntityType, c.Behaviour))
+	}
+
+	for _, list := range [][]string{fp.Documents, fp.LineItems, fp.EntityChanges, fp.Warnings} {
+		sort.Strings(list)
+	}
+	return fp
+}
+
+// paritySubscription is a subscription on the outgoing plan with the plan's grants
+// already materialised, so a change has both line items and entity changes to report.
+func (s *SubscriptionChangeV2Suite) paritySubscription() *subscription.Subscription {
+	sub := s.createSubscription(s.td.starter.ID)
+	s.createLineItem(sub, s.td.starterBase, s.td.starter)
+	s.materialisePlanGrantsFor(sub, s.td.starter.ID)
+	return sub
+}
+
+func deferred(req dto.SubscriptionChangeV2Request) dto.SubscriptionChangeV2Request {
+	req.ChangeAt = lo.ToPtr(types.ScheduleTypePeriodEnd)
+	return req
+}
+
+// Preview is the quote the caller commits to. Individual tests below check single
+// fields on single scenarios; this one holds the whole answer to account across every
+// shape of change, so a field that starts diverging cannot hide behind the others.
+func (s *SubscriptionChangeV2Suite) TestPreviewMatchesExecute_AcrossScenarios() {
+	ctx := s.GetContext()
+
+	cheap := s.createPlan("Cheap", "cheap_parity")
+	s.createFixedPrice(cheap.ID, "base_fee", 5)
+	lateral := s.createPlan("Lateral", "lateral_parity")
+	s.createFixedPrice(lateral.ID, "base_fee", 20)
+
+	s.createPlanGrant(s.td.starter.ID, "starter credits", 100)
+	s.createPlanGrant(s.td.pro.ID, "pro credits", 500)
+
+	unknownAddon := s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)
+	unknownAddon.EntityPolicies = &dto.SubscriptionChangeEntityPolicies{
+		Addons: &dto.EntityChangePolicy{
+			Overrides: map[string]types.EntityChangeBehaviour{
+				"subsaddon_not_attached": types.EntityChangeBehaviourDrop,
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		req  dto.SubscriptionChangeV2Request
+	}{
+		{"upgrade with prorations", s.changeRequest(s.td.pro.ID, types.ProrationBehaviorCreateProrations)},
+		{"downgrade with prorations", s.changeRequest(cheap.ID, types.ProrationBehaviorCreateProrations)},
+		{"lateral move", s.changeRequest(lateral.ID, types.ProrationBehaviorCreateProrations)},
+		{"proration none", s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)},
+		{"anchor reset crediting the remainder", s.resetRequest(s.td.pro.ID)},
+		{"anchor reset forfeiting the remainder", s.forfeitResetRequest(s.td.pro.ID)},
+		{"anchor reset on a downgrade", s.resetRequest(cheap.ID)},
+		{"deferred change", deferred(s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone))},
+		{"deferred change with a reset", deferred(s.forfeitResetRequest(s.td.pro.ID))},
+		{"warns about an addon that is not attached", unknownAddon},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			sub := s.paritySubscription()
+
+			preview, err := s.svc.PreviewPlanChange(ctx, sub.ID, tt.req)
+			s.Require().NoError(err)
+
+			executed, err := s.svc.ExecutePlanChange(ctx, sub.ID, tt.req, time.Now().UTC())
+			s.Require().NoError(err)
+
+			quoted := fingerprintPlanChange(preview)
+			// Equality is worthless if both sides are empty, and a fingerprint that
+			// silently stopped reading a field would be exactly that.
+			s.Require().NotEmpty(quoted.ChangeType)
+			s.Require().NotEmpty(quoted.LineItems)
+			s.Require().NotEmpty(quoted.EntityChanges)
+
+			s.Equal(quoted, fingerprintPlanChange(executed))
+		})
+	}
+}
+
+// The unknown-association warning is raised while resolving the change, which both
+// entry points share — but only execute asserted it, so a preview that dropped its
+// warnings would have gone unnoticed.
+func (s *SubscriptionChangeV2Suite) TestPreview_CarriesTheSameWarningsAsExecute() {
+	ctx := s.GetContext()
+
+	req := s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)
+	req.EntityPolicies = &dto.SubscriptionChangeEntityPolicies{
+		Addons: &dto.EntityChangePolicy{
+			Overrides: map[string]types.EntityChangeBehaviour{
+				"subsaddon_not_attached": types.EntityChangeBehaviourDrop,
+			},
+		},
+	}
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, req)
+	s.Require().NoError(err)
+	s.Require().Len(preview.Warnings, 1)
+	s.Contains(preview.Warnings[0], "subsaddon_not_attached")
+
+	executed, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
+	s.Require().NoError(err)
+	s.Equal(preview.Warnings, executed.Warnings)
+}
+
+// usageAndSettlement splits a response's documents by whether they carry the usage
+// price, which is the whole point of raising two: usage is billed for the window that
+// just ended, the plan-change net is settled on its own document.
+func (s *SubscriptionChangeV2Suite) usageAndSettlement(
+	resp *dto.SubscriptionChangeV2Response,
+	usagePriceID string,
+) (usage, settlement *dto.InvoiceResponse) {
+	for _, changed := range resp.ChangedResources.Invoices {
+		if changed.Invoice == nil {
+			continue
+		}
+		if lo.SomeBy(changed.Invoice.LineItems, func(li *dto.InvoiceLineItemResponse) bool {
+			return lo.FromPtr(li.PriceID) == usagePriceID
+		}) {
+			usage = changed.Invoice
+			continue
+		}
+		settlement = changed.Invoice
+	}
+	return usage, settlement
+}
+
+// Execute raises two documents under a reset with usage. The quote has to show both:
+// a caller shown only the settlement would under-read the bill by the usage total.
+func (s *SubscriptionChangeV2Suite) TestPreview_ResetQuotesUsageAndSettlementSeparately() {
+	ctx := s.GetContext()
+
+	usagePrice := s.seedOutgoingUsage(40, 2)
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID))
+	s.Require().NoError(err)
+	s.Require().Len(preview.ChangedResources.Invoices, 2, "a reset with usage quotes two documents")
+
+	quotedUsage, quotedNet := s.usageAndSettlement(preview, usagePrice.ID)
+	s.Require().NotNil(quotedUsage, "the outgoing window's usage must be quoted")
+	s.Require().NotNil(quotedNet, "the plan-change net must be quoted separately")
+	s.Equal("80", quotedUsage.AmountDue.String(), "40 units at 2")
+	s.False(lo.SomeBy(quotedNet.LineItems, func(li *dto.InvoiceLineItemResponse) bool {
+		return lo.FromPtr(li.PriceID) == usagePrice.ID
+	}), "the quote must not count usage twice either")
+
+	executed, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+	s.Require().Len(executed.ChangedResources.Invoices, 2)
+
+	raisedUsage, raisedNet := s.usageAndSettlement(executed, usagePrice.ID)
+	s.Require().NotNil(raisedUsage)
+	s.Require().NotNil(raisedNet)
+	s.Equal(quotedUsage.AmountDue.String(), raisedUsage.AmountDue.String(), "usage quoted vs raised")
+	s.Equal(quotedNet.AmountDue.String(), raisedNet.AmountDue.String(), "settlement quoted vs raised")
+}

--- a/internal/ee/service/subscription_change_v2_reset_test.go
+++ b/internal/ee/service/subscription_change_v2_reset_test.go
@@ -1,0 +1,569 @@
+package service
+
+import (
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/domain/meter"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+func (s *SubscriptionChangeV2Suite) resetRequest(targetPlanID string) dto.SubscriptionChangeV2Request {
+	req := s.changeRequest(targetPlanID, types.ProrationBehaviorNone)
+	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+	return req
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3.1 Validation matrix
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidationMatrix() {
+	ctx := s.GetContext()
+
+	tests := []struct {
+		name    string
+		mutate  func(*dto.SubscriptionChangeV2Request)
+		wantErr string
+	}{
+		{
+			name:   "omitted behaves as unchanged",
+			mutate: func(_ *dto.SubscriptionChangeV2Request) {},
+		},
+		{
+			name: "explicit unchanged is accepted",
+			mutate: func(r *dto.SubscriptionChangeV2Request) {
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourUnchanged
+			},
+		},
+		{
+			name: "reset_at_effective on an immediate change is accepted",
+			mutate: func(r *dto.SubscriptionChangeV2Request) {
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+			},
+		},
+		{
+			name: "reset_at_effective with prorations is rejected",
+			mutate: func(r *dto.SubscriptionChangeV2Request) {
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+				r.ProrationBehavior = types.ProrationBehaviorCreateProrations
+			},
+			wantErr: "proration is not applicable when the billing period is reset",
+		},
+		{
+			name: "reset_at is rejected rather than inferred",
+			mutate: func(r *dto.SubscriptionChangeV2Request) {
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAt
+			},
+			wantErr: "'reset_at' is not supported yet",
+		},
+		{
+			name: "billing_period is reserved",
+			mutate: func(r *dto.SubscriptionChangeV2Request) {
+				r.BillingPeriodConfig = &dto.SubscriptionChangeBillingPeriod{
+					BillingPeriodCount: lo.ToPtr(3),
+				}
+			},
+			wantErr: "billing_period is not supported yet",
+		},
+		{
+			name: "billing_period is reserved even alongside a supported behaviour",
+			mutate: func(r *dto.SubscriptionChangeV2Request) {
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+				r.BillingPeriodConfig = &dto.SubscriptionChangeBillingPeriod{}
+			},
+			wantErr: "billing_period is not supported yet",
+		},
+		{
+			name: "an unknown behaviour is rejected",
+			mutate: func(r *dto.SubscriptionChangeV2Request) {
+				r.BillingPeriodBehaviour = "reset_next_period"
+			},
+			wantErr: "invalid billing_period_behaviour",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.SetupTest()
+
+			req := s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)
+			tt.mutate(&req)
+
+			_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
+			if tt.wantErr == "" {
+				s.Require().NoError(err)
+				return
+			}
+
+			s.Require().Error(err)
+			s.True(ierr.IsValidation(err))
+			s.Contains(err.Error(), tt.wantErr)
+			s.Equal(s.td.starter.ID, s.currentSub().PlanID, "a rejected request changes nothing")
+		})
+	}
+}
+
+// Resetting to an arbitrary instant contradicts calendar alignment.
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetRejectedOnCalendarBilling() {
+	ctx := s.GetContext()
+
+	sub := s.currentSub()
+	sub.BillingCycle = types.BillingCycleCalendar
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	_, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().Error(err)
+	s.True(ierr.IsValidation(err))
+	s.Contains(err.Error(), "calendar")
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3.4 Re-anchor
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetMovesTheAnchorToTheChangeInstant() {
+	ctx := s.GetContext()
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	at := resp.EffectiveAt
+	sub := s.currentSub()
+
+	s.True(sub.BillingAnchor.Equal(at), "the anchor moves to the change instant")
+	s.True(sub.CurrentPeriodStart.Equal(at), "the term restarts")
+
+	expectedEnd, err := types.NextBillingDate(&types.NextBillingDateParams{
+		CurrentPeriodStart: at,
+		BillingAnchor:      at,
+		Unit:               sub.BillingPeriodCount,
+		Period:             sub.BillingPeriod,
+		Timezone:           sub.Timezone,
+	})
+	s.Require().NoError(err)
+	s.True(sub.CurrentPeriodEnd.Equal(expectedEnd), "the new period is a full period, never a stub")
+	s.False(sub.CurrentPeriodEnd.Equal(s.td.periodEnd), "the old boundary is gone")
+
+	s.Equal(types.BillingPeriodBehaviourResetAtEffect, resp.BillingPeriod.Behaviour)
+	s.True(resp.BillingPeriod.BillingAnchor.Equal(at))
+	s.True(resp.BillingPeriod.CurrentPeriodStart.Equal(at))
+	s.True(resp.BillingPeriod.CurrentPeriodEnd.Equal(expectedEnd))
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecute_UnchangedLeavesTheAnchorAlone() {
+	ctx := s.GetContext()
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID,
+		s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone), time.Now().UTC())
+	s.Require().NoError(err)
+
+	sub := s.currentSub()
+	s.True(sub.BillingAnchor.Equal(s.td.periodStart))
+	s.True(sub.CurrentPeriodStart.Equal(s.td.periodStart))
+	s.True(sub.CurrentPeriodEnd.Equal(s.td.periodEnd))
+	s.Equal(types.BillingPeriodBehaviourUnchanged, resp.BillingPeriod.Behaviour)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3.2 The deferred path is a genuine no-op
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *SubscriptionChangeV2Suite) TestExecute_DeferredResetIsANoOp() {
+	ctx := s.GetContext()
+
+	req := s.deferredRequest(s.td.pro.ID)
+	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
+	s.Require().NoError(err)
+	s.True(resp.IsScheduled)
+
+	sub := s.currentSub()
+	s.True(sub.BillingAnchor.Equal(s.td.periodStart), "scheduling moves nothing")
+	s.True(sub.CurrentPeriodEnd.Equal(s.td.periodEnd))
+
+	sched := s.pendingPlanChange()
+	s.Require().NotNil(sched)
+	config, err := sched.GetPlanChangeV2Config()
+	s.Require().NoError(err)
+	s.Equal(types.BillingPeriodBehaviourResetAtEffect, config.BillingPeriodBehaviour,
+		"the behaviour round-trips through the schedule blob")
+}
+
+// A month-end anchor must not drift when a deferred reset executes: assigning
+// anchor = effective_at at a rolled Feb-28 boundary would move a Jan-31 chain to the 28th.
+func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_DeferredResetKeepsMonthEndAnchor() {
+	ctx := s.GetContext()
+
+	jan31 := time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC)
+	feb28 := time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC)
+
+	sub := s.currentSub()
+	sub.StartDate = jan31
+	sub.BillingAnchor = jan31
+	sub.CurrentPeriodStart = jan31
+	sub.CurrentPeriodEnd = feb28
+	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
+
+	sched, config := s.createV2Schedule(s.td.pro.ID, feb28)
+	config.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+	s.rollPeriodTo(feb28, time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC))
+
+	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()))
+
+	after := s.currentSub()
+	s.True(after.BillingAnchor.Equal(jan31),
+		"a deferred reset must leave the month-end anchor exactly where it was, got %s", after.BillingAnchor)
+	s.True(after.CurrentPeriodEnd.Equal(time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC)),
+		"the chain stays on the 31st rather than drifting to the 28th")
+	s.Equal(s.td.pro.ID, after.PlanID)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3.5 Settlement
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *SubscriptionChangeV2Suite) resetInvoice(resp *dto.SubscriptionChangeV2Response) *dto.InvoiceResponse {
+	for _, changed := range resp.ChangedResources.Invoices {
+		if changed.Invoice != nil {
+			return changed.Invoice
+		}
+	}
+	return nil
+}
+
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetNetsTheOldCreditAgainstTheNewFullPeriod() {
+	ctx := s.GetContext()
+
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	inv := s.resetInvoice(resp)
+	s.Require().NotNil(inv, "an upgrade nets to a charge, so the settlement is an invoice")
+
+	var charges, credits decimal.Decimal
+	var sawProCharge, sawStarterCredit bool
+	for _, li := range inv.LineItems {
+		if li.Amount.IsNegative() {
+			credits = credits.Add(li.Amount.Abs())
+			if lo.FromPtr(li.PriceID) == s.td.starterBase.ID {
+				sawStarterCredit = true
+			}
+			continue
+		}
+		charges = charges.Add(li.Amount)
+		if lo.FromPtr(li.PriceID) == s.td.proBase.ID {
+			sawProCharge = true
+		}
+	}
+
+	s.True(sawProCharge, "the new plan is billed for its first full period")
+	s.True(sawStarterCredit, "the unused portion of the outgoing plan is credited")
+
+	s.Equal(s.td.proBase.Amount.String(), charges.String(),
+		"the new plan is charged a full period, and the outgoing plan is never re-charged")
+	s.True(credits.LessThan(charges), "the credit is netted, not stacked")
+	s.Equal(charges.Sub(credits).String(), inv.AmountDue.String())
+}
+
+// The old plan's fixed fee must never be both credited and re-charged.
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetDoesNotRebillTheOutgoingPlan() {
+	ctx := s.GetContext()
+
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	inv := s.resetInvoice(resp)
+	s.Require().NotNil(inv)
+
+	for _, li := range inv.LineItems {
+		if lo.FromPtr(li.PriceID) == s.td.starterBase.ID {
+			s.True(li.Amount.IsNegative(),
+				"the outgoing plan may only appear as a credit, never as a charge")
+		}
+	}
+}
+
+// A downgrade can credit more than the new plan costs; the excess must reach the wallet.
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetRoutesExcessCreditToTheWallet() {
+	ctx := s.GetContext()
+
+	cheap := s.createPlan("Cheap", "cheap")
+	s.createFixedPrice(cheap.ID, "base_fee", 1)
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(cheap.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	var walletCredit *dto.ChangedInvoice
+	for i := range resp.ChangedResources.Invoices {
+		if resp.ChangedResources.Invoices[i].Action == dto.ChangedInvoiceActionWalletCredit {
+			walletCredit = &resp.ChangedResources.Invoices[i]
+		}
+	}
+
+	s.Require().NotNil(walletCredit, "credit beyond the new plan's charge must not be discarded")
+	s.Require().NotNil(walletCredit.WalletTransaction)
+	s.True(walletCredit.WalletTransaction.Amount.IsPositive())
+}
+
+// A carried line — same price on both plans — is paid for through the old period end,
+// but the reset hands the customer a fresh full period starting now. The overlap must be
+// credited back and re-charged, or they get it free.
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetRebillsCarriedItemsForTheRestartedPeriod() {
+	ctx := s.GetContext()
+
+	lateral := s.createPlan("Lateral", "lateral")
+	lateralBase := s.createFixedPrice(lateral.ID, "base_fee", 20)
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(lateral.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	live := s.liveLineItems()
+	s.Require().Len(live, 1)
+	s.Equal(s.td.baseLine.ID, live[0].ID, "the line is still carried, not replaced")
+
+	inv := s.resetInvoice(resp)
+	s.Require().NotNil(inv, "a carried line still owes the overlap once the term restarts")
+
+	var charges, credits decimal.Decimal
+	for _, li := range inv.LineItems {
+		if li.Amount.IsNegative() {
+			credits = credits.Add(li.Amount.Abs())
+			continue
+		}
+		charges = charges.Add(li.Amount)
+	}
+
+	s.Equal(lateralBase.Amount.String(), charges.String(), "a full period on the new term")
+	s.True(credits.IsPositive(), "and the unused remainder of the old one credited back")
+	s.True(charges.GreaterThan(credits),
+		"the customer owes the overlap they had already paid for but no longer get")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3.6 Preview parity
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *SubscriptionChangeV2Suite) TestPreview_ResetQuotesTheCloseOutInvoice() {
+	ctx := s.GetContext()
+
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID))
+	s.Require().NoError(err)
+
+	quoted := s.resetInvoice(preview)
+	s.Require().NotNil(quoted, "a reset preview must quote the close-out invoice, not the ordinary delta")
+
+	var sawProCharge bool
+	for _, li := range quoted.LineItems {
+		if lo.FromPtr(li.PriceID) == s.td.proBase.ID && li.Amount.IsPositive() {
+			sawProCharge = true
+		}
+	}
+	s.True(sawProCharge, "the preview prices the target plan, not the outgoing one")
+
+	s.Equal(s.td.starter.ID, s.currentSub().PlanID, "preview writes nothing")
+	s.True(s.currentSub().BillingAnchor.Equal(s.td.periodStart), "preview does not re-anchor")
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	raised := s.resetInvoice(resp)
+	s.Require().NotNil(raised)
+	s.Equal(quoted.AmountDue.String(), raised.AmountDue.String(),
+		"the quote and the invoice must agree")
+}
+
+// Preview reports where the anchor would land, not where it stands, so a caller can see
+// the term restart before committing to it.
+func (s *SubscriptionChangeV2Suite) TestPreview_ResetEchoesTheProjectedAnchor() {
+	ctx := s.GetContext()
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID))
+	s.Require().NoError(err)
+
+	s.Equal(types.BillingPeriodBehaviourResetAtEffect, preview.BillingPeriod.Behaviour)
+	s.True(preview.BillingPeriod.BillingAnchor.Equal(preview.EffectiveAt),
+		"the projected anchor is the change instant")
+	s.True(preview.BillingPeriod.CurrentPeriodStart.Equal(preview.EffectiveAt))
+	s.False(preview.BillingPeriod.CurrentPeriodEnd.Equal(s.td.periodEnd),
+		"and the projected period is the restarted one, not the interrupted one")
+
+	s.True(s.currentSub().BillingAnchor.Equal(s.td.periodStart), "preview still writes nothing")
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+	s.Equal(preview.BillingPeriod.Behaviour, resp.BillingPeriod.Behaviour)
+}
+
+// A deferred reset is a no-op, and preview must say so rather than projecting a move.
+func (s *SubscriptionChangeV2Suite) TestPreview_DeferredResetEchoesAnUnmovedAnchor() {
+	ctx := s.GetContext()
+
+	req := s.deferredRequest(s.td.pro.ID)
+	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, req)
+	s.Require().NoError(err)
+
+	s.True(preview.BillingPeriod.BillingAnchor.Equal(s.td.periodStart))
+	s.True(preview.BillingPeriod.CurrentPeriodEnd.Equal(s.td.periodEnd))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The outgoing window's usage
+// ─────────────────────────────────────────────────────────────────────────────
+
+// seedOutgoingUsage puts a usage price on the outgoing plan and records consumption
+// inside the period the reset will cut short.
+func (s *SubscriptionChangeV2Suite) seedOutgoingUsage(units int64, rate int64) *price.Price {
+	ctx := s.GetContext()
+
+	m := &meter.Meter{
+		ID:          "meter_reset_api_calls",
+		Name:        "API Calls",
+		EventName:   "api_call",
+		Aggregation: meter.Aggregation{Type: types.AggregationSum, Field: "units"},
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().MeterRepo.CreateMeter(ctx, m))
+
+	usagePrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(rate),
+		Currency:           "usd",
+		Type:               types.PRICE_TYPE_USAGE,
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.td.starter.ID,
+		MeterID:            m.ID,
+		LookupKey:          "api_calls",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, usagePrice))
+
+	item := &subscription.SubscriptionLineItem{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		SubscriptionID:     s.td.sub.ID,
+		CustomerID:         s.td.sub.CustomerID,
+		EntityID:           s.td.starter.ID,
+		EntityType:         types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName:    s.td.starter.Name,
+		PriceID:            usagePrice.ID,
+		PriceType:          types.PRICE_TYPE_USAGE,
+		MeterID:            m.ID,
+		DisplayName:        "API Calls",
+		Quantity:           decimal.Zero,
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		StartDate:          s.td.periodStart,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, item))
+
+	s.Require().NoError(s.GetStores().MeterUsageRepo.BulkInsertMeterUsage(ctx, []*events.MeterUsage{{
+		Event: events.Event{
+			ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_EVENT),
+			TenantID:           types.GetTenantID(ctx),
+			EnvironmentID:      types.GetEnvironmentID(ctx),
+			ExternalCustomerID: s.td.customer.ExternalID,
+			CustomerID:         s.td.customer.ID,
+			EventName:          m.EventName,
+			Timestamp:          s.td.periodStart.AddDate(0, 0, 1),
+		},
+		MeterID:  m.ID,
+		QtyTotal: decimal.NewFromInt(units),
+	}}))
+
+	return usagePrice
+}
+
+// The outgoing period never reaches its boundary, and the next roll's window starts at
+// the change instant — so if the reset does not bill this usage, nobody ever will.
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetInvoicesTheOutgoingWindowsUsageSeparately() {
+	ctx := s.GetContext()
+
+	usagePrice := s.seedOutgoingUsage(40, 2)
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	var usageInvoice, netInvoice *dto.InvoiceResponse
+	for _, changed := range resp.ChangedResources.Invoices {
+		if changed.Invoice == nil {
+			continue
+		}
+		if lo.SomeBy(changed.Invoice.LineItems, func(li *dto.InvoiceLineItemResponse) bool {
+			return lo.FromPtr(li.PriceID) == usagePrice.ID
+		}) {
+			usageInvoice = changed.Invoice
+			continue
+		}
+		netInvoice = changed.Invoice
+	}
+
+	s.Require().NotNil(usageInvoice, "the outgoing window's usage must be invoiced at the change")
+	s.Equal("80", usageInvoice.AmountDue.String(), "40 units at 2")
+
+	for _, li := range usageInvoice.LineItems {
+		s.Equal(usagePrice.ID, lo.FromPtr(li.PriceID),
+			"the usage invoice carries usage only — arrear fixed charges misprice over a short window")
+	}
+
+	s.Require().NotNil(netInvoice, "the plan-change net is settled separately")
+	s.False(lo.SomeBy(netInvoice.LineItems, func(li *dto.InvoiceLineItemResponse) bool {
+		return lo.FromPtr(li.PriceID) == usagePrice.ID
+	}), "usage must not be counted twice")
+}
+
+// With usage kept separate, a net-negative downgrade still leaves a revenue record for
+// what was consumed instead of folding it into a wallet credit.
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetInvoicesUsageEvenWhenTheNetIsACredit() {
+	ctx := s.GetContext()
+
+	usagePrice := s.seedOutgoingUsage(1, 1)
+	cheap := s.createPlan("Cheap", "cheap")
+	s.createFixedPrice(cheap.ID, "base_fee", 1)
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(cheap.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	var sawUsageInvoice, sawWalletCredit bool
+	for _, changed := range resp.ChangedResources.Invoices {
+		if changed.Action == dto.ChangedInvoiceActionWalletCredit {
+			sawWalletCredit = true
+			continue
+		}
+		if changed.Invoice != nil && lo.SomeBy(changed.Invoice.LineItems, func(li *dto.InvoiceLineItemResponse) bool {
+			return lo.FromPtr(li.PriceID) == usagePrice.ID
+		}) {
+			sawUsageInvoice = true
+		}
+	}
+
+	s.True(sawUsageInvoice, "consumed usage is invoiced regardless of which way the net falls")
+	s.True(sawWalletCredit, "and the net credit still reaches the wallet")
+}

--- a/internal/ee/service/subscription_change_v2_reset_test.go
+++ b/internal/ee/service/subscription_change_v2_reset_test.go
@@ -43,13 +43,13 @@ func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidation
 			},
 		},
 		{
-			name: "reset_at_effective on an immediate change is accepted",
+			name: "reset_at_effect on an immediate change is accepted",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
 				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
 			},
 		},
 		{
-			name: "reset_at_effective with prorations is rejected",
+			name: "reset_at_effect with prorations is rejected",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
 				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
 				r.ProrationBehavior = types.ProrationBehaviorCreateProrations
@@ -66,19 +66,19 @@ func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidation
 		{
 			name: "billing_period is reserved",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
-				r.BillingPeriodConfig = &dto.SubscriptionChangeBillingPeriod{
+				r.BillingPeriodConfig = &dto.BillingPeriodConfig{
 					BillingPeriodCount: lo.ToPtr(3),
 				}
 			},
-			wantErr: "billing_period is not supported yet",
+			wantErr: "billing_period_config is not supported yet",
 		},
 		{
 			name: "billing_period is reserved even alongside a supported behaviour",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
 				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
-				r.BillingPeriodConfig = &dto.SubscriptionChangeBillingPeriod{}
+				r.BillingPeriodConfig = &dto.BillingPeriodConfig{}
 			},
-			wantErr: "billing_period is not supported yet",
+			wantErr: "billing_period_config is not supported yet",
 		},
 		{
 			name: "an unknown behaviour is rejected",

--- a/internal/ee/service/subscription_change_v2_reset_test.go
+++ b/internal/ee/service/subscription_change_v2_reset_test.go
@@ -14,7 +14,17 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// resetRequest restarts the term and credits the unused remainder of the outgoing
+// plan. See forfeitResetRequest for the variant that keeps the remainder.
 func (s *SubscriptionChangeV2Suite) resetRequest(targetPlanID string) dto.SubscriptionChangeV2Request {
+	req := s.changeRequest(targetPlanID, types.ProrationBehaviorCreateProrations)
+	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
+	return req
+}
+
+// forfeitResetRequest restarts the term and settles nothing for the period it cut
+// short: the customer keeps no credit for the days they paid for and will not use.
+func (s *SubscriptionChangeV2Suite) forfeitResetRequest(targetPlanID string) dto.SubscriptionChangeV2Request {
 	req := s.changeRequest(targetPlanID, types.ProrationBehaviorNone)
 	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 	return req
@@ -49,12 +59,11 @@ func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidation
 			},
 		},
 		{
-			name: "reset_at_effect with prorations is rejected",
+			name: "anchor_at_effect with prorations is accepted — it asks for the credit",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
 				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 				r.ProrationBehavior = types.ProrationBehaviorCreateProrations
 			},
-			wantErr: "proration is not applicable when the billing period is reset",
 		},
 		{
 			name: "reset_at is rejected rather than inferred",
@@ -297,6 +306,47 @@ func (s *SubscriptionChangeV2Suite) TestExecute_ResetDoesNotRebillTheOutgoingPla
 }
 
 // A downgrade can credit more than the new plan costs; the excess must reach the wallet.
+// proration_behavior selects what happens to the period the reset cut short.
+// none forfeits it: the new plan is billed in full and nothing is credited back, which
+// is the only way to ask for a clean restart. Before this, none was the *required*
+// value and the credit was issued anyway, so no caller could express either intent.
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetWithoutProrationsForfeitsTheRemainder() {
+	ctx := s.GetContext()
+
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	forfeited, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.forfeitResetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	invoice := s.resetInvoice(forfeited)
+	s.Require().NotNil(invoice, "the new plan is still billed for its full period")
+	s.Equal(s.td.proBase.Amount.String(), invoice.AmountDue.String(),
+		"the full price of the new plan, with nothing credited back")
+
+	for _, li := range invoice.LineItems {
+		s.False(li.Amount.IsNegative(), "a forfeited remainder must not appear as a credit line")
+	}
+}
+
+// The same change asking for the credit bills strictly less, and the difference is the
+// unused remainder of the outgoing plan.
+func (s *SubscriptionChangeV2Suite) TestExecute_ResetWithProrationsCreditsTheRemainder() {
+	ctx := s.GetContext()
+
+	s.recordBilled(s.td.baseLine.ID, s.td.starterBase.Amount)
+
+	credited, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID), time.Now().UTC())
+	s.Require().NoError(err)
+
+	invoice := s.resetInvoice(credited)
+	s.Require().NotNil(invoice)
+	s.True(invoice.AmountDue.LessThan(s.td.proBase.Amount),
+		"asking for prorations must bill less than the full price, got %s", invoice.AmountDue)
+	s.True(lo.SomeBy(invoice.LineItems, func(li *dto.InvoiceLineItemResponse) bool {
+		return li.Amount.IsNegative()
+	}), "the credit for the outgoing plan is a line on the settlement")
+}
+
 func (s *SubscriptionChangeV2Suite) TestExecute_ResetRoutesExcessCreditToTheWallet() {
 	ctx := s.GetContext()
 

--- a/internal/ee/service/subscription_change_v2_reset_test.go
+++ b/internal/ee/service/subscription_change_v2_reset_test.go
@@ -53,7 +53,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidation
 			},
 		},
 		{
-			name: "reset_at_effect on an immediate change is accepted",
+			name: "anchor_at_effect on an immediate change is accepted",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
 				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 			},
@@ -66,11 +66,11 @@ func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidation
 			},
 		},
 		{
-			name: "reset_at is rejected rather than inferred",
+			name: "anchor_at_config is rejected rather than inferred",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
-				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourUpdateToConfig
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtConfig
 			},
-			wantErr: "'reset_at' is not supported yet",
+			wantErr: "'anchor_at_config' is not supported yet",
 		},
 		{
 			name: "billing_period is reserved",

--- a/internal/ee/service/subscription_change_v2_reset_test.go
+++ b/internal/ee/service/subscription_change_v2_reset_test.go
@@ -16,7 +16,7 @@ import (
 
 func (s *SubscriptionChangeV2Suite) resetRequest(targetPlanID string) dto.SubscriptionChangeV2Request {
 	req := s.changeRequest(targetPlanID, types.ProrationBehaviorNone)
-	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 	return req
 }
 
@@ -45,13 +45,13 @@ func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidation
 		{
 			name: "reset_at_effect on an immediate change is accepted",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
-				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 			},
 		},
 		{
 			name: "reset_at_effect with prorations is rejected",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
-				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 				r.ProrationBehavior = types.ProrationBehaviorCreateProrations
 			},
 			wantErr: "proration is not applicable when the billing period is reset",
@@ -59,7 +59,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidation
 		{
 			name: "reset_at is rejected rather than inferred",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
-				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAt
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourUpdateToConfig
 			},
 			wantErr: "'reset_at' is not supported yet",
 		},
@@ -75,7 +75,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_BillingPeriodBehaviourValidation
 		{
 			name: "billing_period is reserved even alongside a supported behaviour",
 			mutate: func(r *dto.SubscriptionChangeV2Request) {
-				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+				r.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 				r.BillingPeriodConfig = &dto.BillingPeriodConfig{}
 			},
 			wantErr: "billing_period_config is not supported yet",
@@ -152,7 +152,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_ResetMovesTheAnchorToTheChangeIn
 	s.True(sub.CurrentPeriodEnd.Equal(expectedEnd), "the new period is a full period, never a stub")
 	s.False(sub.CurrentPeriodEnd.Equal(s.td.periodEnd), "the old boundary is gone")
 
-	s.Equal(types.BillingPeriodBehaviourResetAtEffect, resp.BillingPeriod.Behaviour)
+	s.Equal(types.BillingPeriodBehaviourAnchorAtEffect, resp.BillingPeriod.Behaviour)
 	s.True(resp.BillingPeriod.BillingAnchor.Equal(at))
 	s.True(resp.BillingPeriod.CurrentPeriodStart.Equal(at))
 	s.True(resp.BillingPeriod.CurrentPeriodEnd.Equal(expectedEnd))
@@ -180,7 +180,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_DeferredResetIsANoOp() {
 	ctx := s.GetContext()
 
 	req := s.deferredRequest(s.td.pro.ID)
-	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 
 	resp, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
 	s.Require().NoError(err)
@@ -194,7 +194,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_DeferredResetIsANoOp() {
 	s.Require().NotNil(sched)
 	config, err := sched.GetPlanChangeV2Config()
 	s.Require().NoError(err)
-	s.Equal(types.BillingPeriodBehaviourResetAtEffect, config.BillingPeriodBehaviour,
+	s.Equal(types.BillingPeriodBehaviourAnchorAtEffect, config.BillingPeriodBehaviour,
 		"the behaviour round-trips through the schedule blob")
 }
 
@@ -214,7 +214,7 @@ func (s *SubscriptionChangeV2Suite) TestExecuteScheduledV2_DeferredResetKeepsMon
 	s.Require().NoError(s.GetStores().SubscriptionRepo.Update(ctx, sub))
 
 	sched, config := s.createV2Schedule(s.td.pro.ID, feb28)
-	config.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+	config.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 	s.rollPeriodTo(feb28, time.Date(2026, 3, 31, 0, 0, 0, 0, time.UTC))
 
 	s.Require().NoError(s.svc.ExecuteScheduledPlanChangeV2(ctx, sched, config, s.currentSub()))
@@ -397,7 +397,7 @@ func (s *SubscriptionChangeV2Suite) TestPreview_ResetEchoesTheProjectedAnchor() 
 	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, s.resetRequest(s.td.pro.ID))
 	s.Require().NoError(err)
 
-	s.Equal(types.BillingPeriodBehaviourResetAtEffect, preview.BillingPeriod.Behaviour)
+	s.Equal(types.BillingPeriodBehaviourAnchorAtEffect, preview.BillingPeriod.Behaviour)
 	s.True(preview.BillingPeriod.BillingAnchor.Equal(preview.EffectiveAt),
 		"the projected anchor is the change instant")
 	s.True(preview.BillingPeriod.CurrentPeriodStart.Equal(preview.EffectiveAt))
@@ -416,7 +416,7 @@ func (s *SubscriptionChangeV2Suite) TestPreview_DeferredResetEchoesAnUnmovedAnch
 	ctx := s.GetContext()
 
 	req := s.deferredRequest(s.td.pro.ID)
-	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourResetAtEffect
+	req.BillingPeriodBehaviour = types.BillingPeriodBehaviourAnchorAtEffect
 
 	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, req)
 	s.Require().NoError(err)

--- a/internal/ee/service/subscription_change_v2_test.go
+++ b/internal/ee/service/subscription_change_v2_test.go
@@ -66,6 +66,7 @@ func (s *SubscriptionChangeV2Suite) serviceParams() ServiceParams {
 		PriceUnitRepo:              st.PriceUnitRepo,
 		EventRepo:                  st.EventRepo,
 		MeterRepo:                  st.MeterRepo,
+		MeterUsageRepo:             st.MeterUsageRepo,
 		CustomerRepo:               st.CustomerRepo,
 		InvoiceRepo:                st.InvoiceRepo,
 		InvoiceLineItemRepo:        st.InvoiceLineItemRepo,

--- a/internal/ee/service/subscription_change_v2_test.go
+++ b/internal/ee/service/subscription_change_v2_test.go
@@ -712,7 +712,7 @@ func (s *SubscriptionChangeV2Suite) TestExecute_AddonCarriesByDefault() {
 
 	s.Require().Len(resp.EntityChanges, 1)
 	s.Equal(types.EntityChangeBehaviourCarry, resp.EntityChanges[0].Behaviour)
-	s.Equal(assoc.ID, resp.EntityChanges[0].ReferenceID)
+	s.Equal(assoc.ID, resp.EntityChanges[0].EntityID)
 }
 
 func (s *SubscriptionChangeV2Suite) TestExecute_AddonDropClosesAttachment() {

--- a/internal/ee/service/subscription_change_v2_test.go
+++ b/internal/ee/service/subscription_change_v2_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/addonassociation"
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/domain/plan"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/domain/subscription"
@@ -71,6 +72,7 @@ func (s *SubscriptionChangeV2Suite) serviceParams() ServiceParams {
 		InvoiceRepo:                st.InvoiceRepo,
 		InvoiceLineItemRepo:        st.InvoiceLineItemRepo,
 		EntitlementRepo:            st.EntitlementRepo,
+		EntitlementGrantRepo:       st.EntitlementGrantRepo,
 		EnvironmentRepo:            st.EnvironmentRepo,
 		FeatureRepo:                st.FeatureRepo,
 		TenantRepo:                 st.TenantRepo,
@@ -390,6 +392,59 @@ func (s *SubscriptionChangeV2Suite) TestPreviewMatchesExecute() {
 	s.True(quoted.Equal(charged), "quoted %s but charged %s", quoted, charged)
 	s.Equal(preview.ChangeType, executed.ChangeType)
 	s.Len(preview.ChangedResources.LineItems, len(executed.ChangedResources.LineItems))
+}
+
+// The swap re-anchors the subscription to the target plan's price sequence, so a preview
+// that still reports the outgoing plan's is describing a subscription execute never leaves.
+func (s *SubscriptionChangeV2Suite) TestPreviewMatchesExecute_OnTheTargetPriceSequence() {
+	ctx := s.GetContext()
+
+	s.createUsagePriceWithSequence(s.td.pro.ID, 7)
+	s.Require().EqualValues(0, s.currentSub().SyncedPriceSequence)
+
+	req := s.changeRequest(s.td.pro.ID, types.ProrationBehaviorNone)
+
+	preview, err := s.svc.PreviewPlanChange(ctx, s.td.sub.ID, req)
+	s.Require().NoError(err)
+	s.EqualValues(7, preview.Subscription.SyncedPriceSequence)
+
+	executed, err := s.svc.ExecutePlanChange(ctx, s.td.sub.ID, req, time.Now().UTC())
+	s.Require().NoError(err)
+	s.Equal(preview.Subscription.SyncedPriceSequence, executed.Subscription.SyncedPriceSequence)
+	s.EqualValues(7, s.currentSub().SyncedPriceSequence, "and the stored row agrees")
+}
+
+func (s *SubscriptionChangeV2Suite) createUsagePriceWithSequence(planID string, sequence int64) *price.Price {
+	ctx := s.GetContext()
+
+	m := &meter.Meter{
+		ID:          types.GenerateUUIDWithPrefix(types.UUID_PREFIX_METER),
+		Name:        "seq_meter",
+		EventName:   "seq_event",
+		Aggregation: meter.Aggregation{Type: types.AggregationSum, Field: "units"},
+		BaseModel:   types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().MeterRepo.CreateMeter(ctx, m))
+
+	p := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(1),
+		Currency:           "usd",
+		Type:               types.PRICE_TYPE_USAGE,
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           planID,
+		MeterID:            m.ID,
+		LookupKey:          "seq_calls",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		Sequence:           sequence,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.Require().NoError(s.GetStores().PriceRepo.Create(ctx, p))
+	return p
 }
 
 // A net credit is paid to the wallet, never invoiced, so the quote has to say so:

--- a/internal/repository/ent/entitlement.go
+++ b/internal/repository/ent/entitlement.go
@@ -317,6 +317,8 @@ func (r *entitlementRepository) Update(ctx context.Context, e *domainEntitlement
 		SetUsageResetPeriod(e.UsageResetPeriod).
 		SetStaticValue(e.StaticValue).
 		SetNillableParentEntitlementID(e.ParentEntitlementID).
+		SetNillableStartDate(e.StartDate).
+		SetNillableEndDate(e.EndDate).
 		SetStatus(string(e.Status)).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).

--- a/internal/repository/ent/entitlement_test.go
+++ b/internal/repository/ent/entitlement_test.go
@@ -1,0 +1,95 @@
+package ent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/cache"
+	"github.com/flexprice/flexprice/internal/config"
+	domainEntitlement "github.com/flexprice/flexprice/internal/domain/entitlement"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestEntitlementRepository(t *testing.T) domainEntitlement.Repository {
+	t.Helper()
+	client := newRealPostgresTestClient(t)
+	log, err := logger.NewLogger(&config.Configuration{
+		Logging: config.LoggingConfig{Level: types.LogLevelInfo},
+	})
+	require.NoError(t, err)
+	return NewEntitlementRepository(client, log, cache.NewInMemoryCache(), noopRedisCache{})
+}
+
+func newTestEntitlement(t *testing.T) *domainEntitlement.Entitlement {
+	t.Helper()
+	ctx := testCouponContext()
+	e := &domainEntitlement.Entitlement{
+		ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENTITLEMENT),
+		EntityType:       types.ENTITLEMENT_ENTITY_TYPE_SUBSCRIPTION,
+		EntityID:         types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION),
+		FeatureID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_FEATURE),
+		FeatureType:      types.FeatureTypeStatic,
+		StaticValue:      "2000",
+		IsEnabled:        true,
+		UsageResetPeriod: types.ENTITLEMENT_USAGE_RESET_PERIOD_MONTHLY,
+		EnvironmentID:    types.GetEnvironmentID(ctx),
+		BaseModel:        types.GetDefaultBaseModel(ctx),
+	}
+	e.Status = types.StatusPublished
+	return e
+}
+
+// end_date is what stops a subscription-scoped override from stacking with the plan
+// entitlement that replaced it, and the plan-change close is the only writer. Update
+// silently ignored the field for a while, so the close reported a drop it never made
+// and the customer kept both limits.
+func TestEntitlementUpdate_PersistsTheClosingWindow(t *testing.T) {
+	repo := newTestEntitlementRepository(t)
+	ctx := testCouponContext()
+
+	created, err := repo.Create(ctx, newTestEntitlement(t))
+	require.NoError(t, err)
+	require.Nil(t, created.EndDate, "a fresh entitlement has no end date")
+
+	closedAt := time.Now().UTC().Truncate(time.Second)
+	_, err = repo.Update(ctx, domainEntitlement.NewEntitlementBuilder(created).
+		WithEndDate(closedAt).
+		Build())
+	require.NoError(t, err)
+
+	reloaded, err := repo.Get(ctx, created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.EndDate, "the close must survive the write")
+	require.True(t, closedAt.Equal(reloaded.EndDate.UTC()),
+		"closed at %s but stored %s", closedAt, reloaded.EndDate.UTC())
+}
+
+// The field is Nillable rather than set-or-clear, so an update that carries no end
+// date narrows nothing. Reopening a closed entitlement is a deliberate act and must
+// not fall out of an unrelated field update.
+func TestEntitlementUpdate_DoesNotReopenAClosedEntitlement(t *testing.T) {
+	repo := newTestEntitlementRepository(t)
+	ctx := testCouponContext()
+
+	closedAt := time.Now().UTC().Truncate(time.Second)
+	seed := newTestEntitlement(t)
+	seed.EndDate = lo.ToPtr(closedAt)
+	created, err := repo.Create(ctx, seed)
+	require.NoError(t, err)
+	require.NotNil(t, created.EndDate)
+
+	stale := *created
+	stale.EndDate = nil
+	stale.StaticValue = "3000"
+	_, err = repo.Update(ctx, &stale)
+	require.NoError(t, err)
+
+	reloaded, err := repo.Get(ctx, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "3000", reloaded.StaticValue, "the update still applied")
+	require.NotNil(t, reloaded.EndDate, "but it did not reopen the window")
+	require.True(t, closedAt.Equal(reloaded.EndDate.UTC()))
+}

--- a/internal/testutil/inmemory_subscription_schedule_store.go
+++ b/internal/testutil/inmemory_subscription_schedule_store.go
@@ -57,20 +57,18 @@ func (s *InMemorySubscriptionScheduleStore) Update(ctx context.Context, schedule
 	if err := s.InMemoryStore.Update(ctx, schedule.ID, schedule); err != nil {
 		return err
 	}
-	// Update index if subscription ID changed
+	// Re-point the index at the updated value. Callers that build an updated copy
+	// (the domain builders all do) would otherwise leave the index serving the stale
+	// pointer, which the ent repository never does.
 	s.mu.Lock()
-	if oldSchedule.SubscriptionID != schedule.SubscriptionID {
-		// Remove from old subscription's list
-		schedules := s.schedulesBySubscription[oldSchedule.SubscriptionID]
-		for i, sched := range schedules {
-			if sched.ID == schedule.ID {
-				s.schedulesBySubscription[oldSchedule.SubscriptionID] = append(schedules[:i], schedules[i+1:]...)
-				break
-			}
+	schedules := s.schedulesBySubscription[oldSchedule.SubscriptionID]
+	for i, sched := range schedules {
+		if sched.ID == schedule.ID {
+			s.schedulesBySubscription[oldSchedule.SubscriptionID] = append(schedules[:i], schedules[i+1:]...)
+			break
 		}
-		// Add to new subscription's list
-		s.schedulesBySubscription[schedule.SubscriptionID] = append(s.schedulesBySubscription[schedule.SubscriptionID], schedule)
 	}
+	s.schedulesBySubscription[schedule.SubscriptionID] = append(s.schedulesBySubscription[schedule.SubscriptionID], schedule)
 	s.mu.Unlock()
 	return nil
 }

--- a/internal/types/subscription_change.go
+++ b/internal/types/subscription_change.go
@@ -10,12 +10,26 @@ type EntityChangeBehaviour string
 const (
 	EntityChangeBehaviourCarry EntityChangeBehaviour = "carry"
 	EntityChangeBehaviourDrop  EntityChangeBehaviour = "drop"
+	EntityChangeBehaviourAdd   EntityChangeBehaviour = "add"
 )
 
+// EntityChangeBehaviourValues is the set a caller may request. It deliberately excludes
+// the report-only behaviours.
 var EntityChangeBehaviourValues = []EntityChangeBehaviour{
 	EntityChangeBehaviourCarry,
 	EntityChangeBehaviourDrop,
 }
+
+type SubscriptionChangeEntityType string
+
+const (
+	SubscriptionChangeEntityTypePlan        SubscriptionChangeEntityType = "plan"
+	SubscriptionChangeEntityTypeAddon       SubscriptionChangeEntityType = "addon"
+	SubscriptionChangeEntityTypeCreditGrant SubscriptionChangeEntityType = "credit_grant"
+	SubscriptionChangeEntityTypeEntitlement SubscriptionChangeEntityType = "entitlement"
+)
+
+func (t SubscriptionChangeEntityType) String() string { return string(t) }
 
 func (d EntityChangeBehaviour) String() string { return string(d) }
 

--- a/internal/types/subscription_change.go
+++ b/internal/types/subscription_change.go
@@ -34,3 +34,33 @@ func (d EntityChangeBehaviour) Validate() error {
 	}
 	return nil
 }
+
+type OnPendingSchedulePolicy string
+
+const (
+	OnPendingSchedulePolicyReject    OnPendingSchedulePolicy = "reject"
+	OnPendingSchedulePolicySupersede OnPendingSchedulePolicy = "supersede"
+)
+
+var OnPendingSchedulePolicyValues = []OnPendingSchedulePolicy{
+	OnPendingSchedulePolicyReject,
+	OnPendingSchedulePolicySupersede,
+}
+
+func (p OnPendingSchedulePolicy) String() string { return string(p) }
+
+func (p OnPendingSchedulePolicy) Validate() error {
+	if p == "" {
+		return nil
+	}
+	if !lo.Contains(OnPendingSchedulePolicyValues, p) {
+		return ierr.NewError("invalid on_pending_schedule policy").
+			WithHint("Policy must be one of the allowed values").
+			WithReportableDetails(map[string]any{
+				"on_pending_schedule": string(p),
+				"allowed":             OnPendingSchedulePolicyValues,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}

--- a/internal/types/subscription_change.go
+++ b/internal/types/subscription_change.go
@@ -78,3 +78,44 @@ func (p OnPendingSchedulePolicy) Validate() error {
 	}
 	return nil
 }
+
+// BillingPeriodBehaviour decides what a plan change does to the subscription's billing
+// anchor and period bounds.
+type BillingPeriodBehaviour string
+
+const (
+	// BillingPeriodBehaviourUnchanged keeps the anchor and period bounds. Default.
+	BillingPeriodBehaviourUnchanged BillingPeriodBehaviour = "unchanged"
+
+	// BillingPeriodBehaviourResetAtEffect moves the anchor to the moment the change
+	// takes effect and starts a full new period there. For a period-end change that
+	// instant is already the anchor, so nothing moves.
+	BillingPeriodBehaviourResetAtEffect BillingPeriodBehaviour = "reset_at_effect"
+
+	// BillingPeriodBehaviourResetAt resets to a caller-supplied instant.
+	BillingPeriodBehaviourResetAt BillingPeriodBehaviour = "reset_at"
+)
+
+var BillingPeriodBehaviourValues = []BillingPeriodBehaviour{
+	BillingPeriodBehaviourUnchanged,
+	BillingPeriodBehaviourResetAtEffect,
+	BillingPeriodBehaviourResetAt,
+}
+
+func (b BillingPeriodBehaviour) String() string { return string(b) }
+
+func (b BillingPeriodBehaviour) Validate() error {
+	if b == "" {
+		return nil
+	}
+	if !lo.Contains(BillingPeriodBehaviourValues, b) {
+		return ierr.NewError("invalid billing_period_behaviour").
+			WithHint("Behaviour must be one of the allowed values").
+			WithReportableDetails(map[string]any{
+				"billing_period_behaviour": string(b),
+				"allowed":                  BillingPeriodBehaviourValues,
+			}).
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}

--- a/internal/types/subscription_change.go
+++ b/internal/types/subscription_change.go
@@ -13,8 +13,6 @@ const (
 	EntityChangeBehaviourAdd   EntityChangeBehaviour = "add"
 )
 
-// EntityChangeBehaviourValues is the set a caller may request. It deliberately excludes
-// the report-only behaviours.
 var EntityChangeBehaviourValues = []EntityChangeBehaviour{
 	EntityChangeBehaviourCarry,
 	EntityChangeBehaviourDrop,

--- a/internal/types/subscription_change.go
+++ b/internal/types/subscription_change.go
@@ -21,10 +21,11 @@ var EntityChangeBehaviourValues = []EntityChangeBehaviour{
 type SubscriptionChangeEntityType string
 
 const (
-	SubscriptionChangeEntityTypePlan        SubscriptionChangeEntityType = "plan"
-	SubscriptionChangeEntityTypeAddon       SubscriptionChangeEntityType = "addon"
-	SubscriptionChangeEntityTypeCreditGrant SubscriptionChangeEntityType = "credit_grant"
-	SubscriptionChangeEntityTypeEntitlement SubscriptionChangeEntityType = "entitlement"
+	SubscriptionChangeEntityTypePlan             SubscriptionChangeEntityType = "plan"
+	SubscriptionChangeEntityTypeAddon            SubscriptionChangeEntityType = "addon"
+	SubscriptionChangeEntityTypeCreditGrant      SubscriptionChangeEntityType = "credit_grant"
+	SubscriptionChangeEntityTypeEntitlement      SubscriptionChangeEntityType = "entitlement"
+	SubscriptionChangeEntityTypeEntitlementGrant SubscriptionChangeEntityType = "entitlement_grant"
 )
 
 func (t SubscriptionChangeEntityType) String() string { return string(t) }
@@ -85,19 +86,19 @@ const (
 	// BillingPeriodBehaviourUnchanged keeps the anchor and period bounds. Default.
 	BillingPeriodBehaviourUnchanged BillingPeriodBehaviour = "unchanged"
 
-	// BillingPeriodBehaviourResetAtEffect moves the anchor to the moment the change
+	// BillingPeriodBehaviourAnchorAtEffect moves the anchor to the moment the change
 	// takes effect and starts a full new period there. For a period-end change that
 	// instant is already the anchor, so nothing moves.
-	BillingPeriodBehaviourResetAtEffect BillingPeriodBehaviour = "reset_at_effect"
+	BillingPeriodBehaviourAnchorAtEffect BillingPeriodBehaviour = "anchor_at_effect"
 
-	// BillingPeriodBehaviourResetAt resets to a caller-supplied instant.
-	BillingPeriodBehaviourResetAt BillingPeriodBehaviour = "reset_at"
+	// BillingPeriodBehaviourUpdateToConfig resets to a caller-supplied instant.
+	BillingPeriodBehaviourUpdateToConfig BillingPeriodBehaviour = "update_to_config"
 )
 
 var BillingPeriodBehaviourValues = []BillingPeriodBehaviour{
 	BillingPeriodBehaviourUnchanged,
-	BillingPeriodBehaviourResetAtEffect,
-	BillingPeriodBehaviourResetAt,
+	BillingPeriodBehaviourAnchorAtEffect,
+	BillingPeriodBehaviourUpdateToConfig,
 }
 
 func (b BillingPeriodBehaviour) String() string { return string(b) }

--- a/internal/types/subscription_change.go
+++ b/internal/types/subscription_change.go
@@ -91,14 +91,19 @@ const (
 	// instant is already the anchor, so nothing moves.
 	BillingPeriodBehaviourAnchorAtEffect BillingPeriodBehaviour = "anchor_at_effect"
 
-	// BillingPeriodBehaviourUpdateToConfig resets to a caller-supplied instant.
-	BillingPeriodBehaviourUpdateToConfig BillingPeriodBehaviour = "update_to_config"
+	// BillingPeriodBehaviourAnchorAtConfig moves the anchor to a caller-supplied
+	// instant in billing_period_config. Not supported yet: the request validator
+	// rejects it.
+	BillingPeriodBehaviourAnchorAtConfig BillingPeriodBehaviour = "anchor_at_config"
 )
 
+// BillingPeriodBehaviourValues is the parse set, not the accepted set: it admits
+// anchor_at_config so a caller sending it gets "not supported yet" rather than
+// "invalid billing_period_behaviour".
 var BillingPeriodBehaviourValues = []BillingPeriodBehaviour{
 	BillingPeriodBehaviourUnchanged,
 	BillingPeriodBehaviourAnchorAtEffect,
-	BillingPeriodBehaviourUpdateToConfig,
+	BillingPeriodBehaviourAnchorAtConfig,
 }
 
 func (b BillingPeriodBehaviour) String() string { return string(b) }


### PR DESCRIPTION
## **User description**
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription plan changes support conflict policies, billing-period resets, billing-anchor updates, and improved preview and execution results.
  * Plan credit grants and entitlement overrides are updated correctly during plan changes, while unrelated grants remain unaffected.
  * Invoice requests can specify invoice type and billing reason.

* **Bug Fixes**
  * Corrected billing-period boundary handling and future credit-grant cancellation filtering.

* **Documentation**
  * Clarified subscription plan-change preview, execution, and pending-schedule behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Expand subscription plan changes with billing-anchor resets, conflict replacement, and resource migration

### What Changed
- Plan changes can keep the existing billing period or restart it at the effective time; responses and previews report the resulting billing anchor and period dates.
- Restarted periods settle unused plan time against the new full-period charge, invoice usage from the outgoing period separately, and send excess credits to the wallet.
- Pending plan changes are rejected by default or replaced atomically with `on_conflict_policies.on_pending_schedule = 'supersede'`; previews show which schedule would be cancelled.
- Plan credit grants move to the target plan without reclaiming previously granted credits, while addon grants remain active.
- Subscription entitlement overrides and grant windows inherited from the outgoing plan close when the change takes effect and appear in the reported resource changes.
- Advance-billed items ending exactly at the next billing boundary are no longer billed in that following period.

### Impact
`✅ Predictable billing-anchor resets`
`✅ Fewer duplicate or missed plan-change charges`
`✅ Credits and entitlements match the active plan`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
