### PR TITLE
chore: add CODEOWNERS default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — default reviewers for all changes.
+# Team slugs must exist in the flexprice org. Branch protection must have
+# "Require review from Code Owners" enabled for this to gate merges.
+
+*       @flexprice/flexprice-oss-maintainers


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` making `@flexprice/flexprice-oss-maintainers` the default owner of the whole repo, so all PRs request their review.

**Note:** "Require review from Code Owners" must be enabled in `develop` branch protection for this to actually gate merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added default ownership rules for repository changes.
  * Documented the repository settings required for ownership-based review enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->