### PR TITLE
fix(subscriptions): honour bucket_size on line item price override

### DIFF
--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -137,6 +137,10 @@ type UpdateSubscriptionLineItemRequest struct {
 	// TransformQuantity determines how to transform the quantity for this line item
 	TransformQuantity *price.TransformQuantity `json:"transform_quantity,omitempty"`
 
+	// BucketSize overrides the windowing used to turn this meter's usage into
+	// billable units for this line item. See CreatePriceRequest.BucketSize.
+	BucketSize types.WindowSize `json:"bucket_size,omitempty"`
+
 	// Metadata for the new line item
 	Metadata map[string]string `json:"metadata,omitempty"`
 
@@ -584,7 +588,7 @@ func (r *UpdateSubscriptionLineItemRequest) Validate() error {
 	// If EffectiveFrom is provided, at least one critical field must be present
 	if r.EffectiveFrom != nil && !r.ShouldCreateNewLineItem() {
 		return ierr.NewError("effective_from requires at least one critical field").
-			WithHint("When providing effective_from, you must also provide one of: amount, billing_model, tier_mode, tiers, transform_quantity, or commitment fields").
+			WithHint("When providing effective_from, you must also provide one of: amount, billing_model, tier_mode, tiers, transform_quantity, bucket_size, or commitment fields").
 			Mark(ierr.ErrValidation)
 	}
 
@@ -779,6 +783,7 @@ func (r *UpdateSubscriptionLineItemRequest) ShouldCreateNewLineItem() bool {
 		r.TierMode != "" ||
 		len(r.Tiers) > 0 ||
 		r.TransformQuantity != nil ||
+		r.BucketSize != "" ||
 		r.HasCommitment() ||
 		r.CommitmentOverageFactor != nil ||
 		r.CommitmentTrueUpEnabled != nil ||

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -519,6 +519,7 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			TierMode:          req.TierMode,
 			Tiers:             req.Tiers,
 			TransformQuantity: req.TransformQuantity,
+			BucketSize:        req.BucketSize,
 		}
 
 		priceMap := map[string]*dto.PriceResponse{existingLineItem.PriceID: price}


### PR DESCRIPTION
## Summary
`PUT /v1/subscriptions/lineitems/:id` silently dropped `bucket_size`: `UpdateSubscriptionLineItemRequest` had no such field, so Go's JSON binding discarded it before it ever reached the price-override logic — even though the plumbing underneath (`OverrideLineItemRequest.BucketSize`, already consumed by `ProcessSubscriptionPriceOverrides`) has supported it since price-level bucketing landed (#2609). The frontend's `UpdateSubscriptionLineItemRequest` type already documents this as working ("same new-price/end-date-old-price semantics as `UpdatePriceRequest.bucket_size`"), confirming this was an intended feature that never got wired up on this one endpoint, not a deliberate omission.

Repro (confirmed via live requests against api-dev):
```
PUT /v1/subscriptions/lineitems/{id}
{"bucket_size":"DAY","commitment_windowed":false,"commitment_time_buckets":[]}
```
→ 200, a new subscription-scoped line item/price *is* created (correctly, since `commitment_windowed`/`commitment_time_buckets` trigger the successor path), but `bucket_size` is silently ignored — the new price never gets it.

## Fix
- Added `BucketSize types.WindowSize` to `UpdateSubscriptionLineItemRequest`.
- Wired it into `ShouldCreateNewLineItem()` so setting it takes the same successor-price path as `amount`/`billing_model`/`tiers`.
- Passed it through to `OverrideLineItemRequest.BucketSize` in `UpdateSubscriptionLineItem`, reusing the existing (already-working) `ProcessSubscriptionPriceOverrides` consumption — no new price-creation logic needed.

## Test plan
- [x] `go build ./internal/api/dto/... ./internal/ee/service/...`
- [x] `go test ./internal/ee/service/... -run TestSubscriptionLineItem` — all passing (no regressions)
- [ ] Manual: `PUT /v1/subscriptions/lineitems/{id}` with `bucket_size` and confirm the resulting price reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription line-item updates now support changing the bucket size.
  * Bucket-size changes take effect from the selected effective date.
  * Updating the bucket size creates a new line item and preserves the updated pricing override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->