### PR TITLE
refactor(meter_usage): move lake publish from CH repo to service layer

### DIFF
--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/events"
 	"github.com/flexprice/flexprice/internal/domain/meter"
 	"github.com/flexprice/flexprice/internal/expression"
+	kafkaPkg "github.com/flexprice/flexprice/internal/kafka"
 	"github.com/flexprice/flexprice/internal/pubsub"
 	"github.com/flexprice/flexprice/internal/pubsub/kafka"
 	pubsubRouter "github.com/flexprice/flexprice/internal/pubsub/router"
@@ -55,17 +56,23 @@ type meterUsageTrackingService struct {
 	bulkPubSub          pubsub.PubSub
 	meterUsageRepo      events.MeterUsageRepository
 	expressionEvaluator expression.Evaluator
+	// lakePublisher is optional (nil unless kafka.lake_topic is configured). When set,
+	// meter_usage records are additively published to the analytics lake AFTER a
+	// successful ClickHouse insert. fx injects it from the graph; nil = no-op.
+	lakePublisher *kafkaPkg.MeterUsagePublisher
 }
 
 // NewMeterUsageTrackingService creates a new meter usage tracking service
 func NewMeterUsageTrackingService(
 	params ServiceParams,
 	meterUsageRepo events.MeterUsageRepository,
+	lakePublisher *kafkaPkg.MeterUsagePublisher,
 ) MeterUsageTrackingService {
 	svc := &meterUsageTrackingService{
 		ServiceParams:       params,
 		meterUsageRepo:      meterUsageRepo,
 		expressionEvaluator: expression.NewCELEvaluator(),
+		lakePublisher:       lakePublisher,
 	}
 
 	ps, err := kafka.NewPubSubFromConfig(
@@ -347,6 +354,11 @@ func (s *meterUsageTrackingService) processBulkMessage(ctx context.Context, msg 
 		return fmt.Errorf("bulk insert meter usage: %w", err)
 	}
 
+	// Additive, fire-and-forget lake publish AFTER the ClickHouse write commits. ClickHouse
+	// stays authoritative: PublishMeterUsage swallows its own errors and is a no-op when no
+	// lake publisher is configured, so this can never fail the insert or affect billing.
+	_ = s.lakePublisher.PublishMeterUsage(ctx, records)
+
 	s.Logger.Debug(ctx, "bulk meter usage batch inserted",
 		"record_count", len(records),
 		"batch_size", len(batch.Events),
@@ -505,6 +517,11 @@ func (s *meterUsageTrackingService) processEvent(ctx context.Context, event *eve
 	if err := s.meterUsageRepo.BulkInsertMeterUsage(ctx, records); err != nil {
 		return fmt.Errorf("failed to bulk insert meter usage: %w", err)
 	}
+
+	// Additive, fire-and-forget lake publish AFTER the ClickHouse write commits. ClickHouse
+	// stays authoritative: PublishMeterUsage swallows its own errors and is a no-op when no
+	// lake publisher is configured, so this can never fail the insert or affect billing.
+	_ = s.lakePublisher.PublishMeterUsage(ctx, records)
 
 	s.Logger.Debug(ctx, "meter usage records inserted",
 		"event_id", event.ID,

--- a/internal/repository/clickhouse/meter_usage.go
+++ b/internal/repository/clickhouse/meter_usage.go
@@ -10,7 +10,6 @@ import (
 	"github.com/flexprice/flexprice/internal/clickhouse"
 	"github.com/flexprice/flexprice/internal/domain/events"
 	ierr "github.com/flexprice/flexprice/internal/errors"
-	"github.com/flexprice/flexprice/internal/kafka"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/samber/lo"
@@ -25,25 +24,15 @@ type MeterUsageRepository struct {
 	store  *clickhouse.ClickHouseStore
 	logger *logger.Logger
 	qb     *MeterUsageQueryBuilder
-	// lakePublisher is optional: when configured, meter_usage records are additively
-	// published to the analytics lake topic after a successful ClickHouse insert.
-	// Nil (the default) disables lake publishing. See BulkInsertMeterUsage.
-	lakePublisher *kafka.MeterUsagePublisher
 }
 
-// NewMeterUsageRepository builds the repository. An optional *kafka.MeterUsagePublisher may be
-// passed to enable additive, fire-and-forget lake publishing; omit it (or pass nil) to disable.
-// It is variadic so existing callers that construct without a publisher keep compiling.
-func NewMeterUsageRepository(store *clickhouse.ClickHouseStore, logger *logger.Logger, lakePublisher ...*kafka.MeterUsagePublisher) events.MeterUsageRepository {
-	var lp *kafka.MeterUsagePublisher
-	if len(lakePublisher) > 0 {
-		lp = lakePublisher[0]
-	}
+// NewMeterUsageRepository builds the repository. This is a strictly-DB layer: analytics-lake
+// publishing lives in the service layer (meterUsageTrackingService), not here.
+func NewMeterUsageRepository(store *clickhouse.ClickHouseStore, logger *logger.Logger) events.MeterUsageRepository {
 	return &MeterUsageRepository{
-		store:         store,
-		logger:        logger,
-		qb:            NewMeterUsageQueryBuilder(),
-		lakePublisher: lp,
+		store:  store,
+		logger: logger,
+		qb:     NewMeterUsageQueryBuilder(),
 	}
 }
 
@@ -107,11 +96,6 @@ func (r *MeterUsageRepository) BulkInsertMeterUsage(ctx context.Context, records
 				Mark(ierr.ErrDatabase)
 		}
 	}
-
-	// Additive, fire-and-forget lake publish AFTER the ClickHouse write commits. ClickHouse
-	// stays authoritative: PublishMeterUsage swallows its own errors, and it is a no-op when
-	// no lake publisher is configured, so this can never fail the insert or affect billing.
-	_ = r.lakePublisher.PublishMeterUsage(ctx, records)
 
 	SetSpanSuccess(span)
 	return nil

--- a/internal/repository/factory.go
+++ b/internal/repository/factory.go
@@ -292,7 +292,7 @@ func NewCostSheetUsageRepository(p RepositoryParams) events.CostSheetUsageReposi
 }
 
 func NewMeterUsageRepository(p RepositoryParams) events.MeterUsageRepository {
-	return clickhouseRepo.NewMeterUsageRepository(p.ClickHouseDB, p.Logger, p.MeterUsageLakePublisher)
+	return clickhouseRepo.NewMeterUsageRepository(p.ClickHouseDB, p.Logger)
 }
 
 func NewWorkflowExecutionRepository(p RepositoryParams) workflowexecution.Repository {


### PR DESCRIPTION
## What
Follow-up to #2658. That PR wired the analytics-lake publish **inside** the ClickHouse repository (`MeterUsageRepository.BulkInsertMeterUsage` calls `PublishMeterUsage` after the CH write). A DB repository publishing to Kafka mixes layers — the repo should be strictly-DB.

This moves the publish **up into the service layer** (`meterUsageTrackingService`), so the service orchestrates both as siblings:
```
service (meter_usage_tracking)
   ├─→ CH repository   : only writes ClickHouse  (zero kafka refs now)
   └─→ Kafka publisher : only publishes to the lake
```

## Changes (3 files)
- `repository/clickhouse/meter_usage.go` — drop the `lakePublisher` field + variadic constructor param + the in-repo publish line + unused `kafka` import. Constructor is back to `NewMeterUsageRepository(store, logger)`.
- `repository/factory.go` — `NewMeterUsageRepository(p)` no longer passes the publisher.
- `ee/service/meter_usage_tracking.go` — publisher added as a constructor param (fx auto-injects by type from the existing graph); publish fire-and-forget after **both** successful `BulkInsertMeterUsage` calls.

## Behavior
Identical end-to-end: meter_usage still lands in CH, still publishes to the lake when configured, nil publisher = no-op (dark-gated default). Only the layer performing the publish changed.

## Verification
- CH repo: 0 kafka references (grep-confirmed).
- Service publishes after both insert sites.
- Build + `internal/repository/clickhouse` + `internal/ee/service` tests: PASS.
- `events.MeterUsageRepository` interface unchanged → no mock regen needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meter usage records are now published to the analytics lake after successful single or bulk processing.
  * Publishing occurs asynchronously, so analytics delivery does not delay or prevent successful usage recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->