### PR TITLE
feat(plan): add price sync status to PlanResponse and related structures

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -19948,6 +19948,20 @@ const docTemplate = `{
                 }
             }
         },
+        "PlanPriceSyncStatusResponse": {
+            "type": "object",
+            "properties": {
+                "current_sequence": {
+                    "type": "integer"
+                },
+                "synced": {
+                    "type": "boolean"
+                },
+                "unsynced_subscription_count": {
+                    "type": "integer"
+                }
+            }
+        },
         "PlanResponse": {
             "type": "object",
             "properties": {
@@ -19989,6 +20003,14 @@ const docTemplate = `{
                 },
                 "name": {
                     "type": "string"
+                },
+                "price_sync_status": {
+                    "description": "PriceSyncStatus reports how many subscriptions are still behind this\nplan's current price sequence. Only populated on the list/search\nendpoint (GetPlans) when ` + "`" + `expand=price_sync_status` + "`" + ` is requested,\nsince computing it is extra per-plan work most callers don't need.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/PlanPriceSyncStatusResponse"
+                        }
+                    ]
                 },
                 "prices": {
                     "description": "TODO: Add inline addons",

--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -21932,6 +21932,20 @@
           }
         }
       },
+      "PlanPriceSyncStatusResponse": {
+        "type": "object",
+        "properties": {
+          "current_sequence": {
+            "type": "integer"
+          },
+          "synced": {
+            "type": "boolean"
+          },
+          "unsynced_subscription_count": {
+            "type": "integer"
+          }
+        }
+      },
       "PlanResponse": {
         "type": "object",
         "properties": {
@@ -21974,6 +21988,9 @@
           },
           "name": {
             "type": "string"
+          },
+          "price_sync_status": {
+            "$ref": "#/components/schemas/PlanPriceSyncStatusResponse"
           },
           "prices": {
             "type": "array",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -19620,6 +19620,20 @@
                 }
             }
         },
+        "PlanPriceSyncStatusResponse": {
+            "type": "object",
+            "properties": {
+                "current_sequence": {
+                    "type": "integer"
+                },
+                "synced": {
+                    "type": "boolean"
+                },
+                "unsynced_subscription_count": {
+                    "type": "integer"
+                }
+            }
+        },
         "PlanResponse": {
             "type": "object",
             "properties": {
@@ -19661,6 +19675,10 @@
                 },
                 "name": {
                     "type": "string"
+                },
+                "price_sync_status": {
+                    "description": "PriceSyncStatus reports how many subscriptions are still behind this\nplan's current price sequence. Only populated on the list/search\nendpoint (GetPlans) when `expand=price_sync_status` is requested,\nsince computing it is extra per-plan work most callers don't need.",
+                    "$ref": "#/definitions/PlanPriceSyncStatusResponse"
                 },
                 "prices": {
                     "description": "TODO: Add inline addons",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5128,6 +5128,15 @@ definitions:
       voided_at:
         type: string
     type: object
+  PlanPriceSyncStatusResponse:
+    properties:
+      current_sequence:
+        type: integer
+      synced:
+        type: boolean
+      unsynced_subscription_count:
+        type: integer
+    type: object
   PlanResponse:
     properties:
       created_at:
@@ -5156,6 +5165,14 @@ definitions:
         $ref: '#/definitions/types.Metadata'
       name:
         type: string
+      price_sync_status:
+        allOf:
+        - $ref: '#/definitions/PlanPriceSyncStatusResponse'
+        description: |-
+          PriceSyncStatus reports how many subscriptions are still behind this
+          plan's current price sequence. Only populated on the list/search
+          endpoint (GetPlans) when `expand=price_sync_status` is requested,
+          since computing it is extra per-plan work most callers don't need.
       prices:
         description: 'TODO: Add inline addons'
         items:

--- a/internal/api/dto/plan.go
+++ b/internal/api/dto/plan.go
@@ -130,6 +130,11 @@ type PlanResponse struct {
 	Prices       []*PriceResponse       `json:"prices,omitempty"`
 	Entitlements []*EntitlementResponse `json:"entitlements,omitempty"`
 	CreditGrants []*CreditGrantResponse `json:"credit_grants,omitempty"`
+	// PriceSyncStatus reports how many subscriptions are still behind this
+	// plan's current price sequence. Only populated on the list/search
+	// endpoint (GetPlans) when `expand=price_sync_status` is requested,
+	// since computing it is extra per-plan work most callers don't need.
+	PriceSyncStatus *PlanPriceSyncStatusResponse `json:"price_sync_status,omitempty"`
 }
 
 type UpdatePlanRequest struct {
@@ -191,6 +196,16 @@ type SynchronizationSummary struct {
 	TotalPrices   int `json:"total_prices"`
 	ActivePrices  int `json:"active_prices"`
 	ExpiredPrices int `json:"expired_prices"`
+}
+
+// PlanPriceSyncStatusResponse reports how many of a plan's subscriptions are
+// still behind the plan's current price sequence (i.e. not yet reconciled by
+// a sync run). UnsyncedSubscriptionCount == 0 means every eligible
+// subscription is caught up and a sync run would be a no-op.
+type PlanPriceSyncStatusResponse struct {
+	CurrentSequence           int64 `json:"current_sequence"`
+	UnsyncedSubscriptionCount int64 `json:"unsynced_subscription_count"`
+	Synced                    bool  `json:"synced"`
 }
 
 // ClonePlanRequest represents the request to clone a plan

--- a/internal/domain/planpricesync/repository.go
+++ b/internal/domain/planpricesync/repository.go
@@ -118,6 +118,12 @@ type Repository interface {
 
 	// ReanchorSubSyncedSequence sets synced_price_sequence forward or backward.
 	ReanchorSubSyncedSequence(ctx context.Context, subscriptionID string, seq int64) error
+
+	// CountUnsyncedSubscriptions returns how many of the plan's subscriptions
+	// are stale relative to targetSeq (synced_price_sequence < targetSeq).
+	// Mirrors the `stale_subs` eligibility filter used by
+	// ListPlanLineItemsToCreateV2, without paging.
+	CountUnsyncedSubscriptions(ctx context.Context, planID string, targetSeq int64) (int64, error)
 }
 
 // ListPlanLineItemsToCreateV2Params drives the V2 discovery query.

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -232,6 +232,22 @@ func (s *planService) GetPlans(ctx context.Context, filter *types.PlanFilter) (*
 		}
 	}
 
+	// Fetch price sync status if requested. Not bulk-fetchable (each plan has
+	// its own current sequence and stale-subscription count), so this is one
+	// query pair per plan — fine for the opt-in, small-N callers (e.g. a
+	// single-plan lookup by ID) this expand is meant for; avoid requesting it
+	// on large unfiltered plan listings.
+	syncStatusByPlanID := make(map[string]*dto.PlanPriceSyncStatusResponse)
+	if filter.GetExpand().Has(types.ExpandPriceSyncStatus) {
+		for _, planID := range planIDs {
+			status, err := s.planPriceSyncStatus(ctx, planID)
+			if err != nil {
+				return nil, err
+			}
+			syncStatusByPlanID[planID] = status
+		}
+	}
+
 	// Build response with expanded fields
 	for i, plan := range plans {
 
@@ -248,6 +264,11 @@ func (s *planService) GetPlans(ctx context.Context, filter *types.PlanFilter) (*
 		// Add credit grants if available
 		if creditGrants, ok := creditGrantsByPlanID[plan.ID]; ok {
 			response.Items[i].CreditGrants = creditGrants
+		}
+
+		// Add price sync status if available
+		if syncStatus, ok := syncStatusByPlanID[plan.ID]; ok {
+			response.Items[i].PriceSyncStatus = syncStatus
 		}
 	}
 
@@ -770,6 +791,35 @@ func (s *planService) SyncPlanPricesV2(ctx context.Context, planID string) (*dto
 			LineItemsCreated:          lineItemsCreated,
 			LineItemsTerminated:       lineItemsTerminated,
 		},
+	}, nil
+}
+
+// planPriceSyncStatus reports how many of the plan's eligible subscriptions
+// are still behind the plan's current price sequence. Attached to
+// PlanResponse.PriceSyncStatus so the frontend can disable the sync trigger
+// once every subscription is caught up (count 0), instead of inferring
+// "nothing to do" from workflow run state alone.
+func (s *planService) planPriceSyncStatus(ctx context.Context, planID string) (*dto.PlanPriceSyncStatusResponse, error) {
+	targetSeq, err := s.PlanPriceSyncRepo.CurrentPlanSequence(ctx, planID)
+	if err != nil {
+		return nil, err
+	}
+
+	if targetSeq == 0 {
+		return &dto.PlanPriceSyncStatusResponse{
+			Synced: true,
+		}, nil
+	}
+
+	unsyncedCount, err := s.PlanPriceSyncRepo.CountUnsyncedSubscriptions(ctx, planID, targetSeq)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dto.PlanPriceSyncStatusResponse{
+		CurrentSequence:           targetSeq,
+		UnsyncedSubscriptionCount: unsyncedCount,
+		Synced:                    unsyncedCount == 0,
 	}, nil
 }
 

--- a/internal/ee/service/plan.go
+++ b/internal/ee/service/plan.go
@@ -235,8 +235,11 @@ func (s *planService) GetPlans(ctx context.Context, filter *types.PlanFilter) (*
 	// Fetch price sync status if requested. Not bulk-fetchable (each plan has
 	// its own current sequence and stale-subscription count), so this is one
 	// query pair per plan — fine for the opt-in, small-N callers (e.g. a
-	// single-plan lookup by ID) this expand is meant for; avoid requesting it
-	// on large unfiltered plan listings.
+	// single-plan lookup by ID) this expand is meant for.
+	// TODO(perf): serial per-plan fetch degrades on a large unfiltered
+	// listing (up to QueryFilter's 1000-row cap, i.e. up to 2000 sequential
+	// queries). Consider a bulk repository method or a bounded errgroup if
+	// this expand starts getting combined with wide plan listings.
 	syncStatusByPlanID := make(map[string]*dto.PlanPriceSyncStatusResponse)
 	if filter.GetExpand().Has(types.ExpandPriceSyncStatus) {
 		for _, planID := range planIDs {

--- a/internal/ee/service/plan_test.go
+++ b/internal/ee/service/plan_test.go
@@ -54,6 +54,7 @@ func (s *PlanServiceSuite) SetupTest() {
 		WebhookPublisher:         s.GetWebhookPublisher(),
 		IntegrationFactory:       s.GetIntegrationFactory(),
 		ConnectionRepo:           s.GetStores().ConnectionRepo,
+		PlanPriceSyncRepo:        s.GetStores().PlanPriceSyncRepo,
 	}
 	s.service = NewPlanService(s.params)
 }

--- a/internal/repository/ent/plan_price_sync_v2.go
+++ b/internal/repository/ent/plan_price_sync_v2.go
@@ -277,6 +277,75 @@ func (r *planPriceSyncRepository) TerminatePlanPricesLineItemsV2(
 	return int(n), nil
 }
 
+// CountUnsyncedSubscriptions returns how many of the plan's subscriptions are
+// stale relative to targetSeq. Uses the same eligibility filter as the
+// `stale_subs` CTE in ListPlanLineItemsToCreateV2 (published, active/
+// trialing/draft/incomplete, subscription types that own plan line items),
+// scanned via the same partial index, but with no LIMIT/paging.
+func (r *planPriceSyncRepository) CountUnsyncedSubscriptions(
+	ctx context.Context,
+	planID string,
+	targetSeq int64,
+) (int64, error) {
+	if planID == "" {
+		return 0, ierr.NewError("plan_id is required").Mark(ierr.ErrValidation)
+	}
+
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	span := StartRepositorySpan(ctx, "plan_price_sync_v2", "count_unsynced_subscriptions", map[string]interface{}{
+		"plan_id":    planID,
+		"target_seq": targetSeq,
+	})
+	defer FinishSpan(span)
+
+	query := fmt.Sprintf(`
+		SELECT COUNT(*)
+		FROM subscriptions
+		WHERE tenant_id = $1
+		  AND environment_id = $2
+		  AND status = '%s'
+		  AND plan_id = $3
+		  AND subscription_status IN ('%s','%s', '%s', '%s')
+		  AND subscription_type IN (%s)
+		  AND synced_price_sequence < $4
+	`,
+		string(types.StatusPublished),
+		string(types.SubscriptionStatusActive),
+		string(types.SubscriptionStatusTrialing),
+		string(types.SubscriptionStatusDraft),
+		string(types.SubscriptionStatusIncomplete),
+		strings.Join(lo.Map(types.SubscriptionTypesWithLineItems, func(t types.SubscriptionType, _ int) string { return fmt.Sprintf("'%s'", string(t)) }), ","),
+	)
+
+	rows, qerr := r.client.Reader(ctx).QueryContext(ctx, query, tenantID, environmentID, planID, targetSeq)
+	if qerr != nil {
+		SetSpanError(span, qerr)
+		return 0, ierr.WithError(qerr).
+			WithHint("Failed to count unsynced subscriptions").
+			Mark(ierr.ErrDatabase)
+	}
+	defer rows.Close()
+
+	var count int64
+	if rows.Next() {
+		if scanErr := rows.Scan(&count); scanErr != nil {
+			SetSpanError(span, scanErr)
+			return 0, ierr.WithError(scanErr).
+				WithHint("Failed to scan unsynced subscription count").
+				Mark(ierr.ErrDatabase)
+		}
+	}
+	if rerr := rows.Err(); rerr != nil {
+		SetSpanError(span, rerr)
+		return 0, ierr.WithError(rerr).Mark(ierr.ErrDatabase)
+	}
+
+	SetSpanSuccess(span)
+	return count, nil
+}
+
 // ReanchorSubSyncedSequence sets synced_price_sequence in either direction
 // (StampSubsAsSynced is forward-only and cannot express a lower target sequence).
 func (r *planPriceSyncRepository) ReanchorSubSyncedSequence(

--- a/internal/testutil/inmemory_planpricesync_store.go
+++ b/internal/testutil/inmemory_planpricesync_store.go
@@ -187,6 +187,19 @@ func (r *InMemoryPlanPriceSyncStore) StampSubsAsSynced(
 	return updated, nil
 }
 
+// CountUnsyncedSubscriptions returns how many of the plan's candidate subs are
+// stale relative to targetSeq. Mirrors staleSubsForPlan with no limit.
+func (r *InMemoryPlanPriceSyncStore) CountUnsyncedSubscriptions(
+	ctx context.Context,
+	planID string,
+	targetSeq int64,
+) (int64, error) {
+	if planID == "" {
+		return 0, ierr.NewError("plan_id is required").Mark(ierr.ErrValidation)
+	}
+	return int64(len(r.staleSubsForPlan(ctx, planID, targetSeq, 0))), nil
+}
+
 // ListPlanLineItemsToCreateV2 returns missing (sub, price) pairs and the full
 // set of stale sub IDs for a plan. A sub is stale when
 // synced_price_sequence < TargetSeq. A pair is missing when a candidate plan

--- a/internal/types/expand.go
+++ b/internal/types/expand.go
@@ -39,6 +39,7 @@ const (
 	ExpandCreditsAvailableBreakdown ExpandableField = "credits_available_breakdown"
 	ExpandSubscriptionLineItems     ExpandableField = "subscription_line_items"
 	ExpandIntegrations              ExpandableField = "integrations"
+	ExpandPriceSyncStatus           ExpandableField = "price_sync_status"
 )
 
 // ExpandConfig defines which fields can be expanded and their nested expansions
@@ -53,12 +54,13 @@ type ExpandConfig struct {
 var (
 	// PlanExpandConfig defines what can be expanded on a plan
 	PlanExpandConfig = ExpandConfig{
-		AllowedFields: []ExpandableField{ExpandPrices, ExpandMeters, ExpandEntitlements, ExpandCreditGrant, ExpandPriceUnit},
+		AllowedFields: []ExpandableField{ExpandPrices, ExpandMeters, ExpandEntitlements, ExpandCreditGrant, ExpandPriceUnit, ExpandPriceSyncStatus},
 		NestedExpands: map[ExpandableField][]ExpandableField{
-			ExpandPrices:       {ExpandMeters, ExpandPriceUnit, ExpandFeatures},
-			ExpandEntitlements: {ExpandFeatures},
-			ExpandCreditGrant:  {ExpandFeatures},
-			ExpandPriceUnit:    {},
+			ExpandPrices:          {ExpandMeters, ExpandPriceUnit, ExpandFeatures},
+			ExpandEntitlements:    {ExpandFeatures},
+			ExpandCreditGrant:     {ExpandFeatures},
+			ExpandPriceUnit:       {},
+			ExpandPriceSyncStatus: {},
 		},
 	}
 


### PR DESCRIPTION
## **User description**
## Summary
- Rebased onto latest `develop` (`git rebase` resolved conflicts in `internal/webhook/payload/invoice.go`, `internal/ee/infrastructure/helm/flexprice/{values.yaml,templates/jobs/migration.yaml}`, and `internal/types/expand.go` — all in favor of the already-current `develop` content, since those changes had already landed upstream through other merged PRs).
- Introduces `PlanPriceSyncStatusResponse` to track the sync status of subscriptions against a plan's current price sequence.
- `PlanResponse` now supports a `price_sync_status` expand field (`price_sync_status`), returning the current sequence and unsynced-subscription count.
- Adds `CountUnsyncedSubscriptions` to the plan price sync repository (Ent + in-memory test store) to back the new field.
- Updates Swagger docs accordingly.

## Test plan
- [x] `go build ./internal/... ./cmd/... ./ent/...`
- [x] `go test ./internal/ee/service/... ./internal/types/... ./internal/webhook/...`
- [ ] Manual: request a plan with `expand=price_sync_status` and confirm `price_sync_status.unsynced_subscriptions_count` reflects reality

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Expose plan price synchronization status through the Plans API

### What Changed
- Plans can now include the current price sequence, the number of eligible subscriptions still needing synchronization, and whether all subscriptions are caught up.
- The status is returned when callers request `expand=price_sync_status`, avoiding extra work for ordinary plan responses.
- Unsynced counts use the same subscription eligibility rules as price synchronization, including database and in-memory support.
- API documentation now describes the new response fields.

### Impact
`✅ Clearer plan synchronization status`
`✅ Fewer unnecessary synchronization runs`
`✅ Visible count of subscriptions awaiting price updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan listings can optionally include price synchronization status.
  * Status shows the current price sequence, synchronization state, and number of subscriptions needing updates.
  * Request this information using the `price_sync_status` expansion.
  * Plans with no pending price updates are identified as synchronized.

* **Documentation**
  * Updated API documentation and schemas to describe the new response fields and expansion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->