### PR TITLE
ci: add PR-time Trivy shift-left security scan (soft-fail phase 1)

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -1,0 +1,52 @@
+name: PR Security Scan
+
+# Shift-left security gate. The image scan in publish-app-image.yml only runs on
+# tag push against the built image, so dependency CVEs surface at release and
+# Dockerfile misconfig is never scanned. This runs Trivy at PR time instead:
+#   - trivy fs   -> go.sum dependency CVEs (the shift-left dep-CVE gate)
+#   - trivy config -> Dockerfile / Dockerfile.e2eprobe misconfiguration
+#
+# Phase 1 is soft-fail (exit-code 0): like the Checkov rollout there is likely
+# legacy dep-CVE debt, and a hard gate on day one would block every PR. It
+# reports without failing while the baseline is triaged. Phase 2 flips the
+# `trivy fs` step to exit-code 1 on HIGH/CRITICAL fixable vulns once triage is
+# done; `trivy config` stays soft-fail until the Dockerfile findings are cleared.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy:
+    name: Trivy dependency & config scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # Dependency CVEs from go.sum. Secret/license scanners are disabled
+      # (scanners: vuln) — GitGuardian already owns secret detection, so
+      # running Trivy's secret scanner here would only duplicate findings.
+      # Phase 2: flip exit-code to '1' after the CVE baseline is triaged.
+      - name: Trivy fs scan (Go dependency CVEs)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          format: table
+          exit-code: '0'
+
+      # Dockerfile / IaC misconfiguration (Dockerfile, Dockerfile.e2eprobe).
+      # Stays soft-fail through phase 2 until the findings are cleared.
+      - name: Trivy config scan (Dockerfile misconfig)
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          scan-type: config
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          format: table
+          exit-code: '0'


### PR DESCRIPTION
What & why

Today Trivy only runs in publish-app-image.yml on tag push (v*), scanning the built image. That means dependency CVEs are caught at release, not at merge, and Dockerfile misconfiguration is never scanned at all. This adds a PR-time scan to shift-left.

New workflow .github/workflows/pr-security-scan.yml runs on pull_request only (the tag-push path already does image scanning) and performs two Trivy scans on the repo root:

- trivy fs (scanners: vuln) - scans go.sum for vulnerable Go dependencies. This is the shift-left dep-CVE gate.
- trivy config - scans the Dockerfiles (Dockerfile, Dockerfile.e2eprobe) for misconfiguration.

Phase 1 = soft-fail

Both scans use exit-code: 0 (report, do not fail). Like the Checkov rollout (#309), there is legacy dep-CVE debt; a hard gate on day one would block every PR. Phase 1 establishes visibility while the baseline is triaged.

Phase 2 hardening plan

Once the CVE baseline is triaged, flip the trivy fs step to exit-code: 1 on HIGH/CRITICAL fixable vulns (ignore-unfixed already set), turning it into a real merge gate. trivy config stays soft-fail until the Dockerfile findings are cleared.

Secrets delegated to GitGuardian

The fs scan sets scanners: vuln, disabling Trivy secret/license scanning. GitGuardian already owns secret detection, so this avoids duplicate secret findings.

Details

- Trivy action pinned to the same immutable digest already used in publish-e2eprobe-image.yml: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 (v0.35.0).
- permissions: { contents: read }.
- fs: scan-type fs, severity HIGH,CRITICAL, ignore-unfixed true, format table.
- config: scan-type config, severity HIGH,CRITICAL, format table.

Local verification (Trivy 0.72.0)

- trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed: runs, reports 4 HIGH Go dependency vulns (confirms real debt, validating soft-fail phase 1).
- trivy config: runs, detects and reports both target Dockerfiles (Dockerfile, Dockerfile.e2eprobe), 11 HIGH/CRITICAL misconfigs total.
- Workflow YAML validated (yaml.safe_load OK).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security checks for pull requests.
  * Scans dependencies and Dockerfile configuration for high- and critical-severity vulnerabilities and misconfigurations.
  * Uses read-only repository access during security scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->