### PR TITLE
fix(cache): real logger in NewRedisCache (unmasks silent Redis failures)

### DIFF
--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -34,7 +34,24 @@ type redisCacheImpl struct {
 // Redis cache instance
 var redisCache *redisCacheImpl
 
-// NewRedisCache creates a new Redis cache
+// NewRedisCache creates a new Redis cache.
+//
+// It builds its own config and logger rather than taking them as fx-injected
+// parameters — every other RedisCache-typed provider in main.go's fx graph
+// (NewRedisLocker included) receives the app's already-validated config and
+// logger, but this one is called with zero dependencies, and several
+// standalone scripts under scripts/ call it the same parameterless way. Both
+// call sites are preserved here rather than reshaped into main.go's fx graph.
+//
+// The logger matters beyond convenience: every Redis GET/SET/DEL error inside
+// redisCacheImpl.* is reported through whatever logger InitializeRedisCache was
+// given, and it is given exactly once (redisCache is a package singleton). A
+// noop logger here means every later Redis error from this cache — including
+// the SAML AuthnRequest tracker's Set/Get — is silently discarded for the
+// process lifetime, with nothing distinguishing "Redis is fine" from "Redis
+// calls are failing and nobody can see it." Using the real structured logger
+// keeps that failure mode observable; noop remains only the fallback for when
+// building the real logger itself fails.
 func NewRedisCache() RedisCache {
 	if redisCache == nil {
 		cfg, err := config.NewConfig()
@@ -42,8 +59,11 @@ func NewRedisCache() RedisCache {
 			logger.NewNoopLogger().Error(context.Background(), "Failed to initialize Redis cache", "error", err)
 			return nil
 		}
-		noop := logger.NewNoopLogger()
-		InitializeRedisCache(cfg, noop)
+		log, err := logger.NewLogger(cfg)
+		if err != nil {
+			log = logger.NewNoopLogger()
+		}
+		InitializeRedisCache(cfg, log)
 	}
 	return redisCache
 }


### PR DESCRIPTION
## **User description**
## Problem
`cache.NewRedisCache()` built the fx-wired Redis cache singleton with `logger.NewNoopLogger()`. Since `redisCacheImpl.Get`/`Set` report every Redis error through `c.log.Error(...)`, and this is a process-lifetime singleton, **every Redis GET/SET failure was silently swallowed**.

This masked a complete cache outage on a self-hosted (AWS/ElastiCache) staging deploy for hours: the SAML SP-initiated login tracker stores the outstanding AuthnRequest ID in Redis at `/login` and reads it at `/acs`; the Set was failing (TLS/cluster-mode misconfig against ElastiCache), so `/acs` always saw an empty set and rejected every assertion with `InResponseTo does not match (expected [])` — with **nothing in the logs**.

## Fix
`NewRedisCache()` now builds the real structured logger from `cfg` (same construction the rest of the app uses), falling back to noop only if logger construction itself fails. No signature change — all 15 call sites unaffected.

## Why it matters
The underlying outage was fixed by deployment config (`FLEXPRICE_REDIS_USE_TLS=true`, `FLEXPRICE_REDIS_CLUSTER_MODE=false` for non-cluster TLS-only ElastiCache), but this logger bug is what made it invisible. With this fix, a future Redis failure surfaces immediately instead of silently degrading all caching.

## Verification
`go build` + `go test ./internal/cache/... ./internal/ee/auth/saml/...` pass. Logger-selection branch mutates a package singleton + reads real env, so no unit test added for that branch specifically; the tracker logic it protects is covered by existing `routes_test.go`.


___

## **CodeAnt-AI Description**
Surface Redis cache failures instead of silently hiding them

### What Changed
- Redis cache GET, SET, and DELETE failures now appear in the application’s structured logs
- The cache uses the application logger during normal startup and only falls back to a silent logger if logger setup fails
- Existing cache callers continue to work without configuration changes

### Impact
`✅ Visible Redis outage errors`
`✅ Faster diagnosis of SAML login failures`
`✅ Fewer silently rejected authentication requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Redis cache initialization logging.
  * Added a safe fallback when logger setup is unavailable, preventing logging issues from interrupting cache initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->