### PR TITLE
ci(deploy): deploy ECS app services from GHCR; drop ECR build/push

### DIFF
--- a/.github/actions/deploy-ecs-service/action.yml
+++ b/.github/actions/deploy-ecs-service/action.yml
@@ -14,11 +14,18 @@ inputs:
     description: 'ECS service name to deploy'
     required: true
   image:
-    description: 'Docker image to deploy (e.g. ECR URI:tag)'
+    description: 'Docker image to deploy (GHCR or ECR URI:tag)'
     required: true
   ecr_repo_prefix:
-    description: 'ECR repository prefix for matching container images to update'
+    description: 'ECR repository prefix — matches the app container to update, and also matches taskdefs still on the old ECR image so the cutover is idempotent'
     required: true
+  ghcr_repo_prefix:
+    description: 'GHCR repository prefix (e.g. ghcr.io/owner/flexprice) — matches taskdefs already migrated to GHCR so redeploys stay idempotent'
+    required: true
+  ghcr_credentials_arn:
+    description: 'Secrets Manager ARN of the GHCR pull credentials. Injected as repositoryCredentials when the deployed image is a private GHCR image; required for Fargate to pull it.'
+    required: false
+    default: ''
   dry_run:
     description: 'If true, only print plan and do not register/update'
     required: true
@@ -35,6 +42,8 @@ runs:
         SERVICE: ${{ inputs.service_name }}
         IMAGE: ${{ inputs.image }}
         ECR_REPO_PREFIX: ${{ inputs.ecr_repo_prefix }}
+        GHCR_REPO_PREFIX: ${{ inputs.ghcr_repo_prefix }}
+        GHCR_CREDENTIALS_ARN: ${{ inputs.ghcr_credentials_arn }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         set -euo pipefail
@@ -66,15 +75,33 @@ runs:
           exit 0
         fi
 
-        # Pass image and ecr_repo_prefix via env so they never appear in script/logs
-        NEW_TASK_DEF=$(echo "$TASK_DEF" | ECR_REPO_PREFIX="$ECR_REPO_PREFIX" IMAGE="$IMAGE" python3 -c "
+        # Pass values via env so they never appear in the script text or logs
+        NEW_TASK_DEF=$(echo "$TASK_DEF" \
+          | ECR_REPO_PREFIX="$ECR_REPO_PREFIX" \
+            GHCR_REPO_PREFIX="$GHCR_REPO_PREFIX" \
+            GHCR_CREDENTIALS_ARN="$GHCR_CREDENTIALS_ARN" \
+            IMAGE="$IMAGE" python3 -c "
         import json, sys, os
         ecr_prefix = os.environ['ECR_REPO_PREFIX']
+        ghcr_prefix = os.environ['GHCR_REPO_PREFIX']
+        ghcr_creds = os.environ.get('GHCR_CREDENTIALS_ARN', '')
         new_image = os.environ['IMAGE']
+        new_is_ghcr = new_image.startswith(ghcr_prefix)
         td = json.load(sys.stdin)
         for c in td.get('containerDefinitions', []):
-            if c.get('image', '').startswith(ecr_prefix):
+            cur = c.get('image', '')
+            # Match the app container whether it is still on ECR or already on GHCR,
+            # so this rewrite is idempotent in both directions during/after cutover.
+            if cur.startswith(ecr_prefix) or cur.startswith(ghcr_prefix):
                 c['image'] = new_image
+                if new_is_ghcr:
+                    # Private GHCR package -> Fargate needs pull credentials.
+                    if not ghcr_creds:
+                        sys.exit('GHCR image requires ghcr_credentials_arn but none was provided')
+                    c['repositoryCredentials'] = {'credentialsParameter': ghcr_creds}
+                else:
+                    # Deploying an ECR image (e.g. rollback) -> drop any GHCR creds.
+                    c.pop('repositoryCredentials', None)
         for f in [
             'taskDefinitionArn', 'revision', 'status',
             'requiresAttributes', 'compatibilities',

--- a/.github/actions/run-ecs-migration/action.yml
+++ b/.github/actions/run-ecs-migration/action.yml
@@ -31,6 +31,13 @@ inputs:
   ecr_repo_prefix:
     description: 'ECR repository prefix identifying the application container'
     required: true
+  ghcr_repo_prefix:
+    description: 'GHCR repository prefix (e.g. ghcr.io/owner/flexprice) — matches taskdefs already migrated to GHCR so the container is found post-cutover'
+    required: true
+  ghcr_credentials_arn:
+    description: 'Secrets Manager ARN of the GHCR pull credentials. Injected as repositoryCredentials when the migration image is a private GHCR image; required for Fargate to pull it.'
+    required: false
+    default: ''
   dry_run:
     description: 'If true, print the plan and do not run anything'
     required: true
@@ -51,6 +58,8 @@ runs:
         SERVICE: ${{ inputs.service_name }}
         IMAGE: ${{ inputs.image }}
         ECR_REPO_PREFIX: ${{ inputs.ecr_repo_prefix }}
+        GHCR_REPO_PREFIX: ${{ inputs.ghcr_repo_prefix }}
+        GHCR_CREDENTIALS_ARN: ${{ inputs.ghcr_credentials_arn }}
         DRY_RUN: ${{ inputs.dry_run }}
         TIMEOUT_MINUTES: ${{ inputs.timeout_minutes }}
       run: |
@@ -96,17 +105,33 @@ runs:
         # role, log configuration -- comes across unchanged. Sidecars are dropped:
         # a log shipper or proxy has nothing to do here and would keep the task
         # RUNNING after the migration container exits, so the task never stops.
-        NEW_TASK_DEF=$(echo "$TASK_DEF" | ECR_REPO_PREFIX="$ECR_REPO_PREFIX" IMAGE="$IMAGE" python3 -c "
+        NEW_TASK_DEF=$(echo "$TASK_DEF" \
+          | ECR_REPO_PREFIX="$ECR_REPO_PREFIX" \
+            GHCR_REPO_PREFIX="$GHCR_REPO_PREFIX" \
+            GHCR_CREDENTIALS_ARN="$GHCR_CREDENTIALS_ARN" \
+            IMAGE="$IMAGE" python3 -c "
         import json, sys, os
-        ecr_prefix = os.environ['ECR_REPO_PREFIX']
-        new_image  = os.environ['IMAGE']
+        ecr_prefix  = os.environ['ECR_REPO_PREFIX']
+        ghcr_prefix = os.environ['GHCR_REPO_PREFIX']
+        ghcr_creds  = os.environ.get('GHCR_CREDENTIALS_ARN', '')
+        new_image   = os.environ['IMAGE']
+        new_is_ghcr = new_image.startswith(ghcr_prefix)
         td = json.load(sys.stdin)
 
-        app = [c for c in td.get('containerDefinitions', []) if c.get('image','').startswith(ecr_prefix)]
+        # Match whether the service is still on ECR or already cut over to GHCR.
+        app = [c for c in td.get('containerDefinitions', [])
+               if c.get('image','').startswith(ecr_prefix) or c.get('image','').startswith(ghcr_prefix)]
         if len(app) != 1:
-            sys.exit('expected exactly one container matching the ECR prefix, found %d' % len(app))
+            sys.exit('expected exactly one container matching the ECR/GHCR prefix, found %d' % len(app))
         c = app[0]
         c['image'] = new_image
+        if new_is_ghcr:
+            # Private GHCR package -> Fargate needs pull credentials.
+            if not ghcr_creds:
+                sys.exit('GHCR image requires ghcr_credentials_arn but none was provided')
+            c['repositoryCredentials'] = {'credentialsParameter': ghcr_creds}
+        else:
+            c.pop('repositoryCredentials', None)
         c['essential'] = True
         # dependsOn would reference sidecars that no longer exist in this task.
         c.pop('dependsOn', None)
@@ -196,11 +221,13 @@ runs:
         # Print the migration's own output. Without this a failure shows only an
         # exit code, and the message that says which migration broke -- or that the
         # database was never adopted -- stays in CloudWatch where nobody looks.
-        LOG_CFG=$(echo "$TASK_DEF" | ECR_REPO_PREFIX="$ECR_REPO_PREFIX" python3 -c "
+        LOG_CFG=$(echo "$TASK_DEF" | ECR_REPO_PREFIX="$ECR_REPO_PREFIX" GHCR_REPO_PREFIX="$GHCR_REPO_PREFIX" python3 -c "
         import json, sys, os
+        ecr_prefix  = os.environ['ECR_REPO_PREFIX']
+        ghcr_prefix = os.environ['GHCR_REPO_PREFIX']
         td = json.load(sys.stdin)
         for c in td['containerDefinitions']:
-            if c.get('image','').startswith(os.environ['ECR_REPO_PREFIX']):
+            if c.get('image','').startswith(ecr_prefix) or c.get('image','').startswith(ghcr_prefix):
                 o = (c.get('logConfiguration') or {}).get('options', {})
                 print(o.get('awslogs-group',''))
                 print(o.get('awslogs-stream-prefix',''))

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,10 +152,12 @@ jobs:
       - name: Set image output
         id: set-image
         env:
-          ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
-          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
           GITHUB_SHA: ${{ github.sha }}
-        run: echo "image=${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+        # ECS now deploys the GHCR image (same immutable :<sha> the build job pushed
+        # to GHCR alongside ECR). ECR is still pushed for cache/rollback; the deploy
+        # target is GHCR. The composite action injects repositoryCredentials for it.
+        run: echo "image=${GHCR_IMAGE}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
   # ──────────────────────────────────────────────────────────────────────────
   # Job 2: Resolve deployment targets (production only)
@@ -384,8 +386,10 @@ jobs:
           cluster: ${{ matrix.target.cluster }}
           region: ${{ matrix.target.region }}
           service_name: ${{ matrix.target.preprod_service }}
-          image: ${{ needs.build.outputs.image || format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, github.sha) }}
+          image: ${{ needs.build.outputs.image || format('{0}:{1}', env.GHCR_IMAGE, github.sha) }}
           ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
+          ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
           dry_run: ${{ needs.resolve-config.outputs.dry_run }}
 
   # ──────────────────────────────────────────────────────────────────────────
@@ -508,8 +512,10 @@ jobs:
           cluster: ${{ matrix.target.cluster }}
           region: ${{ matrix.target.region }}
           service_name: ${{ matrix.target.api_service }}
-          image: ${{ needs.build.outputs.image || format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, github.sha) }}
+          image: ${{ needs.build.outputs.image || format('{0}:{1}', env.GHCR_IMAGE, github.sha) }}
           ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
+          ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
           dry_run: ${{ needs.resolve-config.outputs.dry_run }}
 
   deploy-consumer:
@@ -545,8 +551,10 @@ jobs:
           cluster: ${{ matrix.target.cluster }}
           region: ${{ matrix.target.region }}
           service_name: ${{ matrix.target.consumer_service }}
-          image: ${{ needs.build.outputs.image || format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, github.sha) }}
+          image: ${{ needs.build.outputs.image || format('{0}:{1}', env.GHCR_IMAGE, github.sha) }}
           ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
+          ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
           dry_run: ${{ needs.resolve-config.outputs.dry_run }}
 
   deploy-worker:
@@ -582,6 +590,8 @@ jobs:
           cluster: ${{ matrix.target.cluster }}
           region: ${{ matrix.target.region }}
           service_name: ${{ matrix.target.worker_service }}
-          image: ${{ needs.build.outputs.image || format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, github.sha) }}
+          image: ${{ needs.build.outputs.image || format('{0}:{1}', env.GHCR_IMAGE, github.sha) }}
           ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
+          ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
           dry_run: ${{ needs.resolve-config.outputs.dry_run }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -309,6 +309,8 @@ jobs:
           service_name: ${{ matrix.target.api_service }}
           image: ${{ needs.build.outputs.image || format('{0}:{1}', env.GHCR_IMAGE, github.sha) }}
           ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
+          ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
           dry_run: ${{ needs.resolve-config.outputs.dry_run }}
 
   # ──────────────────────────────────────────────────────────────────────────

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,7 @@ jobs:
         env:
           GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
           GITHUB_SHA: ${{ github.sha }}
-        run: echo "image=${GHCR_IMAGE}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
+        run: echo "image=${GHCR_IMAGE}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
   # ──────────────────────────────────────────────────────────────────────────
   # Job 2: Resolve deployment targets (production only)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ env:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────────
-  # Job 1: Build the Docker image and push it to ECR
+  # Job 1: Build the Docker image and push it to GHCR
   # Skipped on dry-run dispatches (no code change, no reason to rebuild)
   # ──────────────────────────────────────────────────────────────────────────
   build:
@@ -58,15 +58,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-cicd
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
-
       - name: Login to GitHub Container Registry
         # Best-effort on non-main branches; REQUIRED on main — GCP prod deploys off
         # the GHCR :<sha> this pushes (promoted to :main post-approval), so a GHCR
@@ -81,17 +72,12 @@ jobs:
       - name: Prepare image tags
         id: image-tag
         env:
-          ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
-          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          echo "ecr_tag=${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
-          # legacy output used by deploy jobs
-          echo "tag=${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
-
+          IS_DEVELOP="${{ github.ref_name == 'develop' }}"
           IS_MAIN="${{ github.ref_name == 'main' }}"
           IS_DEVELOP="${{ github.ref_name == 'develop' }}"
 
@@ -118,27 +104,8 @@ jobs:
             echo "platforms=linux/arm64" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build & push image to ECR
-        id: build-ecr
+      - name: Build & push image to GHCR
         uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: Dockerfile
-          platforms: ${{ steps.image-tag.outputs.platforms }}
-          push: true
-          tags: ${{ steps.image-tag.outputs.ecr_tag }}
-          provenance: false
-          # Shared layer cache in GHCR (both AWS + GCP self-hosted runners reach it).
-          # First build of a commit populates it; rebuilds and the GHCR step below hit it.
-          cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache
-          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache,mode=max
-
-      - name: Push image to GHCR
-        uses: docker/build-push-action@v7
-        # Best-effort on non-main branches; REQUIRED on main — GCP prod deploys off
-        # the GHCR :<sha> this pushes (promoted to :main post-approval), so a GHCR
-        # failure on main must fail the build, not slip through silently.
-        continue-on-error: ${{ github.ref_name != 'main' }}
         with:
           context: .
           file: Dockerfile
@@ -146,17 +113,15 @@ jobs:
           push: true
           tags: ${{ steps.image-tag.outputs.ghcr_tags }}
           provenance: false
-          # Reuses the cache the ECR build just populated -> all layers hit, no rebuild.
+          # Shared layer cache in GHCR (both AWS + GCP self-hosted runners reach it).
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache,mode=max
 
       - name: Set image output
         id: set-image
         env:
           GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
           GITHUB_SHA: ${{ github.sha }}
-        # ECS now deploys the GHCR image (same immutable :<sha> the build job pushed
-        # to GHCR alongside ECR). ECR is still pushed for cache/rollback; the deploy
-        # target is GHCR. The composite action injects repositoryCredentials for it.
         run: echo "image=${GHCR_IMAGE}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
   # ──────────────────────────────────────────────────────────────────────────
@@ -342,7 +307,7 @@ jobs:
           cluster: ${{ matrix.target.cluster }}
           region: ${{ matrix.target.region }}
           service_name: ${{ matrix.target.api_service }}
-          image: ${{ needs.build.outputs.image || format('{0}/{1}:{2}', env.ECR_REGISTRY, env.ECR_REPOSITORY, github.sha) }}
+          image: ${{ needs.build.outputs.image || format('{0}:{1}', env.GHCR_IMAGE, github.sha) }}
           ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
           dry_run: ${{ needs.resolve-config.outputs.dry_run }}
 


### PR DESCRIPTION
## What

Point the ECS deploy pipeline at the **GHCR** app image and stop building/pushing to ECR entirely. GHCR is now the single registry for the pipeline-managed services in `PROD_DEPLOY_TARGETS` (api, consumer, worker, preprod).

## Why

The `build` job already pushed to GHCR alongside ECR, and every other deployment (GCP ArgoCD) pulls GHCR. ECR was only still the ECS deploy target and a redundant second push. This unifies on one registry and drops the ECR build, push, and AWS/ECR login from the build job.

## Changes

- **`deploy.yml` build job**:
  - Builds and pushes the app image to **GHCR only** (`ghcr.io/<owner>/flexprice:<sha>`, plus `:develop` on develop, `:<tag>`/`:latest` on release). The GHCR push now owns the shared buildcache.
  - Removed: AWS OIDC config + ECR login steps, the ECR build-push step, and the `ecr_tag`/`tag` outputs that only fed it.
  - The GHCR push is now **required on every branch** (no `continue-on-error`) — the deploy step has no ECR image to fall back to.
- **`deploy.yml` deploy jobs** deploy the GHCR `:<sha>`; the composite action injects `repositoryCredentials` (private GHCR pull creds) for it.
- **`deploy-ecs-service` composite action** (unchanged from prior revision):
  - Matches the app container whether it is on **ECR or GHCR** → redeploys/rollbacks of task defs still on a pre-cutover ECR image stay idempotent.
  - Injects `repositoryCredentials` for a GHCR image; **drops** them for an ECR image.
  - **Hard-fails** if a GHCR image is deployed without `ghcr_credentials_arn`.
  - Input `ghcr_credentials_arn` <- `vars.ECS_GHCR_PULL_CREDENTIALS_ARN`.

## Prerequisites

- Repo var `ECS_GHCR_PULL_CREDENTIALS_ARN` points at the Secrets Manager entry holding the GHCR pull credentials.
- Task execution role already grants read on that secret path — no IAM change.
- GHCR app image is multi-arch (amd64+arm64); task definitions are ARM64 — arch match OK.

## Rollback

No new ECR images are built after this change, so the "deploy an ECR `:<sha>`" path is gone. To roll back:

- Roll the ECS service back to a **prior task-definition revision** (pre-cutover revisions still reference their ECR image and are all still registered — the composite action drops the GHCR creds automatically when it sees an ECR image), **or**
- Redeploy an **older GHCR `:<sha>`** that is still present in the registry.

## Test

Composite-action taskdef-rewrite logic self-checked (5 cases): ECR→GHCR swap+creds, GHCR→GHCR idempotent, GHCR→ECR rollback drops creds, missing-creds hard fail, sidecar container untouched. All pass. `deploy.yml` validated as YAML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment workflows now support container images hosted in GHCR.
  * Private GHCR images can use configured repository credentials during application and migration deployments.
  * Deployments automatically update containers using either GHCR or ECR image references.
  * Container builds now publish deployment images to GHCR.
  * Pushes to the `develop` branch publish a GHCR image without triggering ECS deployments.

* **Bug Fixes**
  * GHCR credentials are validated when required and removed when deploying ECR images.
  * Deployment image selection now consistently falls back to the GHCR image tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->