### PR TITLE
feat(wallets): add optional per-tenant free credit grant cap

### DIFF
--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -364,6 +364,8 @@ func (s *settingsService) GetSettingByKeyUnchecked(ctx context.Context, key type
 		return getSettingByKey[types.DraftInvoiceRecomputeConfig](s, ctx, key)
 	case types.SettingKeySAMLConfig:
 		return getSettingByKey[types.SAMLConfig](s, ctx, key)
+	case types.SettingKeyWalletTopupConfig:
+		return getSettingByKey[types.WalletTopupConfig](s, ctx, key)
 	default:
 		return nil, ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).
@@ -420,6 +422,8 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 		return updateSettingByKey[types.DraftInvoiceRecomputeConfig](s, ctx, key, req)
 	case types.SettingKeySAMLConfig:
 		return updateSettingByKey[types.SAMLConfig](s, ctx, key, req)
+	case types.SettingKeyWalletTopupConfig:
+		return updateSettingByKey[types.WalletTopupConfig](s, ctx, key, req)
 	default:
 		return nil, ierr.NewErrorf("unknown setting key: %s", key).
 			WithHintf("Unknown setting key: %s", key).

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -588,6 +588,28 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 			Mark(ierr.ErrValidation)
 	}
 
+	// Enforce org-level free credit limit per transaction.
+	if req.TransactionReason == types.TransactionReasonFreeCredit {
+		settingsSvc := &settingsService{ServiceParams: s.ServiceParams}
+		topupCfg, err := GetSetting[types.WalletTopupConfig](settingsSvc, ctx, types.SettingKeyWalletTopupConfig)
+		if err != nil {
+			return nil, err
+		}
+		if topupCfg.FreeCreditLimitPerTransaction.IsPositive() {
+			// currency amount = credits * topup_conversion_rate
+			txAmountInCurrency := req.CreditsToAdd.Mul(w.TopupConversionRate)
+			if txAmountInCurrency.GreaterThan(topupCfg.FreeCreditLimitPerTransaction) {
+				return nil, ierr.NewError("free credit amount exceeds the per-transaction limit").
+					WithHint("Reduce the credit amount to stay within the configured limit").
+					WithReportableDetails(map[string]interface{}{
+						"requested_amount": txAmountInCurrency,
+						"limit":            topupCfg.FreeCreditLimitPerTransaction,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+		}
+	}
+
 	// Resolve bonus credits from the tenant's slab config when the caller didn't pass an
 	// explicit override. Only "purchased" (paid) top-up reasons trigger slab resolution;
 	// req.BonusCreditsToAdd is mutated in place so every downstream step just reads it.

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -589,7 +589,7 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 	}
 
 	if req.TransactionReason == types.TransactionReasonFreeCredit {
-		settingsSvc := &settingsService{ServiceParams: s.ServiceParams}
+		settingsSvc := NewSettingsService(s.ServiceParams).(*settingsService)
 		topupCfg, err := GetSetting[types.WalletTopupConfig](settingsSvc, ctx, types.SettingKeyWalletTopupConfig)
 		if err != nil {
 			return nil, err

--- a/internal/ee/service/wallet.go
+++ b/internal/ee/service/wallet.go
@@ -588,7 +588,6 @@ func (s *walletService) TopUpWallet(ctx context.Context, walletID string, req *d
 			Mark(ierr.ErrValidation)
 	}
 
-	// Enforce org-level free credit limit per transaction.
 	if req.TransactionReason == types.TransactionReasonFreeCredit {
 		settingsSvc := &settingsService{ServiceParams: s.ServiceParams}
 		topupCfg, err := GetSetting[types.WalletTopupConfig](settingsSvc, ctx, types.SettingKeyWalletTopupConfig)

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -3596,7 +3596,7 @@ func (s *WalletServiceSuite) TestBonusCreditsTopupConfig_APIDispatch() {
 }
 
 func (s *WalletServiceSuite) seedFreeCreditLimit(limit decimal.Decimal) {
-	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+	svc := NewSettingsService(s.service.(*walletService).ServiceParams).(*settingsService)
 	s.NoError(UpdateSetting(svc, s.GetContext(), types.SettingKeyWalletTopupConfig, types.WalletTopupConfig{
 		FreeCreditLimitPerTransaction: limit,
 	}))
@@ -3606,7 +3606,7 @@ func (s *WalletServiceSuite) seedFreeCreditLimit(limit decimal.Decimal) {
 // be registered in — types.ValidateSettingValue plus the service's Get/Update dispatchers — none
 // of which the generic GetSetting/UpdateSetting helpers exercise.
 func (s *WalletServiceSuite) TestWalletTopupConfig_APIDispatch() {
-	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+	svc := NewSettingsService(s.service.(*walletService).ServiceParams)
 
 	updateResp, err := svc.UpdateSettingByKey(s.GetContext(), types.SettingKeyWalletTopupConfig, &dto.UpdateSettingRequest{
 		Value: map[string]interface{}{"free_credit_limit_per_transaction": "500"},
@@ -3620,7 +3620,7 @@ func (s *WalletServiceSuite) TestWalletTopupConfig_APIDispatch() {
 }
 
 func (s *WalletServiceSuite) TestWalletTopupConfig_RejectsNegativeLimit() {
-	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+	svc := NewSettingsService(s.service.(*walletService).ServiceParams)
 
 	_, err := svc.UpdateSettingByKey(s.GetContext(), types.SettingKeyWalletTopupConfig, &dto.UpdateSettingRequest{
 		Value: map[string]interface{}{"free_credit_limit_per_transaction": "-1"},

--- a/internal/ee/service/wallet_test.go
+++ b/internal/ee/service/wallet_test.go
@@ -3595,6 +3595,77 @@ func (s *WalletServiceSuite) TestBonusCreditsTopupConfig_APIDispatch() {
 	s.Equal(true, getResp.Value["enabled"])
 }
 
+func (s *WalletServiceSuite) seedFreeCreditLimit(limit decimal.Decimal) {
+	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+	s.NoError(UpdateSetting(svc, s.GetContext(), types.SettingKeyWalletTopupConfig, types.WalletTopupConfig{
+		FreeCreditLimitPerTransaction: limit,
+	}))
+}
+
+// TestWalletTopupConfig_APIDispatch covers the three separate switches a new setting key has to
+// be registered in — types.ValidateSettingValue plus the service's Get/Update dispatchers — none
+// of which the generic GetSetting/UpdateSetting helpers exercise.
+func (s *WalletServiceSuite) TestWalletTopupConfig_APIDispatch() {
+	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+
+	updateResp, err := svc.UpdateSettingByKey(s.GetContext(), types.SettingKeyWalletTopupConfig, &dto.UpdateSettingRequest{
+		Value: map[string]interface{}{"free_credit_limit_per_transaction": "500"},
+	})
+	s.NoError(err, "UpdateSettingByKey must recognize wallet_topup_config")
+	s.Equal(types.SettingKeyWalletTopupConfig, updateResp.Key)
+
+	getResp, err := svc.GetSettingByKey(s.GetContext(), types.SettingKeyWalletTopupConfig)
+	s.NoError(err, "GetSettingByKey must recognize wallet_topup_config")
+	s.Equal("500", fmt.Sprint(getResp.Value["free_credit_limit_per_transaction"]))
+}
+
+func (s *WalletServiceSuite) TestWalletTopupConfig_RejectsNegativeLimit() {
+	svc := &settingsService{ServiceParams: s.service.(*walletService).ServiceParams}
+
+	_, err := svc.UpdateSettingByKey(s.GetContext(), types.SettingKeyWalletTopupConfig, &dto.UpdateSettingRequest{
+		Value: map[string]interface{}{"free_credit_limit_per_transaction": "-1"},
+	})
+	s.ErrorContains(err, "cannot be negative", "a negative limit must be rejected on its own merits")
+}
+
+func (s *WalletServiceSuite) TestFreeCreditLimit_DefaultIsUnlimited() {
+	_, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(100000),
+		TransactionReason: types.TransactionReasonFreeCredit,
+		IdempotencyKey:    lo.ToPtr("free_credit_default_unlimited"),
+	})
+	s.NoError(err, "the default limit of 0 must leave free credits uncapped")
+}
+
+func (s *WalletServiceSuite) TestFreeCreditLimit_EnforcedPerTransaction() {
+	s.seedFreeCreditLimit(decimal.NewFromInt(500))
+
+	_, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(501),
+		TransactionReason: types.TransactionReasonFreeCredit,
+		IdempotencyKey:    lo.ToPtr("free_credit_over_limit"),
+	})
+	s.Error(err, "501 must be rejected against a 500 limit")
+
+	_, err = s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(500),
+		TransactionReason: types.TransactionReasonFreeCredit,
+		IdempotencyKey:    lo.ToPtr("free_credit_at_limit"),
+	})
+	s.NoError(err, "the limit itself must be allowed")
+}
+
+func (s *WalletServiceSuite) TestFreeCreditLimit_DoesNotCapOtherReasons() {
+	s.seedFreeCreditLimit(decimal.NewFromInt(500))
+
+	_, err := s.service.TopUpWallet(s.GetContext(), s.testData.wallet.ID, &dto.TopUpWalletRequest{
+		CreditsToAdd:      decimal.NewFromInt(5000),
+		TransactionReason: types.TransactionReasonPurchasedCreditDirect,
+		IdempotencyKey:    lo.ToPtr("purchased_above_free_limit"),
+	})
+	s.NoError(err, "the free credit cap must not apply to purchased credits")
+}
+
 func (s *WalletServiceSuite) bonusTxByParent(parentID string) *wallet.Transaction {
 	filter := types.NewNoLimitWalletTransactionFilter()
 	filter.WalletID = &s.testData.wallet.ID

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -33,6 +33,7 @@ const (
 	SettingKeyPaymentMandateLimits        SettingKey = "payment_mandate_limits"
 	SettingKeyDraftInvoiceRecomputeConfig SettingKey = "draft_invoice_recompute_config"
 	SettingKeySAMLConfig                  SettingKey = "saml_config"
+	SettingKeyWalletTopupConfig           SettingKey = "wallet_topup_config"
 )
 
 func (s *SettingKey) Validate() error {
@@ -52,6 +53,7 @@ func (s *SettingKey) Validate() error {
 		SettingKeyPaymentMandateLimits,
 		SettingKeyDraftInvoiceRecomputeConfig,
 		SettingKeySAMLConfig,
+		SettingKeyWalletTopupConfig,
 	}
 
 	if !lo.Contains(allowedKeys, *s) {
@@ -511,6 +513,23 @@ func (c DraftInvoiceRecomputeConfig) Validate() error {
 	return nil
 }
 
+// WalletTopupConfig holds org-level guard rails for wallet top-up operations.
+type WalletTopupConfig struct {
+	// FreeCreditLimitPerTransaction is the maximum currency amount allowed for a single
+	// FREE_CREDIT_GRANT transaction. Zero or negative means no limit is enforced.
+	FreeCreditLimitPerTransaction decimal.Decimal `json:"free_credit_limit_per_transaction" swaggertype:"string"`
+}
+
+// Validate implements SettingConfig.
+func (c WalletTopupConfig) Validate() error {
+	if c.FreeCreditLimitPerTransaction.IsNegative() {
+		return ierr.NewError("free_credit_limit_per_transaction cannot be negative").
+			WithHint("Set to zero to disable the limit, or provide a positive value").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
 // GetDefaultSettings returns the default settings configuration for all setting keys
 // Uses typed structs and converts them to maps using ToMap utility from conversion.go
 func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
@@ -693,6 +712,14 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 		return nil, err
 	}
 
+	defaultWalletTopupConfig := WalletTopupConfig{
+		FreeCreditLimitPerTransaction: decimal.Zero,
+	}
+	defaultWalletTopupConfigMap, err := utils.ToMap(defaultWalletTopupConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	return map[SettingKey]DefaultSettingValue{
 		SettingKeyInvoiceConfig: {
 			Key:          SettingKeyInvoiceConfig,
@@ -774,6 +801,11 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 			Key:          SettingKeyDraftInvoiceRecomputeConfig,
 			DefaultValue: defaultDraftInvoiceRecomputeConfigMap,
 			Description:  "Gates the daily draft-and-compute job: when enabled, every active subscription's current-period draft invoice is created if missing and recomputed once per day (never finalized)",
+		},
+		SettingKeyWalletTopupConfig: {
+			Key:          SettingKeyWalletTopupConfig,
+			DefaultValue: defaultWalletTopupConfigMap,
+			Description:  "Org-level guard rails for wallet top-up operations (e.g. free credit limit per transaction)",
 		},
 	}, nil
 }
@@ -907,6 +939,13 @@ func ValidateSettingValue(key SettingKey, value map[string]interface{}) error {
 		// rules that matter (certificate parses, identity provider is https,
 		// role is one a user may actually hold) live in the SAML package.
 		return validateSAMLConfig(value)
+
+	case SettingKeyWalletTopupConfig:
+		config, err := utils.ToStruct[WalletTopupConfig](value)
+		if err != nil {
+			return err
+		}
+		return config.Validate()
 
 	default:
 		return ierr.NewErrorf("unknown setting key: %s", key).

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -513,10 +513,10 @@ func (c DraftInvoiceRecomputeConfig) Validate() error {
 	return nil
 }
 
-// WalletTopupConfig holds org-level guard rails for wallet top-up operations.
+// WalletTopupConfig holds guard rails for wallet top-up operations.
 type WalletTopupConfig struct {
 	// FreeCreditLimitPerTransaction is the maximum currency amount allowed for a single
-	// FREE_CREDIT_GRANT transaction. Zero or negative means no limit is enforced.
+	// FREE_CREDIT_GRANT transaction. Zero means no limit is enforced.
 	FreeCreditLimitPerTransaction decimal.Decimal `json:"free_credit_limit_per_transaction" swaggertype:"string"`
 }
 
@@ -805,7 +805,7 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 		SettingKeyWalletTopupConfig: {
 			Key:          SettingKeyWalletTopupConfig,
 			DefaultValue: defaultWalletTopupConfigMap,
-			Description:  "Org-level guard rails for wallet top-up operations (e.g. free credit limit per transaction)",
+			Description:  "Guard rails for wallet top-up operations (e.g. free credit limit per transaction)",
 		},
 	}, nil
 }


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
## Summary
- Add `wallet_topup_config.free_credit_limit_per_transaction` so each tenant can cap a single `FREE_CREDIT_GRANT` top-up.
- Default is `0` (no cap). Tenants with no setting keep current behavior until they set a positive value.
- Enforce the cap in `TopUpWallet` only for `FREE_CREDIT_GRANT`. Purchased credits, subscription credit grants, refunds, and auto-topup are unchanged.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added configurable per-transaction limits for free-credit wallet top-ups.
- Limits are managed through wallet top-up settings and default to unlimited.
- Purchased-credit top-ups remain unaffected.

## Bug Fixes

- Invalid negative limits are rejected.
- Free-credit top-ups exceeding the configured limit are blocked with a validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->