### PR TITLE
chore(ci): add Dependabot config for weekly grouped version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot config.
+# Note: security ALERTS and automatic security-updates are already enabled via
+# repo settings. This file only adds scheduled weekly *version* bumps, grouped
+# into one PR per ecosystem to avoid PR floods.
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      gomod:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      docker:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` enabling scheduled **weekly version updates** for three ecosystems:

- `gomod` (`/` — go.mod)
- `docker` (`/` — root Dockerfile)
- `github-actions` (`/` — workflows)

## Why

Security **alerts** and automatic **security-updates** are already enabled via repo settings. This file adds the missing piece: scheduled version bumps to keep dependencies current.

## Details

- `open-pull-requests-limit: 5` per ecosystem
- Each ecosystem groups all patterns (`["*"]`) into **one grouped PR** to avoid PR floods (one PR per ecosystem per week, not one per dependency).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for Go modules, Docker dependencies, and GitHub Actions.
  * Groups updates by ecosystem and limits the number of open update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->