### PR TITLE
fix(chart): verify-migrations reports MISSING against correctly-migrated infra

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -633,11 +633,27 @@ spec:
               CH_HTTP_HOST="{{ if eq .Values.clickhouse.mode "external" }}{{ index (splitList ":" .Values.clickhouse.address) 0 }}{{ else if eq .Values.clickhouse.mode "altinity" }}chi-{{ include "flexprice.fullname" . }}-flexprice-0-0{{ if .Values.clickhouse.namespace }}.{{ .Values.clickhouse.namespace }}.svc.cluster.local{{ end }}{{ else }}{{ include "flexprice.clickhouseServiceHost" . }}{{ end }}"
               CH_HTTP_PORT="{{ if eq .Values.clickhouse.mode "external" }}{{ index (splitList ":" .Values.clickhouse.address) 1 }}{{ else if eq .Values.clickhouse.mode "altinity" }}8123{{ else }}{{ .Values.clickhouse.standalone.service.httpPort }}{{ end }}"
               CH_SCHEME="{{ if .Values.clickhouse.tls }}https{{ else }}http{{ end }}"
+              # Resolved into a variable instead of templated inline at the end of
+              # the wget call. Inline, the left-chomp on the conditional eats the
+              # preceding newline, so the previous line's trailing backslash ends up
+              # mid-line rather than last on its line:
+              #
+              #   --header="X-ClickHouse-Key: ..." \ 2>/dev/null || echo 0)
+              #
+              # A backslash only continues a line when it is the final character.
+              # There it escapes the space instead, wget receives " 2" as a
+              # positional argument and exits with `bad address ' 2'`, the
+              # `|| echo 0` sets n=0, and every table is reported MISSING against a
+              # ClickHouse that migrated correctly.
+              CH_INSECURE=""
+              {{- if $.Values.clickhouse.tlsSkipVerify }}
+              CH_INSECURE="--no-check-certificate"
+              {{- end }}
               for t in events meter_usage; do
                 n=$(wget -qO- "${CH_SCHEME}://${CH_HTTP_HOST}:${CH_HTTP_PORT}/?query=SELECT+count()+FROM+system.tables+WHERE+database='{{ .Values.clickhouse.database }}'+AND+name='${t}'" \
                     --header="X-ClickHouse-User: ${FLEXPRICE_CLICKHOUSE_USERNAME}" \
                     --header="X-ClickHouse-Key: ${FLEXPRICE_CLICKHOUSE_PASSWORD}" \
-                    {{- if $.Values.clickhouse.tlsSkipVerify }} --no-check-certificate{{- end }} 2>/dev/null || echo 0)
+                    ${CH_INSECURE} 2>/dev/null || echo 0)
                 [ "$n" = "1" ] || { echo "❌ MISSING ClickHouse table: ${t}"; exit 1; }
                 echo "  ✅ ${t}"
               done
@@ -645,10 +661,29 @@ spec:
               {{- if .Values.migration.steps.kafka }}
               echo "verify: Kafka topics"
               KAFKA_BROKER="{{ include "flexprice.kafkaBrokers" . }}"
-              KAFKA_TOPICS_CMD="kafka-topics"
-              if command -v kafka-topics.sh >/dev/null 2>&1; then
+              KAFKA_TOPICS_CMD=""
+              if command -v kafka-topics >/dev/null 2>&1; then
+                KAFKA_TOPICS_CMD="kafka-topics"
+              elif command -v kafka-topics.sh >/dev/null 2>&1; then
                 KAFKA_TOPICS_CMD="kafka-topics.sh"
               fi
+              # Unlike create-kafka-topics, which runs in the cp-kafka image, this
+              # step runs in the APPLICATION image -- which ships no Kafka CLI. The
+              # previous default assumed `kafka-topics` was present. When it is not,
+              # the --list below fails, its stderr is swallowed by 2>/dev/null,
+              # EXISTING comes back empty, and every topic is reported MISSING
+              # against a broker that holds all of them.
+              #
+              # A verification that cannot run is worse than one that is skipped: it
+              # fails the deploy and blames the infrastructure. Skip and say so.
+              if [ -z "${KAFKA_TOPICS_CMD}" ]; then
+                echo "  (kafka CLI not present in this image -- skipping topic verification)"
+                echo "  topics are created and listed by the create-kafka-topics step"
+              else
+              # NOTE: this branch is deliberately NOT indented. It contains a
+              # <<'PROPS' heredoc whose terminator must land at column 0 after YAML
+              # strips the block scalar's common indent; indenting the branch would
+              # leave "  PROPS", which never closes the heredoc.
               CMD_CONFIG=""
               {{- if or .Values.kafkaConfig.useSASL .Values.kafkaConfig.tls }}
               CMD_CONFIG=/tmp/kafka-admin.properties
@@ -680,6 +715,7 @@ spec:
               done
               [ "${MISSING}" -eq 0 ] || { echo "❌ ${MISSING} required Kafka topic(s) missing"; exit 1; }
               echo "  ✅ core topics present"
+              fi
               {{- end }}
               echo "✅ verify-migrations complete"
           env:


### PR DESCRIPTION
## **User description**
Both checks in the `verify-migrations` step can fail a deployment whose ClickHouse and Kafka are fully and correctly provisioned. Both were hit on a real deployment (`flexprice-staging-apne1`, a from-scratch BYOC rehearsal), where they blocked an apply against infrastructure that had migrated perfectly.

Symptom in both cases is the same, and it is the misleading kind: the step reports the *infrastructure* as broken when the infrastructure is fine and the check itself is what failed.

## ClickHouse — stray line continuation

`--no-check-certificate` was templated inline at the end of the `wget` invocation with a left-chomping conditional. When `tlsSkipVerify` is false the conditional renders empty and the chomp pulls the line up, leaving the preceding line's continuation backslash in the middle of a line:

```sh
--header="X-ClickHouse-Key: ${FLEXPRICE_CLICKHOUSE_PASSWORD}" \ 2>/dev/null || echo 0)
```

A backslash only continues a line when it is the **last** character on it. Here it escapes the space instead, so `2` becomes a positional argument and `wget` exits with `bad address ' 2'`. The `|| echo 0` then sets `n=0` and **every** table is reported `MISSING`.

Fix: resolve the flag into a `CH_INSECURE` variable before the loop, so it is never adjacent to a line continuation.

## Kafka — CLI assumed present in an image that has none

`KAFKA_TOPICS_CMD` defaulted to `kafka-topics` on the assumption the binary exists. This step runs in the **application** image, which ships no Kafka CLI — unlike `create-kafka-topics`, which runs in `cp-kafka`. The `--list` then fails, its stderr is discarded by the `2>/dev/null`, `EXISTING` comes back empty, and every topic is reported `MISSING` against a broker holding all of them.

Fix: probe for both binaries and skip the check with an explicit message when neither is present.

> A verification that cannot run is worse than one that is skipped: it fails the deploy and names the infrastructure as the cause.

Splitting this check into a `cp-kafka` container so it actually runs is the better long-term answer, but it is a bigger change than this fix and is left out deliberately.

## Reviewer note

The skip branch is **intentionally not indented**. It contains a `<<'PROPS'` heredoc whose terminator must land at column 0 once YAML strips the block scalar's common indent; indenting the branch would leave `  PROPS`, which never closes the heredoc.

## Verification

`helm template` across `tlsSkipVerify` × `useSASL` × `tls` combinations. For each, the rendered verify script:

- passes `sh -n`
- contains **0** mid-line continuation backslashes
- keeps the heredoc terminator at column 0

| combination | `sh -n` | mid-line `\` | `PROPS` col 0 |
|---|---|---|---|
| `tlsSkipVerify=false, SASL=false` (the failing combo) | OK | 0 | yes |
| `tlsSkipVerify=true, SASL=true` (SCRAM-SHA-512) | OK | 0 | yes |
| `tls=true, tlsSkipVerify=false, kafka TLS` | OK | 0 | yes |

The same check run against the unpatched template on `develop` reproduces the defect:

```
mid-line backslash lines: 1
>>> --header="X-ClickHouse-Key: ${FLEXPRICE_CLICKHOUSE_PASSWORD}" \ 2>/dev/null || echo 0)
```

Branch cut from `develop` (not `main`) — `main` is currently 16 ahead / 31 behind, and this file has diverged between the two, so the fix was re-applied onto `develop`'s copy rather than ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent false migration failures for correctly provisioned ClickHouse and Kafka

### What Changed
- ClickHouse table checks now work correctly when TLS certificate verification is enabled, instead of reporting every table as missing.
- Kafka topic checks recognize either supported Kafka command and verify topics when a CLI is available.
- When the application image has no Kafka CLI, topic verification is skipped with a clear message rather than failing the deployment and blaming missing topics.

### Impact
`✅ Fewer false migration failures`
`✅ Accurate ClickHouse migration results`
`✅ Clear Kafka verification status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment verification for ClickHouse connections using TLS, preventing malformed download commands.
  - Kafka verification now supports either available Kafka command-line tool.
  - When no supported Kafka tool is installed, verification is skipped with a clear explanatory message instead of failing unexpectedly.
  - Existing Kafka topic checks continue to run when a supported tool is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->