### PR TITLE
feat(chart): worker Temporal-KEDA + multi-trigger autoscaling + single-controller guard

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.3.2
+version: 1.3.3
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-api.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-api.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.api.enabled .Values.api.keda.enabled -}}
+{{- if .Values.api.autoscaling.enabled }}
+{{- fail "api: enable either api.autoscaling (HPA) or api.keda (KEDA), not both — they fight over the same Deployment" }}
+{{- end }}
+{{- /*
+  KEDA ScaledObject for the api Deployment. Combines ALB request-rate
+  (aws-cloudwatch scaler on RequestCountPerTarget) with native cpu/memory
+  triggers — KEDA scales to the max demand across all configured triggers.
+
+  Requires KEDA (https://keda.sh) installed cluster-wide, with IRSA wired for
+  cloudwatch:GetMetricData via api.keda.request.authenticationRef when the
+  request trigger is enabled. Off by default.
+*/}}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "flexprice.fullname" . }}-api
+  labels:
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "api") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "flexprice.fullname" . }}-api
+  pollingInterval: {{ .Values.api.keda.pollingInterval | default 30 }}
+  cooldownPeriod: {{ .Values.api.keda.cooldownPeriod | default 300 }}
+  minReplicaCount: {{ .Values.api.keda.minReplicas | default 1 }}
+  maxReplicaCount: {{ .Values.api.keda.maxReplicas | default 3 }}
+  triggers:
+    {{- if .Values.api.keda.request.enabled }}
+    - type: aws-cloudwatch
+      metadata:
+        namespace: AWS/ApplicationELB
+        metricName: RequestCountPerTarget
+        dimensionName: TargetGroup
+        dimensionValue: {{ .Values.api.keda.request.targetGroup | quote }}
+        statistic: Sum
+        targetMetricValue: {{ .Values.api.keda.request.targetValue | default 1000 | quote }}
+        minMetricValue: "0"
+        awsRegion: {{ .Values.api.keda.request.awsRegion | quote }}
+      {{- with .Values.api.keda.request.authenticationRef }}
+      authenticationRef:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- if .Values.api.keda.cpuValue }}
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: {{ .Values.api.keda.cpuValue | quote }}
+    {{- end }}
+    {{- if .Values.api.keda.memValue }}
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: {{ .Values.api.keda.memValue | quote }}
+    {{- end }}
+{{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-api.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-api.yaml
@@ -3,6 +3,15 @@
 {{- fail "api: enable either api.autoscaling (HPA) or api.keda (KEDA), not both — they fight over the same Deployment" }}
 {{- end }}
 {{- /*
+  api's three triggers (request/cpu/memory) are each individually gated below,
+  so with all three off the triggers list renders empty. The KEDA CRD enforces
+  MinItems=1 on spec.triggers, so an empty list is rejected server-side with an
+  opaque admission error. Fail here instead, naming the fix.
+*/}}
+{{- if not (or .Values.api.keda.request.enabled .Values.api.keda.cpuValue .Values.api.keda.memValue) }}
+{{- fail "api.keda is enabled but no trigger is: set at least one of api.keda.request.enabled, api.keda.cpuValue, or api.keda.memValue" }}
+{{- end }}
+{{- /*
   KEDA ScaledObject for the api Deployment. Combines ALB request-rate
   (aws-cloudwatch scaler on RequestCountPerTarget) with native cpu/memory
   triggers — KEDA scales to the max demand across all configured triggers.

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
@@ -33,17 +33,22 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   triggers:
+    {{- $topics := .Values.consumer.keda.topics }}
+    {{- if not $topics }}
+    {{- $topics = list (dict "topic" .Values.kafkaConfig.topic "lagThreshold" .Values.consumer.keda.lagThreshold) }}
+    {{- end }}
+    {{- range $t := $topics }}
     - type: kafka
       metadata:
-        bootstrapServers: {{ include "flexprice.kafkaBrokers" . | quote }}
-        consumerGroup: {{ .Values.kafkaConfig.consumerGroup | quote }}
-        topic: {{ .Values.kafkaConfig.topic | quote }}
-        lagThreshold: {{ .Values.consumer.keda.lagThreshold | default 1000 | quote }}
-        offsetResetPolicy: {{ .Values.consumer.keda.offsetResetPolicy | default "earliest" | quote }}
-        {{- if or .Values.kafkaConfig.tls .Values.kafkaConfig.useSASL }}
+        bootstrapServers: {{ include "flexprice.kafkaBrokers" $ | quote }}
+        consumerGroup: {{ $.Values.kafkaConfig.consumerGroup | quote }}
+        topic: {{ $t.topic | quote }}
+        lagThreshold: {{ $t.lagThreshold | default $.Values.consumer.keda.lagThreshold | default 1000 | quote }}
+        offsetResetPolicy: {{ $.Values.consumer.keda.offsetResetPolicy | default "earliest" | quote }}
+        {{- if or $.Values.kafkaConfig.tls $.Values.kafkaConfig.useSASL }}
         tls: enable
         {{- end }}
-        {{- if .Values.kafkaConfig.useSASL }}
+        {{- if $.Values.kafkaConfig.useSASL }}
         {{- /*
           KEDA's Kafka scaler names mechanisms differently from sarama: it wants
           lowercase, underscore-separated values (scram_sha512), not the
@@ -57,7 +62,7 @@ spec:
           exists to prevent.
         */}}
         {{- $saslMap := dict "SCRAM-SHA-512" "scram_sha512" "SCRAM-SHA-256" "scram_sha256" "PLAIN" "plaintext" "OAUTHBEARER" "oauthbearer" }}
-        {{- $mechanism := .Values.kafkaConfig.saslMechanism | default "PLAIN" }}
+        {{- $mechanism := $.Values.kafkaConfig.saslMechanism | default "PLAIN" }}
         {{- if not (hasKey $saslMap $mechanism) }}
         {{- fail (printf "kafkaConfig.saslMechanism %q has no KEDA equivalent; the KEDA Kafka scaler supports only: %s. Set the sarama spelling (e.g. SCRAM-SHA-512), or disable consumer.keda.enabled." $mechanism (join ", " (keys $saslMap | sortAlpha))) }}
         {{- end }}
@@ -71,10 +76,11 @@ spec:
         single authenticationRef. See consumer.keda.authenticationRef in
         values.yaml for the resource shape, including the `ca` parameter.
       */}}
-      {{- with .Values.consumer.keda.authenticationRef }}
+      {{- with $.Values.consumer.keda.authenticationRef }}
       authenticationRef:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- end }}
     {{- if .Values.consumer.keda.cpuValue }}
     - type: cpu
       metricType: Utilization

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
@@ -1,4 +1,7 @@
 {{- if and .Values.consumer.enabled .Values.consumer.keda.enabled -}}
+{{- if .Values.consumer.autoscaling.enabled }}
+{{- fail "consumer: enable either consumer.autoscaling (HPA) or consumer.keda (KEDA), not both — they fight over the same Deployment" }}
+{{- end }}
 {{- /*
   KEDA ScaledObject for the consumer Deployment. Scales on Kafka consumer-group
   lag rather than CPU — the right signal for a Kafka consumer where each

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-consumer.yaml
@@ -75,4 +75,16 @@ spec:
       authenticationRef:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- if .Values.consumer.keda.cpuValue }}
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: {{ .Values.consumer.keda.cpuValue | quote }}
+    {{- end }}
+    {{- if .Values.consumer.keda.memValue }}
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: {{ .Values.consumer.keda.memValue | quote }}
+    {{- end }}
 {{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-worker.yaml
@@ -28,14 +28,29 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   triggers:
+    {{- $queues := .Values.worker.keda.queues | default (list (.Values.temporalConfig.taskQueue | default "billing-task-queue")) }}
+    {{- range $q := $queues }}
     - type: temporal
       metadata:
-        endpoint: {{ .Values.worker.keda.endpoint | default "temporal-frontend.temporal.svc:7233" | quote }}
-        namespace: {{ .Values.temporalConfig.namespace | quote }}
-        taskQueue: {{ .Values.temporalConfig.taskQueue | default "billing-task-queue" | quote }}
-        targetQueueSize: {{ .Values.worker.keda.targetQueueSize | default 100 | quote }}
-      {{- with .Values.worker.keda.authenticationRef }}
+        endpoint: {{ $.Values.worker.keda.endpoint | default "temporal-frontend.temporal.svc:7233" | quote }}
+        namespace: {{ $.Values.temporalConfig.namespace | quote }}
+        taskQueue: {{ $q | quote }}
+        targetQueueSize: {{ $.Values.worker.keda.targetQueueSize | default 100 | quote }}
+      {{- with $.Values.worker.keda.authenticationRef }}
       authenticationRef:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+    {{- end }}
+    {{- if $.Values.worker.keda.cpuValue }}
+    - type: cpu
+      metricType: Utilization
+      metadata:
+        value: {{ $.Values.worker.keda.cpuValue | quote }}
+    {{- end }}
+    {{- if $.Values.worker.keda.memValue }}
+    - type: memory
+      metricType: Utilization
+      metadata:
+        value: {{ $.Values.worker.keda.memValue | quote }}
+    {{- end }}
 {{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/keda-worker.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.worker.enabled .Values.worker.keda.enabled -}}
+{{- if .Values.worker.autoscaling.enabled }}
+{{- fail "worker: enable either worker.autoscaling (HPA) or worker.keda (KEDA), not both — they fight over the same Deployment" }}
+{{- end }}
+{{- /*
+  KEDA ScaledObject for the worker Deployment. Scales on Temporal task-queue
+  backlog via KEDA's native temporal scaler (v2.17+). No Prometheus needed —
+  the scaler queries the Temporal frontend gRPC directly. In-cluster Temporal
+  is plaintext (no apiKey/mTLS; those are Temporal-Cloud only).
+*/}}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "flexprice.fullname" . }}-worker
+  labels:
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "worker") | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "flexprice.fullname" . }}-worker
+  pollingInterval: {{ .Values.worker.keda.pollingInterval | default 15 }}
+  cooldownPeriod: {{ .Values.worker.keda.cooldownPeriod | default 300 }}
+  minReplicaCount: {{ .Values.worker.keda.minReplicas | default 1 }}
+  maxReplicaCount: {{ .Values.worker.keda.maxReplicas | default 3 }}
+  {{- with .Values.worker.keda.fallback }}
+  fallback:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  triggers:
+    - type: temporal
+      metadata:
+        endpoint: {{ .Values.worker.keda.endpoint | default "temporal-frontend.temporal.svc:7233" | quote }}
+        namespace: {{ .Values.temporalConfig.namespace | quote }}
+        taskQueue: {{ .Values.temporalConfig.taskQueue | default "billing-task-queue" | quote }}
+        targetQueueSize: {{ .Values.worker.keda.targetQueueSize | default 100 | quote }}
+      {{- with .Values.worker.keda.authenticationRef }}
+      authenticationRef:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -164,6 +164,23 @@ api:
     maxReplicas: 10
     targetCPUUtilizationPercentage: 70
     targetMemoryUtilizationPercentage: 80
+  # KEDA ScaledObject combining ALB request-rate (aws-cloudwatch) with cpu/mem
+  # triggers for the api Deployment. Enable EITHER api.autoscaling (HPA) OR
+  # api.keda — never both (render fails). Off by default.
+  keda:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    pollingInterval: 30
+    cooldownPeriod: 300
+    cpuValue: ""     # target CPU utilization % for the cpu trigger; empty = trigger omitted
+    memValue: ""     # target memory utilization % for the memory trigger; empty = trigger omitted
+    request:
+      enabled: false
+      targetGroup: ""    # ALB target group name/ARN suffix (CloudWatch TargetGroup dimension)
+      targetValue: 1000  # target RequestCountPerTarget
+      awsRegion: ""
+      authenticationRef: {}   # TriggerAuthentication for IRSA (podIdentity: aws) built in infra
   podDisruptionBudget:
     enabled: true
     minAvailable: 1
@@ -226,6 +243,8 @@ consumer:
     pollingInterval: 15         # seconds between KEDA polls
     cooldownPeriod: 300         # seconds before scaling down to minReplicas
     offsetResetPolicy: "earliest"
+    cpuValue: ""                # target CPU utilization % for the cpu trigger; empty = trigger omitted
+    memValue: ""                # target memory utilization % for the memory trigger; empty = trigger omitted
     fallback: {}                # KEDA fallback (e.g. failureThreshold + replicas)
     # Reference to a KEDA TriggerAuthentication when Kafka needs SASL/IAM.
     # Example:
@@ -312,6 +331,9 @@ worker:
     minReplicas: 1
     maxReplicas: 3
     targetQueueSize: 100    # pending tasks per replica (1->N scaling ratio)
+    queues: []               # task queues to watch, one temporal trigger each; empty = single trigger on temporalConfig.taskQueue (back-compat)
+    cpuValue: ""             # target CPU utilization % for the cpu trigger; empty = trigger omitted
+    memValue: ""             # target memory utilization % for the memory trigger; empty = trigger omitted
     fallback: {}
     authenticationRef: {}   # in-cluster plaintext temporal needs none; set for Temporal Cloud
   podDisruptionBudget:

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -239,10 +239,11 @@ consumer:
     enabled: false
     minReplicas: 1
     maxReplicas: 10
-    lagThreshold: 1000          # messages of consumer-group lag per replica
+    lagThreshold: 1000          # default messages of consumer-group lag per replica (used as fallback for topics without their own lagThreshold)
     pollingInterval: 15         # seconds between KEDA polls
     cooldownPeriod: 300         # seconds before scaling down to minReplicas
     offsetResetPolicy: "earliest"
+    topics: []                  # list of {topic, lagThreshold} objects, one kafka trigger each; empty = single trigger on kafkaConfig.topic using lagThreshold above (back-compat)
     cpuValue: ""                # target CPU utilization % for the cpu trigger; empty = trigger omitted
     memValue: ""                # target memory utilization % for the memory trigger; empty = trigger omitted
     fallback: {}                # KEDA fallback (e.g. failureThreshold + replicas)

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -301,6 +301,19 @@ worker:
     minReplicas: 1
     maxReplicas: 5
     targetCPUUtilizationPercentage: 70
+  keda:
+    # Temporal task-queue-depth autoscaling for the worker Deployment.
+    # Requires KEDA >= v2.17 (native temporal scaler) installed cluster-wide.
+    # Enable EITHER worker.autoscaling (HPA) OR worker.keda — never both (render fails). Off by default.
+    enabled: false
+    endpoint: "temporal-frontend.temporal.svc:7233"   # in-cluster Temporal frontend gRPC (host:port); override for Temporal Cloud
+    pollingInterval: 15
+    cooldownPeriod: 300
+    minReplicas: 1
+    maxReplicas: 3
+    targetQueueSize: 100    # pending tasks per replica (1->N scaling ratio)
+    fallback: {}
+    authenticationRef: {}   # in-cluster plaintext temporal needs none; set for Temporal Cloud
   podDisruptionBudget:
     enabled: true
     minAvailable: 1


### PR DESCRIPTION
## **User description**
## What
Adds the missing autoscaling chart templates the infra BYOC autoscaling matrix needs.

- **keda-worker.yaml** (new): KEDA ScaledObject, native `temporal` scaler (v2.17+) on task-queue depth, **per-queue** (loops `worker.keda.queues`) + CPU + memory triggers. CHANGELOG claimed this existed; it didn't — now real.
- **keda-api.yaml** (new): KEDA ScaledObject, aws-cloudwatch (ALB RequestCountPerTarget) + CPU + memory.
- **keda-consumer.yaml**: added CPU + memory triggers alongside the existing Kafka-lag trigger (multi-trigger).
- **Single-autoscaler guard**: `{{ fail }}` in every keda template when both `<svc>.autoscaling` (HPA) and `<svc>.keda` are enabled for one workload — prevents two controllers fighting one Deployment.
- Values: `worker.keda.{queues,cpuValue,memValue,...}`, `api.keda.{request,cpuValue,memValue,...}`, `consumer.keda.{cpuValue,memValue}`.

All values-driven, off by default. Uses `temporalConfig.*` (chart has no top-level `temporal:`).

## Verification
helm lint + render proofs: each workload renders a multi-trigger ScaledObject; both-enabled guards fail with the expected message. Per-task + opus whole-branch review clean. Consumes `flexprice-kafka-scram` / `flexprice-aws-cloudwatch` TriggerAuthentications created by the infra side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add cloud-agnostic storage with GCS support and safer managed exports

### What Changed
- Invoice PDFs and data exports can use either AWS S3 or Google Cloud Storage, with automatic cloud detection or an explicit provider setting.
- Customer-owned S3 and GCS connections support encrypted credentials, multiple connections per environment, provider-specific validation, uploads, downloads, and presigned URLs.
- Flexprice-managed storage uses deployment credentials at runtime instead of saving credential snapshots on connection records; managed destinations retain their recorded bucket across configuration changes.
- Managed S3 deployments can use static or ambient AWS credentials, while invalid credential settings and unsupported federation modes fail with actionable errors.
- Storage connections are checked before creation or updates are saved, and invalid storage credentials no longer silently fall back to platform credentials.
- Added GCS URL handling for task files, GCS compression and content types, tenant-isolated object keys, and cloud-specific signer configuration for download links.
- Added KEDA autoscaling templates for Temporal workers and the API, CPU and memory triggers for consumers, and chart validation that prevents HPA and KEDA from controlling the same workload.

### Impact
`✅ GCS-backed invoice PDFs and exports`
`✅ No credential snapshots on managed storage connections`
`✅ Fewer invalid storage connections saved`
`✅ Stable export destinations during bucket rotation`
`✅ Queue- and request-aware autoscaling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional KEDA autoscaling for API, consumer, and worker services.
  * API scaling supports request rate, CPU, and memory metrics.
  * Consumer scaling supports Kafka lag thresholds per topic, plus CPU and memory metrics.
  * Worker scaling supports Temporal task-queue depth, CPU, and memory metrics.
  * Added configurable replica limits, polling intervals, fallback behavior, and authentication settings.

* **Bug Fixes**
  * Added validation to prevent conflicting HPA and KEDA autoscaling configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->