### PR TITLE
fix(subscriptions): honour bucket_size on line item update, and validate buckets when it changes

### DIFF
--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -592,6 +592,15 @@ func (r *UpdateSubscriptionLineItemRequest) Validate() error {
 			Mark(ierr.ErrValidation)
 	}
 
+	// BucketSizeNone is the explicit-clear sentinel, not a window, so it skips the
+	// enum check. Validating here stops a bad window reaching the price layer,
+	// where it surfaces only after the override has already been built.
+	if r.BucketSize != "" && r.BucketSize != BucketSizeNone {
+		if err := r.BucketSize.Validate(); err != nil {
+			return err
+		}
+	}
+
 	// Validate commitment fields if provided
 	if err := r.validateCommitmentFields(); err != nil {
 		return err

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -137,6 +137,10 @@ type UpdateSubscriptionLineItemRequest struct {
 	// TransformQuantity determines how to transform the quantity for this line item
 	TransformQuantity *price.TransformQuantity `json:"transform_quantity,omitempty"`
 
+	// BucketSize overrides the windowing used to turn this meter's usage into
+	// billable units for this line item. See CreatePriceRequest.BucketSize.
+	BucketSize types.WindowSize `json:"bucket_size,omitempty"`
+
 	// Metadata for the new line item
 	Metadata map[string]string `json:"metadata,omitempty"`
 
@@ -584,7 +588,7 @@ func (r *UpdateSubscriptionLineItemRequest) Validate() error {
 	// If EffectiveFrom is provided, at least one critical field must be present
 	if r.EffectiveFrom != nil && !r.ShouldCreateNewLineItem() {
 		return ierr.NewError("effective_from requires at least one critical field").
-			WithHint("When providing effective_from, you must also provide one of: amount, billing_model, tier_mode, tiers, transform_quantity, or commitment fields").
+			WithHint("When providing effective_from, you must also provide one of: amount, billing_model, tier_mode, tiers, transform_quantity, bucket_size, or commitment fields").
 			Mark(ierr.ErrValidation)
 	}
 
@@ -779,6 +783,7 @@ func (r *UpdateSubscriptionLineItemRequest) ShouldCreateNewLineItem() bool {
 		r.TierMode != "" ||
 		len(r.Tiers) > 0 ||
 		r.TransformQuantity != nil ||
+		r.BucketSize != "" ||
 		r.HasCommitment() ||
 		r.CommitmentOverageFactor != nil ||
 		r.CommitmentTrueUpEnabled != nil ||

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -576,7 +576,8 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			// misses `{"bucket_size": "FIFTEEN_MIN"}` on a line item whose
 			// hour-aligned buckets are inherited by ToSubscriptionLineItem — the
 			// window narrows and the stale buckets carry over unchecked.
-			if (req.CommitmentTimeBuckets != nil || req.BucketSize != "") && len(newLineItem.CommitmentTimeBuckets) > 0 {
+			// validateBucketArray no-ops on an empty bucket array.
+			if req.CommitmentTimeBuckets != nil || req.BucketSize != "" {
 				_, _, hasCumulative := getSubscriptionCommitmentPeriodBounds(sub, sub.CurrentPeriodStart)
 				if err := s.validateBucketArray(ctx, newLineItem.MeterID, newLineItem.PriceID, newLineItem.CommitmentWindowed, hasCumulative, newLineItem.CommitmentTimeBuckets); err != nil {
 					return err

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -519,6 +519,7 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			TierMode:          req.TierMode,
 			Tiers:             req.Tiers,
 			TransformQuantity: req.TransformQuantity,
+			BucketSize:        req.BucketSize,
 		}
 
 		priceMap := map[string]*dto.PriceResponse{existingLineItem.PriceID: price}

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -576,8 +576,7 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			// misses `{"bucket_size": "FIFTEEN_MIN"}` on a line item whose
 			// hour-aligned buckets are inherited by ToSubscriptionLineItem — the
 			// window narrows and the stale buckets carry over unchecked.
-			// validateBucketArray no-ops on an empty bucket array.
-			if req.CommitmentTimeBuckets != nil || req.BucketSize != "" {
+			if (req.CommitmentTimeBuckets != nil || req.BucketSize != "") && len(newLineItem.CommitmentTimeBuckets) > 0 {
 				_, _, hasCumulative := getSubscriptionCommitmentPeriodBounds(sub, sub.CurrentPeriodStart)
 				if err := s.validateBucketArray(ctx, newLineItem.MeterID, newLineItem.PriceID, newLineItem.CommitmentWindowed, hasCumulative, newLineItem.CommitmentTimeBuckets); err != nil {
 					return err

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -568,6 +568,15 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 				if err := s.createBucketPrices(ctx, newLineItem.ID, existingLineItem.SubscriptionID, *req.CommitmentTimeBuckets, newLineItem.CommitmentTimeBuckets, existingLineItem.CommitmentTimeBuckets); err != nil {
 					return err
 				}
+			}
+
+			// Buckets are validated against the window they will actually bill in,
+			// so re-check whenever EITHER input moved: the buckets themselves, or
+			// the bucket size they must align to. Validating only on resent buckets
+			// misses `{"bucket_size": "FIFTEEN_MIN"}` on a line item whose
+			// hour-aligned buckets are inherited by ToSubscriptionLineItem — the
+			// window narrows and the stale buckets carry over unchecked.
+			if (req.CommitmentTimeBuckets != nil || req.BucketSize != "") && len(newLineItem.CommitmentTimeBuckets) > 0 {
 				_, _, hasCumulative := getSubscriptionCommitmentPeriodBounds(sub, sub.CurrentPeriodStart)
 				if err := s.validateBucketArray(ctx, newLineItem.MeterID, newLineItem.PriceID, newLineItem.CommitmentWindowed, hasCumulative, newLineItem.CommitmentTimeBuckets); err != nil {
 					return err


### PR DESCRIPTION
Supersedes #2663 — includes @dskhairnar's commit unchanged, plus two follow-ups found while reviewing it. Opened here rather than as suggestions on #2663 because that branch is on a fork.

## What #2663 fixes (Dinesh's commit, carried over as-is)

`bucket_size` was wired into price create, price update, and subscription-create `override_line_items`, but **not** `PUT /v1/subscriptions/lineitems/:id`. So a bucket could be set on a plan price or at subscription create, but never changed on an existing line item.

It adds the field to `UpdateSubscriptionLineItemRequest`, counts it in `ShouldCreateNewLineItem()`, and passes it through to `UpdatePriceRequest` — reusing the terminate-and-recreate versioning rather than mutating an immutable column.

## Follow-up 1: stale buckets when only `bucket_size` changes

`validateBucketArray` ran only when `commitment_time_buckets` were resent. Omitting that field *inherits* the existing buckets via `ToSubscriptionLineItem`, so:

```
PUT /v1/subscriptions/lineitems/:id
{ "bucket_size": "FIFTEEN_MIN", "effective_from": "..." }
```

on a line item whose buckets are aligned to `HOUR` re-versions the price to a narrower window and carries the hour-aligned buckets across **unvalidated**. `validateLineItemCommitment` does not catch it — it asserts that *a* bucket size exists, not that the buckets align to it.

Fix: re-check whenever either input moved — the buckets, or the size they must align to. `createBucketPrices` still runs only on resent buckets. The `len(...) > 0` guard keeps it a no-op for line items with no buckets, so unrelated updates are unaffected.

Scoped deliberately to "buckets or bucket_size changed" rather than "always validate when buckets exist". Always-validate is stricter and would also catch pre-existing misaligned data, but it would start rejecting unrelated updates (e.g. an amount change on a line item with historically-misaligned buckets) — a behaviour change beyond this PR.

The clearing case was already safe: `bucket_size: "none"` with `commitment_windowed: true` is caught by `validateLineItemCommitment`'s "window commitment requires a bucket size" branch.

### Related

The frontend has the same defect, flagged by CodeRabbit on flexprice/flexprice-front#1272 — `PriceOverrideDialog.tsx:256-279` and `subscription_line_item_commitment_helpers.ts:361-375` both validate and normalize time buckets against the pre-change bucket size. Fixing only the FE would not have closed this.

## Follow-up 2: validate the window value

`UpdateSubscriptionLineItemRequest.Validate()` did not call `BucketSize.Validate()`, unlike `CreatePriceRequest`. A bad window fell through to the price layer — still caught, but with a worse error and after the override had already been built. `BucketSizeNone` skips the enum check, since it is the explicit-clear sentinel rather than a window.

## Testing

`go build ./internal/...`, `go vet ./internal/...`, gofmt clean; `internal/ee/service` and `internal/api/dto` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Subscription line-item updates now support overriding the bucket size.
  - Bucket size changes are applied to related price overrides.
- **Validation Improvements**
  - Bucket sizes are validated during updates, including when existing bucket settings are retained.
  - Bucket and bucket-size changes are checked together to help prevent invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->