### PR TITLE
feat(meter_usage): publish records to analytics lake topic (additive, fire-and-forget)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -125,6 +125,7 @@ func main() {
 			// Producers and Consumers
 			kafka.NewProducer,
 			kafka.NewSecondaryProducer,
+			kafka.NewMeterUsagePublisher,
 			kafka.NewConsumer,
 
 			// Event Publisher

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -314,6 +314,10 @@ type KafkaConfig struct {
 	// TopicBulk is this cluster's batched-ingest topic. Per-cluster because a shared prod
 	// cluster renames topics (FLEXPRICE_KAFKA_TOPICS).
 	TopicBulk string `mapstructure:"topic_bulk"`
+	// LakeTopic, when set, enables an additive fire-and-forget publish of meter_usage records
+	// to this topic after they are written to ClickHouse, so the analytics lake's Iceberg sink
+	// can ingest them. Empty (the default) disables lake publishing entirely (no-op).
+	LakeTopic string `mapstructure:"lake_topic"`
 	// Batching bounds for PublishBatch; a batch closes at whichever is hit first.
 	// BulkMaxBatchBytes must stay under the topic's max.message.bytes (1 MB default on MSK).
 	// Read from the LOCAL cluster only: both clusters must receive byte-identical payloads to

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -44,6 +44,10 @@ kafka:
   topic: "staging_events"
   topic_lazy: "staging_events_lazy"
   topic_bulk: "staging_events_bulk"
+  # lake_topic, when set, additively publishes meter_usage records to this topic after the
+  # ClickHouse write (fire-and-forget) so the analytics lake can ingest them. Empty = disabled.
+  # Enable per deployment via FLEXPRICE_KAFKA_LAKE_TOPIC (e.g. "analytics.meter_usage").
+  lake_topic: ""
   # Batching bounds for the bulk publish path; whichever is hit first closes the batch.
   # Keep bulk_max_batch_bytes under the topic's max.message.bytes (1 MB default on MSK).
   bulk_max_batch_size: 200

--- a/internal/kafka/meter_usage_publisher.go
+++ b/internal/kafka/meter_usage_publisher.go
@@ -1,0 +1,76 @@
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+// MeterUsagePublisher publishes meter_usage records to the analytics lake topic
+// (cfg.Kafka.LakeTopic) AFTER they are written to ClickHouse. It is ADDITIVE and
+// FIRE-AND-FORGET: ClickHouse stays authoritative, so a publish failure here is logged
+// and swallowed — it must never fail the caller or affect billing. Presence-gated: when the
+// lake topic is not configured the fx provider returns nil, and every method is a no-op.
+type MeterUsagePublisher struct {
+	publisher messagePublisher
+	topic     string
+	logger    *logger.Logger
+}
+
+// NewMeterUsagePublisher is the fx provider. It reuses the local-cluster producer that already
+// carries source events. Presence-based: an empty cfg.Kafka.LakeTopic ⇒ nil publisher (no-op),
+// mirroring the KafkaSecondary dual-write gating.
+func NewMeterUsagePublisher(primaryProducer *Producer, cfg *config.Configuration, logger *logger.Logger) *MeterUsagePublisher {
+	if cfg.Kafka.LakeTopic == "" || primaryProducer == nil {
+		return nil
+	}
+	return &MeterUsagePublisher{
+		publisher: primaryProducer,
+		topic:     cfg.Kafka.LakeTopic,
+		logger:    logger,
+	}
+}
+
+// PublishMeterUsage publishes each record to the lake topic as one JSON message keyed by
+// event id (the lake's dedup key). ingested_at is stamped when unset so the lake has a version
+// column. Fire-and-forget: per-record errors are logged, never returned.
+func (p *MeterUsagePublisher) PublishMeterUsage(ctx context.Context, records []*events.MeterUsage) error {
+	// nil publisher (lake not configured) ⇒ no-op.
+	if p == nil || p.publisher == nil {
+		return nil
+	}
+
+	for _, record := range records {
+		// The lake dedups on (id, ingested_at). BulkInsert relies on the ClickHouse DEFAULT for
+		// ingested_at, so records reach here with it zero — stamp it now to give the lake a version.
+		if record.IngestedAt.IsZero() {
+			record.IngestedAt = time.Now().UTC()
+		}
+
+		payload, err := json.Marshal(record)
+		if err != nil {
+			p.logger.Ctx(ctx).With("event_id", record.ID, "error", err).
+				Error("lake meter_usage marshal failed")
+			continue
+		}
+
+		msg := message.NewMessage(record.ID, payload)
+		msg.Metadata.Set("tenant_id", record.TenantID)
+		msg.Metadata.Set("environment_id", record.EnvironmentID)
+
+		if err := p.publisher.Publish(p.topic, msg); err != nil {
+			p.logger.Ctx(ctx).With(
+				"event_id", record.ID,
+				"tenant_id", record.TenantID,
+				"topic", p.topic,
+				"error", err,
+			).Error("lake meter_usage publish failed")
+		}
+	}
+	return nil
+}

--- a/internal/kafka/meter_usage_publisher_test.go
+++ b/internal/kafka/meter_usage_publisher_test.go
@@ -1,0 +1,91 @@
+package kafka
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/shopspring/decimal"
+)
+
+func sampleMeterUsage() *events.MeterUsage {
+	mu := &events.MeterUsage{
+		MeterID:    "meter_1",
+		QtyTotal:   decimal.NewFromInt(5),
+		UniqueHash: "hash_1",
+	}
+	mu.ID = "evt_1"
+	mu.TenantID = "tenant_1"
+	mu.EnvironmentID = "env_1"
+	mu.EventName = "api_call"
+	mu.Timestamp = time.Unix(1700000000, 0).UTC()
+	return mu
+}
+
+// newLakePub builds a MeterUsagePublisher over a fake, on the lake topic.
+func newLakePub(pub messagePublisher) *MeterUsagePublisher {
+	return &MeterUsagePublisher{
+		publisher: pub,
+		topic:     "analytics.meter_usage",
+		logger:    logger.NewNoopLogger(),
+	}
+}
+
+func TestPublishMeterUsage_MarshalsRecordToLakeTopic(t *testing.T) {
+	fake := &fakePublisher{}
+	p := newLakePub(fake)
+
+	if err := p.PublishMeterUsage(context.Background(), []*events.MeterUsage{sampleMeterUsage()}); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if fake.callCount() != 1 {
+		t.Fatalf("expected 1 publish, got %d", fake.callCount())
+	}
+	if fake.topics[0] != "analytics.meter_usage" {
+		t.Fatalf("expected topic analytics.meter_usage, got %q", fake.topics[0])
+	}
+
+	msg := fake.only()
+	if msg == nil {
+		t.Fatal("expected exactly one message")
+	}
+	if msg.UUID != "evt_1" {
+		t.Fatalf("expected message UUID evt_1 (dedup key), got %q", msg.UUID)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(msg.Payload, &got); err != nil {
+		t.Fatalf("payload not JSON: %v", err)
+	}
+	// The lake needs id + ingested_at (version) + meter_id.
+	if got["id"] != "evt_1" {
+		t.Errorf("missing/wrong id: %v", got["id"])
+	}
+	if got["meter_id"] != "meter_1" {
+		t.Errorf("missing/wrong meter_id: %v", got["meter_id"])
+	}
+	if got["ingested_at"] == nil || got["ingested_at"] == "0001-01-01T00:00:00Z" {
+		t.Errorf("ingested_at must be stamped for lake versioning, got %v", got["ingested_at"])
+	}
+}
+
+// Fire-and-forget: a publisher error must NOT propagate out of PublishMeterUsage.
+func TestPublishMeterUsage_SwallowsPublisherError(t *testing.T) {
+	fake := &fakePublisher{err: context.DeadlineExceeded}
+	p := newLakePub(fake)
+
+	if err := p.PublishMeterUsage(context.Background(), []*events.MeterUsage{sampleMeterUsage()}); err != nil {
+		t.Fatalf("publish error must be swallowed (fire-and-forget), got %v", err)
+	}
+}
+
+// A nil (unconfigured) publisher is a no-op, never a panic.
+func TestPublishMeterUsage_NilPublisherIsNoop(t *testing.T) {
+	var p *MeterUsagePublisher
+	if err := p.PublishMeterUsage(context.Background(), []*events.MeterUsage{sampleMeterUsage()}); err != nil {
+		t.Fatalf("nil publisher must be a no-op, got %v", err)
+	}
+}

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/flexprice/flexprice/internal/clickhouse"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/kafka"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
@@ -24,13 +25,25 @@ type MeterUsageRepository struct {
 	store  *clickhouse.ClickHouseStore
 	logger *logger.Logger
 	qb     *MeterUsageQueryBuilder
+	// lakePublisher is optional: when configured, meter_usage records are additively
+	// published to the analytics lake topic after a successful ClickHouse insert.
+	// Nil (the default) disables lake publishing. See BulkInsertMeterUsage.
+	lakePublisher *kafka.MeterUsagePublisher
 }
 
-func NewMeterUsageRepository(store *clickhouse.ClickHouseStore, logger *logger.Logger) events.MeterUsageRepository {
+// NewMeterUsageRepository builds the repository. An optional *kafka.MeterUsagePublisher may be
+// passed to enable additive, fire-and-forget lake publishing; omit it (or pass nil) to disable.
+// It is variadic so existing callers that construct without a publisher keep compiling.
+func NewMeterUsageRepository(store *clickhouse.ClickHouseStore, logger *logger.Logger, lakePublisher ...*kafka.MeterUsagePublisher) events.MeterUsageRepository {
+	var lp *kafka.MeterUsagePublisher
+	if len(lakePublisher) > 0 {
+		lp = lakePublisher[0]
+	}
 	return &MeterUsageRepository{
-		store:  store,
-		logger: logger,
-		qb:     NewMeterUsageQueryBuilder(),
+		store:         store,
+		logger:        logger,
+		qb:            NewMeterUsageQueryBuilder(),
+		lakePublisher: lp,
 	}
 }
 
@@ -94,6 +107,11 @@ func (r *MeterUsageRepository) BulkInsertMeterUsage(ctx context.Context, records
 				Mark(ierr.ErrDatabase)
 		}
 	}
+
+	// Additive, fire-and-forget lake publish AFTER the ClickHouse write commits. ClickHouse
+	// stays authoritative: PublishMeterUsage swallows its own errors, and it is a no-op when
+	// no lake publisher is configured, so this can never fail the insert or affect billing.
+	_ = r.lakePublisher.PublishMeterUsage(ctx, records)
 
 	SetSpanSuccess(span)
 	return nil

--- a/internal/repository/factory.go
+++ b/internal/repository/factory.go
@@ -49,6 +49,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/user"
 	"github.com/flexprice/flexprice/internal/domain/wallet"
 	"github.com/flexprice/flexprice/internal/domain/workflowexecution"
+	"github.com/flexprice/flexprice/internal/kafka"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/postgres"
 	clickhouseRepo "github.com/flexprice/flexprice/internal/repository/clickhouse"
@@ -77,6 +78,9 @@ type RepositoryParams struct {
 	ClickHouseDB  *clickhouse.ClickHouseStore
 	InMemoryCache cache.InMemoryCache
 	RedisCache    cache.RedisCache
+	// MeterUsageLakePublisher is optional: nil unless kafka.lake_topic is configured.
+	// When present, meter_usage records are additively published to the analytics lake.
+	MeterUsageLakePublisher *kafka.MeterUsagePublisher `optional:"true"`
 }
 
 func NewEventRepository(p RepositoryParams) events.Repository {
@@ -288,7 +292,7 @@ func NewCostSheetUsageRepository(p RepositoryParams) events.CostSheetUsageReposi
 }
 
 func NewMeterUsageRepository(p RepositoryParams) events.MeterUsageRepository {
-	return clickhouseRepo.NewMeterUsageRepository(p.ClickHouseDB, p.Logger)
+	return clickhouseRepo.NewMeterUsageRepository(p.ClickHouseDB, p.Logger, p.MeterUsageLakePublisher)
 }
 
 func NewWorkflowExecutionRepository(p RepositoryParams) workflowexecution.Repository {


### PR DESCRIPTION
## What

Publish `meter_usage` records to a Kafka topic (`analytics.meter_usage`) after they're written to ClickHouse, so an analytics lake can ingest them. **Additive, fire-and-forget, dark by default.**

## Why

Feeds an open-format (Iceberg) analytics lake that unifies meter_usage + Postgres dimensions for revenue/usage analytics, shippable as a BYOC feature. This is the app-side hook; the lake infra is separate.

## How

- New `internal/kafka/MeterUsagePublisher` — thin type over the existing `messagePublisher` (reuses the local-cluster producer; the lake is just another topic).
- `MeterUsageRepository.BulkInsertMeterUsage` publishes the same records **after** the CH batch commits.
- **Presence-gated**: `kafka.lake_topic` empty (default) → publisher is `nil` → whole path is a no-op. CH insert runs exactly as before.
- **Fire-and-forget** (correctness boundary, tested): `PublishMeterUsage` never returns a publish error, and the repo discards its return — structurally cannot fail `BulkInsertMeterUsage` or affect billing.
- Constructor made **variadic** → no existing caller breaks; no mock regen needed.
- `ingested_at` stamped in Go at publish time (records rely on the CH DEFAULT) to give the lake a version column.

## Enable

Set `FLEXPRICE_KAFKA_LAKE_TOPIC=analytics.meter_usage`. Unset = dark no-op.

## Tests

`internal/kafka/meter_usage_publisher_test.go` — topic+payload marshal, fire-and-forget error-swallow, nil no-op. All pass.

## Risk

Ships dark; zero behavior change until the env var is set. A lake-publish failure is logged and swallowed, never propagated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
