### PR TITLE
fix(ci): pin trivy-action by digest in publish-app-image

### DIFF
--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -84,7 +84,7 @@ jobs:
             org.opencontainers.image.licenses=AGPL-3.0-only
 
       - name: Trivy vulnerability scan (fail on HIGH/CRITICAL)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
           format: table


### PR DESCRIPTION
## What

Pins `aquasecurity/trivy-action` by immutable digest in `publish-app-image.yml`, matching `publish-e2eprobe-image.yml` which already does.

```diff
- uses: aquasecurity/trivy-action@0.35.0
+ uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
```

## Why

A version tag (`@0.35.0`) is mutable — the tag can be repointed at malicious code (supply-chain risk on third-party actions). The commit digest is immutable. e2eprobe already pins the same version by this digest; this brings app-image in line.

**Same version (v0.35.0), same digest — no behavior change.** Verified both workflows now reference identical digest.

Part of the continuous-security hardening (pin all third-party actions by digest).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved security and build reliability by pinning the vulnerability scan tool to a specific version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->