### PR TITLE
refactor(user): switch support-chat identity verification from JWT to HMAC

### DIFF
--- a/internal/api/dto/user.go
+++ b/internal/api/dto/user.go
@@ -6,7 +6,6 @@ import (
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/validator"
-	"github.com/golang-jwt/jwt/v4"
 )
 
 // CreateUserRequest represents the request to create a new user (service account or user)
@@ -164,17 +163,10 @@ type ActiveEnvironmentAPIKeys struct {
 	APIKeys []ActiveAPIKey `json:"api_keys"`
 }
 
+// Token is the hex-encoded HMAC-SHA256 of the user's email, verified by Pylon via email_hash.
 type SupportChatTokenResponse struct {
 	Token     string `json:"token"`
 	ExpiresAt string `json:"expires_at"`
-}
-
-type ChatSupportClaims struct {
-	Email             string `json:"email"`
-	Name              string `json:"name,omitempty"`
-	AccountExternalID string `json:"account_external_id,omitempty"`
-	ContactExternalID string `json:"contact_external_id,omitempty"`
-	jwt.RegisteredClaims
 }
 
 // ListUsersResponse is the response type for listing users with pagination

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -17,7 +20,6 @@ import (
 	"github.com/flexprice/flexprice/internal/postgres"
 	"github.com/flexprice/flexprice/internal/rbac"
 	"github.com/flexprice/flexprice/internal/types"
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/nedpals/supabase-go"
 	"github.com/samber/lo"
 )
@@ -620,8 +622,6 @@ func (s *userService) DeleteUser(ctx context.Context, id string) error {
 	return s.userRepo.Delete(ctx, id)
 }
 
-const chatSupportTokenTTL = 10 * time.Minute
-
 func (s *userService) CreateSupportChatToken(ctx context.Context) (*dto.SupportChatTokenResponse, error) {
 	if s.cfg == nil || s.cfg.ChatSupport.AppID == "" || s.cfg.ChatSupport.IdentitySecret == "" {
 		return nil, ierr.NewError("chat support identity verification is not configured").
@@ -640,36 +640,22 @@ func (s *userService) CreateSupportChatToken(ctx context.Context) (*dto.SupportC
 			Mark(ierr.ErrValidation)
 	}
 
-	now := time.Now().UTC()
-	expiresAt := now.Add(chatSupportTokenTTL)
-
-	claims := dto.ChatSupportClaims{
-		Email:             u.Email,
-		Name:              u.Name,
-		ContactExternalID: u.ID,
-		RegisteredClaims: jwt.RegisteredClaims{
-			Audience:  jwt.ClaimStrings{s.cfg.ChatSupport.AppID},
-			IssuedAt:  jwt.NewNumericDate(now),
-			ExpiresAt: jwt.NewNumericDate(expiresAt),
-		},
-	}
-	if u.Tenant != nil {
-		claims.AccountExternalID = u.Tenant.ID
-		if claims.Name == "" {
-			claims.Name = u.Tenant.Name
-		}
-	}
-
-	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(s.cfg.ChatSupport.IdentitySecret))
+	secretBytes, err := hex.DecodeString(s.cfg.ChatSupport.IdentitySecret)
 	if err != nil {
-		s.logger.Error(ctx, "failed to sign support chat token", "error", err, "user_id", u.ID)
+
 		return nil, ierr.WithError(err).
-			WithHint("Failed to sign the support chat token").
+			WithHint("chat_support.identity_secret must be a hex string").
+			Mark(ierr.ErrInternal)
+	}
+
+	mac := hmac.New(sha256.New, secretBytes)
+	if _, err := mac.Write([]byte(u.Email)); err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Failed to hash the support chat email").
 			Mark(ierr.ErrInternal)
 	}
 
 	return &dto.SupportChatTokenResponse{
-		Token:     token,
-		ExpiresAt: expiresAt.Format(time.RFC3339),
+		Token: hex.EncodeToString(mac.Sum(nil)),
 	}, nil
 }

--- a/internal/ee/service/user.go
+++ b/internal/ee/service/user.go
@@ -620,7 +620,7 @@ func (s *userService) DeleteUser(ctx context.Context, id string) error {
 	return s.userRepo.Delete(ctx, id)
 }
 
-const chatSupportTokenTTL = 2 * time.Hour
+const chatSupportTokenTTL = 10 * time.Minute
 
 func (s *userService) CreateSupportChatToken(ctx context.Context) (*dto.SupportChatTokenResponse, error) {
 	if s.cfg == nil || s.cfg.ChatSupport.AppID == "" || s.cfg.ChatSupport.IdentitySecret == "" {

--- a/internal/ee/service/user_test.go
+++ b/internal/ee/service/user_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/flexprice/flexprice/internal/rbac"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 )
@@ -681,6 +682,50 @@ func (s *UserServiceSuite) TestDeleteUser() {
 		err := s.userService.DeleteUser(ctx, "sa-1")
 		s.NoError(err)
 	})
+}
+
+func (s *UserServiceSuite) TestCreateSupportChatToken() {
+	const (
+		appID  = "pylon-app-id"
+		secret = "raw-identity-secret"
+	)
+
+	ctx := testutil.SetupContext()
+	_ = s.userRepo.Create(ctx, &user.User{
+		ID:        types.DefaultUserID,
+		Email:     "support@example.com",
+		Name:      "Support User",
+		Type:      types.UserTypeUser,
+		BaseModel: types.GetDefaultBaseModel(ctx),
+	})
+	s.userService.cfg = &config.Configuration{
+		ChatSupport: config.ChatSupportConfig{
+			AppID:          appID,
+			IdentitySecret: secret,
+		},
+	}
+
+	resp, err := s.userService.CreateSupportChatToken(ctx)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp)
+
+	expiresAt, err := time.Parse(time.RFC3339, resp.ExpiresAt)
+	s.Require().NoError(err)
+
+	parsed, err := jwt.ParseWithClaims(resp.Token, &dto.ChatSupportClaims{}, func(t *jwt.Token) (interface{}, error) {
+		s.Equal(jwt.SigningMethodHS256.Alg(), t.Method.Alg())
+		return []byte(secret), nil
+	})
+	s.Require().NoError(err)
+	s.True(parsed.Valid)
+
+	claims, ok := parsed.Claims.(*dto.ChatSupportClaims)
+	s.Require().True(ok)
+	s.Require().NotNil(claims.IssuedAt)
+	s.Require().NotNil(claims.ExpiresAt)
+	s.Equal(int64(600), claims.ExpiresAt.Unix()-claims.IssuedAt.Unix())
+	s.Equal(10*time.Minute, claims.ExpiresAt.Time.Sub(claims.IssuedAt.Time))
+	s.WithinDuration(claims.IssuedAt.Time.Add(10*time.Minute), expiresAt, time.Second)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/ee/service/user_test.go
+++ b/internal/ee/service/user_test.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -19,7 +22,6 @@ import (
 	"github.com/flexprice/flexprice/internal/rbac"
 	"github.com/flexprice/flexprice/internal/testutil"
 	"github.com/flexprice/flexprice/internal/types"
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 )
@@ -687,13 +689,14 @@ func (s *UserServiceSuite) TestDeleteUser() {
 func (s *UserServiceSuite) TestCreateSupportChatToken() {
 	const (
 		appID  = "pylon-app-id"
-		secret = "raw-identity-secret"
+		secret = "deadbeefdeadbeefdeadbeefdeadbeef"
+		email  = "support@example.com"
 	)
 
 	ctx := testutil.SetupContext()
 	_ = s.userRepo.Create(ctx, &user.User{
 		ID:        types.DefaultUserID,
-		Email:     "support@example.com",
+		Email:     email,
 		Name:      "Support User",
 		Type:      types.UserTypeUser,
 		BaseModel: types.GetDefaultBaseModel(ctx),
@@ -708,24 +711,34 @@ func (s *UserServiceSuite) TestCreateSupportChatToken() {
 	resp, err := s.userService.CreateSupportChatToken(ctx)
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
+	s.Empty(resp.ExpiresAt)
 
-	expiresAt, err := time.Parse(time.RFC3339, resp.ExpiresAt)
+	secretBytes, err := hex.DecodeString(secret)
 	s.Require().NoError(err)
+	mac := hmac.New(sha256.New, secretBytes)
+	_, err = mac.Write([]byte(email))
+	s.Require().NoError(err)
+	s.Equal(hex.EncodeToString(mac.Sum(nil)), resp.Token)
+}
 
-	parsed, err := jwt.ParseWithClaims(resp.Token, &dto.ChatSupportClaims{}, func(t *jwt.Token) (interface{}, error) {
-		s.Equal(jwt.SigningMethodHS256.Alg(), t.Method.Alg())
-		return []byte(secret), nil
+func (s *UserServiceSuite) TestCreateSupportChatToken_InvalidHexSecret() {
+	ctx := testutil.SetupContext()
+	_ = s.userRepo.Create(ctx, &user.User{
+		ID:        types.DefaultUserID,
+		Email:     "support@example.com",
+		Type:      types.UserTypeUser,
+		BaseModel: types.GetDefaultBaseModel(ctx),
 	})
-	s.Require().NoError(err)
-	s.True(parsed.Valid)
+	s.userService.cfg = &config.Configuration{
+		ChatSupport: config.ChatSupportConfig{
+			AppID:          "pylon-app-id",
+			IdentitySecret: "not-a-hex-string",
+		},
+	}
 
-	claims, ok := parsed.Claims.(*dto.ChatSupportClaims)
-	s.Require().True(ok)
-	s.Require().NotNil(claims.IssuedAt)
-	s.Require().NotNil(claims.ExpiresAt)
-	s.Equal(int64(600), claims.ExpiresAt.Unix()-claims.IssuedAt.Unix())
-	s.Equal(10*time.Minute, claims.ExpiresAt.Time.Sub(claims.IssuedAt.Time))
-	s.WithinDuration(claims.IssuedAt.Time.Add(10*time.Minute), expiresAt, time.Second)
+	resp, err := s.userService.CreateSupportChatToken(ctx)
+	s.Require().Error(err)
+	s.Nil(resp)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## **User description**
## Summary
- `CreateSupportChatToken` now signs HMAC-SHA256(email) using the hex-decoded `chat_support.identity_secret`, instead of a signed JWT — JWT signing was causing issues in production.
- Removes `ChatSupportClaims` dto and the `golang-jwt` dependency from `internal/ee/service/user.go` / `internal/api/dto/user.go`.
- Pairs with the frontend PR that sends the returned hash as Pylon's `email_hash` instead of `jwt`.

## Test plan
- [x] `go build ./internal/...` — clean
- [x] `go test ./internal/ee/service/...` — passing, including new `TestCreateSupportChatToken` (valid hash) and `TestCreateSupportChatToken_InvalidHexSecret` cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Switch support-chat identity verification to email hashes

### What Changed
- Support-chat tokens are now hex-encoded HMAC-SHA256 hashes of the user's email, matching Pylon's `email_hash` verification format
- Tokens no longer contain user profile details or expiration timestamps
- Invalid identity secrets are rejected with a clear configuration error
- Added coverage for valid hashes and invalid secrets

### Impact
`✅ Reliable Pylon identity verification`
`✅ No user details exposed in support-chat tokens`
`✅ Clearer configuration errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Support chat authentication tokens now use a secure HMAC-SHA256 hash of the user’s email.
  * Tokens no longer include unnecessary expiration or identity claims, simplifying verification by the support platform.
  * Invalid identity-secret configuration is rejected safely instead of producing an unusable token.

* **Bug Fixes**
  * Improved handling of malformed identity secrets during support chat token creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->