### PR TITLE
feat(otel): expose API request metrics and per-instance metric identity

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -549,6 +549,12 @@ type OtelMetricsConfig struct {
 	// MeterProvider when the metrics pipeline is on. Off by default — Temporal
 	// SDK series are higher volume than app DB/cache metrics.
 	TemporalEnabled bool `mapstructure:"temporal_enabled" default:"false"`
+	// HTTPServerEnabled keeps otelgin's http.server.request.duration instead of
+	// dropping it, so request rate / latency / error rate per route come from
+	// metrics rather than from spans. Off by default (~31% of our own ingestion,
+	// and SigNoz already derives it); turn it on where the backend cannot store
+	// traces and this is the only source of API latency.
+	HTTPServerEnabled bool `mapstructure:"http_server_enabled" default:"false"`
 }
 
 // MergedHeaders — see OtelTracesConfig.MergedHeaders.

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -243,7 +243,7 @@ otel:
     auth_header: "signoz-ingestion-key" # Set auth_value via FLEXPRICE_OTEL_LOGS_AUTH_VALUE
     auth_value: ""
 
-  # App-level DB/cache metrics (always-on aggregate signal, unsampled). Service-level
+  # App-level metrics (always-on aggregate signal, unsampled). Service-level
   # resource only (no per-pod host attrs) to keep metric cardinality — and cost — flat.
   metrics:
     enabled: false
@@ -253,6 +253,10 @@ otel:
     auth_value: ""
     interval_seconds: 60
     temporal_enabled: false
+    # Keep http.server.request.duration (request rate / latency / error rate per
+    # route). Off here — SigNoz derives it from traces; turn it on where the
+    # backend cannot store traces.
+    http_server_enabled: false
 
 pyroscope:
   enabled: false # Set to true to enable continuous profiling

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -249,6 +249,18 @@ func (s *Service) baseResourceAttrs() []attribute.KeyValue {
 	if mode := string(s.cfg.Deployment.Mode); mode != "" {
 		attrs = append(attrs, attribute.String("app.component", mode))
 	}
+
+	// service.instance.id identifies which replica emitted this, on both signals.
+	// Metrics need it: without it every replica exports the same label set, so one
+	// series takes samples from N writers whose cumulative counters reset
+	// independently — duplicates get dropped and a rolling restart reads as a
+	// phantom spike. Aggregate it away at query time (sum by (job) (rate(x[5m])) —
+	// rate() per series first) or in a collector, not here.
+	// Hostname is the pod name on k8s and the container ID on ECS;
+	// OTEL_RESOURCE_ATTRIBUTES overrides it.
+	if host, err := os.Hostname(); err == nil && host != "" {
+		attrs = append(attrs, semconv.ServiceInstanceID(host))
+	}
 	return attrs
 }
 
@@ -267,10 +279,9 @@ func (s *Service) newResource(ctx context.Context) (*resource.Resource, error) {
 	)
 }
 
-// newMetricResource builds a SERVICE-LEVEL resource (no host.name/process attrs).
-// Metric series cardinality = label combinations × resource series; per-pod
-// host attributes would multiply every series by the running pod count, so they
-// are deliberately omitted to keep metric cost flat.
+// newMetricResource builds a SERVICE-LEVEL resource: no host.name/process attrs,
+// which would multiply every series without adding anything service.instance.id
+// does not already say.
 func (s *Service) newMetricResource(ctx context.Context) (*resource.Resource, error) {
 	return resource.New(ctx,
 		resource.WithAttributes(s.baseResourceAttrs()...),
@@ -312,24 +323,12 @@ func (s *Service) initMeter(ctx context.Context) error {
 	if interval <= 0 {
 		interval = 60 * time.Second
 	}
-	mp := sdkmetric.NewMeterProvider(
+	opts := []sdkmetric.Option{
 		sdkmetric.WithResource(res),
 		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter, sdkmetric.WithInterval(interval))),
-		// Drop the framework's auto-emitted HTTP metrics (http.server.* / http.client.*).
-		// Turning on the MeterProvider auto-enabled these; they were ~31% of metric
-		// ingestion and are referenced by no dashboard or alert. Body-size histograms
-		// are unwanted, and request latency is already covered by APM (derived from
-		// traces). NOTE: if API traces are ever sampled below 100%, re-add a coarse
-		// http.server.request.duration here as the always-on latency source.
-		sdkmetric.WithView(sdkmetric.NewView(
-			sdkmetric.Instrument{Name: "http.server.*"},
-			sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
-		)),
-		sdkmetric.WithView(sdkmetric.NewView(
-			sdkmetric.Instrument{Name: "http.client.*"},
-			sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
-		)),
-	)
+	}
+	opts = append(opts, s.httpMetricViews()...)
+	mp := sdkmetric.NewMeterProvider(opts...)
 	otel.SetMeterProvider(mp)
 	s.meterProvider = mp
 
@@ -348,6 +347,35 @@ func (s *Service) initMeter(ctx context.Context) error {
 	s.meterInitDone = true
 	s.logger.Info(ctx, "OTel metrics initialized", "endpoint", mc.Endpoint, "interval", interval.String())
 	return nil
+}
+
+// httpMetricViews decides what happens to the HTTP metrics otelgin emits for free.
+// Everything is dropped by default (~31% of ingestion, and SigNoz derives the same
+// view from spans). http_server_enabled keeps request.duration for deployments with
+// no trace backend, trimmed to bounded attributes — the raw semconv set adds
+// server.address/port and protocol version, which cost series and say nothing here.
+func (s *Service) httpMetricViews() []sdkmetric.Option {
+	drop := func(pattern string) sdkmetric.Option {
+		return sdkmetric.WithView(sdkmetric.NewView(
+			sdkmetric.Instrument{Name: pattern},
+			sdkmetric.Stream{Aggregation: sdkmetric.AggregationDrop{}},
+		))
+	}
+
+	var views []sdkmetric.Option
+	if s.cfg.Otel.Metrics.HTTPServerEnabled {
+		// First matching view wins, so this must precede the http.server.* drop.
+		views = append(views, sdkmetric.WithView(sdkmetric.NewView(
+			sdkmetric.Instrument{Name: "http.server.request.duration"},
+			sdkmetric.Stream{AttributeFilter: attribute.NewAllowKeysFilter(
+				"http.request.method",
+				"http.route",
+				"http.response.status_code",
+				"error.type",
+			)},
+		)))
+	}
+	return append(views, drop("http.server.*"), drop("http.client.*"))
 }
 
 // newMetricExporter builds the OTLP metric exporter (gRPC or HTTP), mirroring

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -2,12 +2,16 @@ package tracing
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/flexprice/flexprice/internal/config"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -242,4 +246,149 @@ func TestTemporalMetricsHandler(t *testing.T) {
 			t.Fatal("expected non-nil Temporal MetricsHandler")
 		}
 	})
+}
+
+// meterWithHTTPViews builds a MeterProvider with the views initMeter installs.
+func meterWithHTTPViews(t *testing.T, httpServerEnabled bool) (metric.Meter, *sdkmetric.ManualReader) {
+	t.Helper()
+	s := &Service{cfg: &config.Configuration{
+		Otel: config.OtelConfig{Metrics: config.OtelMetricsConfig{HTTPServerEnabled: httpServerEnabled}},
+	}}
+	reader := sdkmetric.NewManualReader()
+	opts := append([]sdkmetric.Option{sdkmetric.WithReader(reader)}, s.httpMetricViews()...)
+	return sdkmetric.NewMeterProvider(opts...).Meter("test"), reader
+}
+
+// recordHTTPServerMetrics emits what otelgin does, with its full attribute set.
+func recordHTTPServerMetrics(t *testing.T, meter metric.Meter) {
+	t.Helper()
+	dur, err := meter.Float64Histogram("http.server.request.duration")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := meter.Int64Histogram("http.server.request.body.size")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := meter.Float64Histogram("http.client.request.duration")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attrs := metric.WithAttributes(
+		attribute.String("http.request.method", "POST"),
+		attribute.String("http.route", "/v1/events"),
+		attribute.Int("http.response.status_code", 200),
+		attribute.String("server.address", "api.flexprice.io"),
+		attribute.Int("server.port", 8080),
+		attribute.String("network.protocol.version", "1.1"),
+	)
+	dur.Record(context.Background(), 0.12, attrs)
+	body.Record(context.Background(), 512, attrs)
+	client.Record(context.Background(), 0.05, attrs)
+}
+
+// Flag off keeps today's behaviour: every HTTP metric is dropped.
+func TestHTTPServerMetricsDroppedByDefault(t *testing.T) {
+	meter, reader := meterWithHTTPViews(t, false)
+	recordHTTPServerMetrics(t, meter)
+
+	got := collect(t, reader)
+	for _, name := range []string{
+		"http.server.request.duration",
+		"http.server.request.body.size",
+		"http.client.request.duration",
+	} {
+		if len(got[name]) != 0 {
+			t.Errorf("%s should be dropped when http_server_enabled is false; got %v", name, got[name])
+		}
+	}
+}
+
+// Flag on: request duration survives trimmed; body-size and client stay dropped.
+func TestHTTPServerMetricsKeptWhenEnabled(t *testing.T) {
+	meter, reader := meterWithHTTPViews(t, true)
+	recordHTTPServerMetrics(t, meter)
+
+	got := collect(t, reader)
+	dps := got["http.server.request.duration"]
+	if len(dps) != 1 {
+		t.Fatalf("expected 1 request-duration point, got %v", dps)
+	}
+	if !hasDP(dps, map[string]string{
+		"http.request.method":       "POST",
+		"http.route":                "/v1/events",
+		"http.response.status_code": "200",
+	}) {
+		t.Errorf("expected route/method/status attributes to survive; got %v", dps)
+	}
+	for _, dropped := range []string{"server.address", "server.port", "network.protocol.version"} {
+		if _, ok := dps[0][dropped]; ok {
+			t.Errorf("attribute %q should have been filtered out; got %v", dropped, dps[0])
+		}
+	}
+	if len(got["http.server.request.body.size"]) != 0 {
+		t.Errorf("body-size histogram should stay dropped; got %v", got["http.server.request.body.size"])
+	}
+	if len(got["http.client.request.duration"]) != 0 {
+		t.Errorf("http.client.* should stay dropped; got %v", got["http.client.request.duration"])
+	}
+}
+
+// service.instance.id must be on both resources and has no off switch: without it
+// N replicas write one series with independent counter resets.
+func TestResourcesAlwaysCarryInstanceID(t *testing.T) {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		t.Skip("hostname unavailable")
+	}
+
+	s := &Service{cfg: &config.Configuration{}}
+
+	// Both signals carry it, so a suspect series leads to that replica's spans.
+	for name, build := range map[string]func(context.Context) (*resource.Resource, error){
+		"metrics": s.newMetricResource,
+		"traces":  s.newResource,
+	} {
+		res, err := build(context.Background())
+		if err != nil {
+			t.Fatalf("%s resource: %v", name, err)
+		}
+		got, ok := instanceIDOf(res)
+		if !ok {
+			t.Errorf("service.instance.id missing from the %s resource", name)
+			continue
+		}
+		if got != host {
+			t.Errorf("%s service.instance.id = %q, want hostname %q", name, got, host)
+		}
+	}
+}
+
+// instanceIDOf returns the resource's service.instance.id, if it has one.
+func instanceIDOf(res *resource.Resource) (string, bool) {
+	for _, kv := range res.Attributes() {
+		if kv.Key == semconv.ServiceInstanceIDKey {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// WithFromEnv merges last, so a deployment can override the hostname identity.
+func TestMetricResourceInstanceIDEnvOverride(t *testing.T) {
+	t.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.instance.id=pod-from-downward-api")
+
+	s := &Service{cfg: &config.Configuration{}}
+	res, err := s.newMetricResource(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := instanceIDOf(res)
+	if !ok {
+		t.Fatal("service.instance.id missing from the metric resource")
+	}
+	if got != "pod-from-downward-api" {
+		t.Fatalf("service.instance.id = %q, want the env override to win", got)
+	}
 }


### PR DESCRIPTION
## Why

A self-hosted customer runs Prometheus with no OpenTelemetry Collector and no trace store, and cannot tell whether the platform is healthy.

Transport was never the blocker — a Prometheus 3.x OTLP receiver ingests our metrics with no code change (verified on staging GCP mumbai, 2026-08-21). Two coverage problems were.

## 1. API metrics exist only as spans

Request rate, latency and error rate are derived by SigNoz from traces. A deployment with no trace backend has no source for them; `http.server.*` is dropped outright by a View (#2310).

`http.server.request.duration` is un-dropped behind **`otel.metrics.http_server_enabled`** (default `false`, so our own ingestion volume is unchanged). Attributes trimmed to `http.request.method`, `http.route`, `http.response.status_code`, `error.type` — the raw semconv set also carries `server.address`, `server.port`, `network.protocol.version`, which add series without adding signal for a single service. Body-size and `http.client.*` stay dropped either way.

```promql
sum by (http_route) (rate(http_server_request_duration_seconds_count[5m]))
histogram_quantile(0.99, sum by (http_route,le) (rate(http_server_request_duration_seconds_bucket[5m])))
sum by (http_route) (rate(http_server_request_duration_seconds_count{http_status_code=~"5.."}[5m]))
```

## 2. Metrics carried no instance identity

`newMetricResource` omitted per-host attributes, so **every replica exported an identical label set and the backend saw one series fed by N writers**. Their cumulative counters reset independently, producing interleaved and out-of-order samples and a counter that appears to move backwards. A rolling restart reads as a phantom spike. Same effect as `db.client` counters merging across ECS task rotations.

`service.instance.id` is now **always** set from the container hostname — pod name on Kubernetes, container ID on ECS, unique per replica on both.

**No flag**, because no deployment legitimately wants merged counters. The per-service view costs nothing to recover:

```promql
sum by (job) (rate(db_client_duration_milliseconds_count[5m]))   # correct
rate(sum by (job) (db_client_duration_milliseconds_count)[5m:])  # broken
```

`rate()` runs per series so each instance's reset is detected, and only then is summed. Identity can always be aggregated away downstream; it can never be recovered if it was never sent. Where series count is billed, reduce it in the collector — `cumulativetodelta` → sum away the instance → `deltatocumulative` — which is both where cardinality costs money and where the aggregation is still arithmetically correct.

### Why not just `OTEL_RESOURCE_ATTRIBUTES`?

Considered and rejected as the *default*, kept as the *override*. Setting it per deployment fails silently when forgotten — graphs still render, counters are just wrong, which is the exact failure this PR exists to fix — and it needs different plumbing per runtime (downward API, ECS task metadata, plain hostname). `WithFromEnv` still merges last, so a deployment wanting a different identity sets `OTEL_RESOURCE_ATTRIBUTES=service.instance.id=...` and wins. There is a test pinning that precedence.

## Deliberately not included

**Consumer throughput, DLQ depth and lag are not emitted by the application.** They are broker facts, read from Kafka directly — which stays accurate when a consumer is down, exactly the moment an app-side counter goes silent.

## Testing

- Views drop everything by default; with the flag on, `request.duration` survives with exactly the trimmed attribute set while body-size and `http.client.*` stay dropped.
- `service.instance.id` is always present and equals the hostname; `OTEL_RESOURCE_ATTRIBUTES` overrides it.
- `go test ./internal/tracing/... ./internal/config/...` pass, `go vet` clean, `go build ./internal/...` clean.
- Not yet exercised against a live deployment — planned next on staging GCP mumbai, against the Prometheus already receiving staging metrics over OTLP.

## Cost

Export volume does not change. Every replica was already exporting its own datapoints on its own interval — `N pods x M series x 1/interval` before and after. The attribute only changes how many distinct series those datapoints land in: 1 -> replica count.

| Backend | Billing basis | Effect |
|---|---|---|
| SigNoz Cloud (ours) | samples ingested | roughly flat |
| Self-hosted Prometheus / VictoriaMetrics | memory + index, scales with active series | up |
| Per-series vendors (Datadog custom metrics) | unique series | up |

Series also churn on each deploy, since pod names change.

Worth noting the other direction too: with N replicas writing an identical label set, the backend was receiving multiple values for the same series at the same timestamp. Duplicate and out-of-order samples get rejected or overwritten on arrival, so some datapoints we already paid to export were being dropped. This likely recovers data as much as it adds series.

## Rollout

`http_server_enabled` defaults off, so API metrics are opt-in per deployment. `service.instance.id` is unconditional. Measure the series-count change on staging before it reaches prod; if it lands badly the answer is collector-side aggregation, not going back to ambiguous series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in setting to retain HTTP server request-duration metrics, disabled by default.
  * HTTP server metrics include selected request attributes while excluding unrelated HTTP server and client metrics.
  * Metric resources now include the service instance hostname, with environment-provided settings taking precedence.

* **Documentation**
  * Updated configuration guidance and comments for enabling HTTP server metrics and clarifying application-level metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
