### PR TITLE
feat(reprocess): enforce event_timestamp immutability per event_id (R1 guard)

### DIFF
--- a/internal/api/dto/events.go
+++ b/internal/api/dto/events.go
@@ -25,9 +25,18 @@ import (
 
 type IngestEventRequest struct {
 	EventName          string                 `json:"event_name" validate:"required" binding:"required" example:"api_request" csv:"event_name"`
+	// EventID is the caller's idempotency key. CONTRACT: unique per logical event, and IMMUTABLE
+	// once sent — never reuse an event_id for a different event, and never resend the same event_id
+	// with a different timestamp. Events dedup on (event_id, timestamp) in both ClickHouse
+	// (ReplacingMergeTree, ORDER BY ...timestamp,id) and the analytics lake; a reused event_id with
+	// a changed timestamp is treated as a NEW event and double-counts. Reprocessing enforces this
+	// (rejects a timestamp change); recon flags any event_id seen under two timestamps. Omit to have
+	// one generated.
 	EventID            string                 `json:"event_id" example:"event123" csv:"event_id"`
 	CustomerID         string                 `json:"customer_id" example:"customer456" csv:"customer_id"`
 	ExternalCustomerID string                 `json:"external_customer_id" validate:"required" binding:"required" example:"customer456" csv:"external_customer_id"`
+	// Timestamp is the event's business time. IMMUTABLE per event_id (see EventID) — part of the
+	// dedup identity, so changing it for an existing event_id creates a duplicate.
 	Timestamp          time.Time              `json:"timestamp" example:"2024-03-20T15:04:05Z" csv:"-"` // Handled separately due to parsing
 	TimestampStr       string                 `json:"-" csv:"timestamp"`                                // Used for CSV parsing
 	Source             string                 `json:"source" example:"api" csv:"source"`

--- a/internal/ee/service/raw_events_reprocessing.go
+++ b/internal/ee/service/raw_events_reprocessing.go
@@ -40,6 +40,7 @@ type ReprocessRawEventsResult struct {
 	TotalEventsFailed         int `json:"total_events_failed"`
 	TotalEventsDropped        int `json:"total_events_dropped"`        // Events that failed validation
 	TotalTransformationErrors int `json:"total_transformation_errors"` // Events that errored during transformation
+	TotalR1Violations         int `json:"total_r1_violations"`         // R1: reprocess changed event_timestamp for an existing event_id (skipped, not published)
 	ProcessedBatches          int `json:"processed_batches"`
 }
 
@@ -151,6 +152,7 @@ func (s *rawEventsReprocessingService) ReprocessRawEvents(ctx context.Context, p
 		batchTransformErrors := 0
 		batchPublished := 0
 		batchPublishFailed := 0
+		batchR1Violations := 0
 
 		// Transform each event individually to track which ones fail
 		for i, rawEvent := range rawEvents {
@@ -189,6 +191,27 @@ func (s *rawEventsReprocessingService) ReprocessRawEvents(ctx context.Context, p
 				continue
 			}
 
+			// R1 correctness guard: event_timestamp is immutable per event_id.
+			// A republish that changes the business timestamp for an existing
+			// event_id double-counts in the lake (dedup partitions on id+timestamp,
+			// so a changed timestamp is a NEW identity → both rows survive).
+			// Skip + count it; do NOT fail the batch (mirror the per-event skip idiom).
+			if transformedEvent.ID != "" && !transformedEvent.Timestamp.Equal(rawEvent.Timestamp) {
+				batchR1Violations++
+				result.TotalR1Violations++
+				s.Logger.Error(ctx, "R1 violation - event_timestamp changed for existing event_id, publish skipped",
+					"raw_event_id", rawEvent.ID,
+					"event_id", transformedEvent.ID,
+					"original_timestamp", rawEvent.Timestamp,
+					"transformed_timestamp", transformedEvent.Timestamp,
+					"event_name", transformedEvent.EventName,
+					"external_customer_id", transformedEvent.ExternalCustomerID,
+					"batch", result.ProcessedBatches,
+					"batch_position", i+1,
+				)
+				continue
+			}
+
 			// Publish the transformed event
 			if err := s.publishEvent(ctx, transformedEvent); err != nil {
 				batchPublishFailed++
@@ -218,6 +241,7 @@ func (s *rawEventsReprocessingService) ReprocessRawEvents(ctx context.Context, p
 			"dropped", batchDropped,
 			"transform_errors", batchTransformErrors,
 			"publish_failed", batchPublishFailed,
+			"r1_violations", batchR1Violations,
 			"total_found", result.TotalEventsFound,
 			"total_published", result.TotalEventsPublished,
 		)
@@ -254,6 +278,7 @@ func (s *rawEventsReprocessingService) ReprocessRawEvents(ctx context.Context, p
 		"total_published", result.TotalEventsPublished,
 		"total_dropped", result.TotalEventsDropped,
 		"total_failed", result.TotalEventsFailed,
+		"total_r1_violations", result.TotalR1Violations,
 		"success_rate_pct", fmt.Sprintf("%.2f", successRate),
 	)
 

--- a/internal/ee/service/raw_events_reprocessing_test.go
+++ b/internal/ee/service/raw_events_reprocessing_test.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+type RawEventsReprocessingSuite struct {
+	testutil.BaseServiceTestSuite
+	svc     *rawEventsReprocessingService
+	pubSub  *testutil.InMemoryPubSub
+	rawRepo *fakeRawEventRepo
+	topic   string
+}
+
+func TestRawEventsReprocessingService(t *testing.T) {
+	suite.Run(t, new(RawEventsReprocessingSuite))
+}
+
+func (s *RawEventsReprocessingSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+
+	s.pubSub = testutil.NewInMemoryPubSub()
+	s.rawRepo = &fakeRawEventRepo{}
+	s.topic = "prod_events_v4"
+
+	params := ServiceParams{
+		Logger:       s.GetLogger(),
+		Config:       s.GetConfig(),
+		DB:           s.GetDB(),
+		RawEventRepo: s.rawRepo,
+	}
+	s.GetConfig().RawEventsReprocessing.OutputTopic = s.topic
+
+	s.svc = &rawEventsReprocessingService{
+		ServiceParams: params,
+		rawEventRepo:  s.rawRepo,
+		pubSub:        s.pubSub,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fake RawEventRepository — returns one batch of crafted raw events, then empty.
+// ---------------------------------------------------------------------------
+
+type fakeRawEventRepo struct {
+	batch  []*events.RawEvent
+	served bool
+}
+
+func (f *fakeRawEventRepo) FindRawEvents(ctx context.Context, params *events.FindRawEventsParams) ([]*events.RawEvent, error) {
+	if f.served {
+		return nil, nil
+	}
+	f.served = true
+	return f.batch, nil
+}
+
+func (f *fakeRawEventRepo) FindUnprocessedRawEvents(ctx context.Context, params *events.FindRawEventsParams) ([]*events.RawEvent, *events.KeysetCursor, error) {
+	if f.served {
+		return nil, nil, nil
+	}
+	f.served = true
+	return f.batch, nil, nil
+}
+
+// bentoPayload builds a minimal valid Bento payload whose createdAt (which the
+// transformer maps to Event.Timestamp) is `createdAt`.
+func bentoPayload(eventID, createdAt string) string {
+	return `{"orgId":"` + testTenantID + `","id":"` + eventID +
+		`","methodName":"CHAT_COMPLETION","providerName":"openai","createdAt":"` + createdAt + `"}`
+}
+
+// rawEvent crafts a RawEvent whose DB Timestamp column is `ts`, wrapping a
+// payload whose createdAt is `payloadCreatedAt` (drives the transformed ts).
+func (s *RawEventsReprocessingSuite) rawEvent(id string, ts time.Time, payloadCreatedAt string) *events.RawEvent {
+	return &events.RawEvent{
+		ID:                 id,
+		TenantID:           testTenantID,
+		EnvironmentID:      testEnvironmentID,
+		ExternalCustomerID: "cust_1",
+		EventName:          "chat",
+		Payload:            bentoPayload(id, payloadCreatedAt),
+		Timestamp:          ts,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// R1 guard tests
+// ---------------------------------------------------------------------------
+
+// Healthy reprocess: RawEvent.Timestamp matches the payload createdAt that the
+// transformer produces → guard is a no-op → event is published normally.
+func (s *RawEventsReprocessingSuite) TestReprocess_TimestampUnchanged_Publishes() {
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	s.rawRepo.batch = []*events.RawEvent{
+		s.rawEvent("evt_healthy", ts, "2024-01-15T10:00:00Z"),
+	}
+
+	res, err := s.svc.ReprocessRawEvents(context.Background(), &events.ReprocessRawEventsParams{
+		BatchSize: 100,
+	})
+	require.NoError(s.T(), err)
+
+	require.Equal(s.T(), 1, res.TotalEventsPublished, "healthy event must be published")
+	require.Equal(s.T(), 0, res.TotalR1Violations, "no R1 violation expected")
+	require.Len(s.T(), s.pubSub.GetMessages(s.topic), 1, "exactly one message published")
+}
+
+// R1 violation: same event_id, but reprocessing produces a DIFFERENT timestamp
+// than the original RawEvent.Timestamp → skip publish + count violation.
+func (s *RawEventsReprocessingSuite) TestReprocess_TimestampChanged_SkippedAndCounted() {
+	origTs := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	s.rawRepo.batch = []*events.RawEvent{
+		// original ts is 10:00, but the payload createdAt (transformed ts) is 11:00
+		s.rawEvent("evt_violation", origTs, "2024-01-15T11:00:00Z"),
+	}
+
+	res, err := s.svc.ReprocessRawEvents(context.Background(), &events.ReprocessRawEventsParams{
+		BatchSize: 100,
+	})
+	require.NoError(s.T(), err, "batch must not fail — violation is per-event skip")
+
+	require.Equal(s.T(), 1, res.TotalR1Violations, "one R1 violation expected")
+	require.Equal(s.T(), 0, res.TotalEventsPublished, "violating event must NOT be published")
+	require.Len(s.T(), s.pubSub.GetMessages(s.topic), 0, "nothing published")
+}

--- a/internal/temporal/activities/events/reprocess_raw_events_activity.go
+++ b/internal/temporal/activities/events/reprocess_raw_events_activity.go
@@ -100,6 +100,7 @@ func (a *ReprocessRawEventsActivities) ReprocessRawEvents(ctx context.Context, i
 		"total_events_dropped", result.TotalEventsDropped,
 		"total_transformation_errors", result.TotalTransformationErrors,
 		"total_events_failed", result.TotalEventsFailed,
+		"total_r1_violations", result.TotalR1Violations,
 		"processed_batches", result.ProcessedBatches)
 
 	// Map service result to workflow result
@@ -108,6 +109,7 @@ func (a *ReprocessRawEventsActivities) ReprocessRawEvents(ctx context.Context, i
 	response.TotalEventsFailed = result.TotalEventsFailed
 	response.TotalEventsDropped = result.TotalEventsDropped
 	response.TotalTransformationErrors = result.TotalTransformationErrors
+	response.TotalR1Violations = result.TotalR1Violations
 	response.ProcessedBatches = result.ProcessedBatches
 
 	return response, nil

--- a/internal/temporal/models/events/reprocess_raw_events.go
+++ b/internal/temporal/models/events/reprocess_raw_events.go
@@ -61,6 +61,7 @@ type ReprocessRawEventsWorkflowResult struct {
 	TotalEventsFailed         int       `json:"total_events_failed"`
 	TotalEventsDropped        int       `json:"total_events_dropped"`        // Events that failed validation
 	TotalTransformationErrors int       `json:"total_transformation_errors"` // Events that errored during transformation
+	TotalR1Violations         int       `json:"total_r1_violations"`         // R1: reprocess changed event_timestamp for an existing event_id (skipped, not published)
 	ProcessedBatches          int       `json:"processed_batches"`
 	CompletedAt               time.Time `json:"completed_at"`
 }

--- a/internal/temporal/workflows/events/reprocess_raw_events_workflow.go
+++ b/internal/temporal/workflows/events/reprocess_raw_events_workflow.go
@@ -70,6 +70,7 @@ func ReprocessRawEventsWorkflow(ctx workflow.Context, input models.ReprocessRawE
 		"total_events_dropped", result.TotalEventsDropped,
 		"total_transformation_errors", result.TotalTransformationErrors,
 		"total_events_failed", result.TotalEventsFailed,
+		"total_r1_violations", result.TotalR1Violations,
 		"processed_batches", result.ProcessedBatches)
 
 	result.CompletedAt = workflow.Now(ctx)


### PR DESCRIPTION
## What

Enforce **`event_timestamp` immutability per `event_id`** in the raw-events reprocess path: a republish must not change the business timestamp of an existing event.

## Why (R1)

A live dedup test on the analytics lake proved a real double-count: if an event is republished with the same `event_id` but a **changed** `event_timestamp`, the lake's Iceberg dedup keys on `(id, timestamp)`, so the changed timestamp becomes a **new identity** — both copies survive and `sum(qty)` over-counts. No lake-side fix is possible; the guard must be producer-side. First-time ingest can't violate this (nothing to mutate) — the only place a republish happens is reprocessing.

## How

In `ReprocessRawEvents`, right before re-publishing each transformed event:

```go
if transformedEvent.ID != "" && !transformedEvent.Timestamp.Equal(rawEvent.Timestamp) {
    // R1 violation: skip publish, count it, log ERROR
    continue
}
```

- `.Equal()` (not `==`) — monotonic/location-safe; fires only on a genuine instant difference.
- Mirrors the existing per-event skip idiom (`continue` + counter) — **does not fail the batch**.
- Adds `TotalR1Violations` to `ReprocessRawEventsResult`, surfaced in batch/final summary logs and the Temporal workflow result.
- **No DB lookup** — both timestamps are already in hand (original `rawEvent` + candidate `transformedEvent`). Off the hot path.

Normal reprocessing (timestamp unchanged) is a **no-op** — the transformer derives `Timestamp` from the same source, so `.Equal()` is true and it publishes exactly as before.

## Tests

`raw_events_reprocessing_test.go` (TDD):
- `TestReprocess_TimestampUnchanged_Publishes` — healthy → published, `r1_violations=0`.
- `TestReprocess_TimestampChanged_SkippedAndCounted` — mutated ts → skipped, `r1_violations=1`, 0 published.

Both pass. Build clean on touched packages.

## Companion

The lake recon (infra) gets an R1 detector — any `event_id` under >1 `timestamp` → MISMATCH alert — to catch anything that bypasses this guard (e.g. a direct producer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Raw event reprocessing now detects timestamp mismatches for existing events.
  - Mismatched events are skipped instead of being published.
  - Processing results and completion logs now report the number of detected violations.

- **Documentation**
  - Clarified event ID uniqueness, timestamp immutability, deduplication, reprocessing behavior, and generated IDs.

- **Tests**
  - Added coverage confirming valid events are published and mismatched events are skipped and counted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->