### PR TITLE
feat(helm): optional bento collector deployment

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-bento.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-bento.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.bento.enabled }}
+{{- /*
+  Bento collector — optional stream collector (Kafka/MSK -> in-cluster Flexprice
+  API). Not a Flexprice binary: runs its own image + config, so it does NOT use
+  flexprice.env or the app configmap. It reuses the shared flexprice-secrets
+  Secret for MSK SCRAM creds (kafka-sasl-username / kafka-sasl-password) and
+  POSTs events to the in-cluster api Service so ingest never leaves the cluster.
+*/ -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "flexprice.fullname" . }}-bento
+  labels:
+    {{- include "flexprice.componentLabels" (dict "ctx" . "component" "bento") | nindent 4 }}
+spec:
+  replicas: {{ .Values.bento.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "flexprice.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: bento
+  template:
+    metadata:
+      annotations:
+        checksum/secret: {{ include "flexprice/templates/app/secret.yaml" . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "flexprice.componentPodLabels" (dict "ctx" . "component" "bento") | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "flexprice.componentServiceAccountName" (dict "ctx" . "component" "bento") }}
+      {{- with .Values.bento.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: bento
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.bento.image.digest }}
+          image: "{{ .Values.bento.image.repository }}@{{ .Values.bento.image.digest }}"
+          {{- else }}
+          image: "{{ .Values.bento.image.repository }}:{{ .Values.bento.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.bento.image.pullPolicy }}
+          args:
+            - "-c"
+            - {{ .Values.bento.configPath | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.bento.httpPort }}
+              protocol: TCP
+          env:
+            # In-cluster Flexprice API target — no external egress hop.
+            - name: FLEXPRICE_API_HOST
+              value: {{ .Values.bento.apiHost | default (printf "%s-api" (include "flexprice.fullname" .)) | quote }}
+            - name: FLEXPRICE_SCHEME
+              value: {{ .Values.bento.apiScheme | quote }}
+            # MSK SCRAM creds, reused from the app's Secret (BYOC bootstraps
+            # these keys from AWS Secrets Manager).
+            - name: AWS_KAFKA_SASL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "flexprice.secretName" . }}
+                  key: kafka-sasl-username
+            - name: AWS_KAFKA_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "flexprice.secretName" . }}
+                  key: kafka-sasl-password
+            - name: TMPDIR
+              value: "/tmp"
+            {{- with .Values.bento.env }}
+            {{- range $k, $v := . }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- end }}
+          {{- with .Values.bento.envSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.bento.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with (default .Values.nodeSelector .Values.bento.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.affinity .Values.bento.affinity) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (default .Values.tolerations .Values.bento.tolerations) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (include "flexprice.topologySpreadConstraints" (dict "ctx" . "component" "bento") | trim) }}
+      topologySpreadConstraints:
+        {{- . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/tests/bento.test.sh
+++ b/internal/ee/infrastructure/helm/flexprice/templates/tests/bento.test.sh
@@ -53,6 +53,10 @@ check "bento http port 4195"                      has 'containerPort: 4195'
 check "liveness on /ping"                          has '/ping'
 check "readiness on /ready"                        has '/ready'
 
+echo "== bento default image tag =="
+OUT="$(helm template t "$CHART_DIR" "${BASE[@]}" --set bento.enabled=true 2>/dev/null)"
+check "default image tag is the pinned v1.2.5" has 'ghcr.io/flexprice/bento-collector:v1.2.5'
+
 echo "== bento honors replicaCount + free-form env =="
 OUT="$(helm template t "$CHART_DIR" "${BASE[@]}" \
   --set bento.enabled=true \

--- a/internal/ee/infrastructure/helm/flexprice/templates/tests/bento.test.sh
+++ b/internal/ee/infrastructure/helm/flexprice/templates/tests/bento.test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# bento.test.sh — helm-template assertions for the optional bento collector.
+#
+# Bento is an optional stream collector (Kafka/MSK -> in-cluster Flexprice API).
+# It is a gated app Deployment (like consumer/worker): off by default, config-
+# agnostic (client supplies image + config path + source env via values), and
+# it reuses the existing flexprice-secrets Secret for MSK SCRAM creds.
+#
+# Run: bash templates/tests/bento.test.sh   (from the chart root)
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fail=0
+pass=0
+check() { # check "desc" <cond-cmd...>  — cond is a grep-style predicate on $OUT
+  local desc="$1"; shift
+  if "$@"; then pass=$((pass+1)); else echo "  ✗ FAIL: $desc"; fail=$((fail+1)); fi
+}
+has()  { grep -qE "$1" <<<"$OUT"; }
+hasnt() { ! grep -qE "$1" <<<"$OUT"; }
+
+# Minimal values every render needs (chart requires a credential source). Using
+# existingSecret both satisfies that gate and matches how bento really runs in
+# BYOC — it references the same flexprice-secrets Secret for MSK SCRAM creds.
+BASE=(--set secrets.existingSecret=t-flexprice-secrets)
+
+echo "== bento disabled by default renders nothing =="
+OUT="$(helm template t "$CHART_DIR" "${BASE[@]}" 2>/dev/null)"
+check "no bento Deployment when bento.enabled unset (default false)" \
+  hasnt 'name: t-flexprice-bento'
+
+echo "== bento enabled renders a Deployment =="
+OUT="$(helm template t "$CHART_DIR" "${BASE[@]}" \
+  --set bento.enabled=true \
+  --set bento.image.repository=ghcr.io/flexprice/bento-collector \
+  --set bento.image.tag=v1.2.1 \
+  --set bento.configPath=/app/internal/aws-kafka-to-flexprice.yaml \
+  2>/dev/null)"
+
+check "bento Deployment rendered"                 has 'kind: Deployment'
+check "bento Deployment named <release>-bento"    has 'name: t-flexprice-bento'
+check "bento image wired from values"             has 'ghcr.io/flexprice/bento-collector:v1.2.1'
+check "config path passed as -c arg"              has '/app/internal/aws-kafka-to-flexprice.yaml'
+# In-cluster API target (user decision: post to the api Service, not external host)
+check "FLEXPRICE_API_HOST = in-cluster api svc"   has 'value: "?t-flexprice-api"?'
+check "FLEXPRICE_SCHEME http (in-cluster, no TLS)" has 'FLEXPRICE_SCHEME'
+# MSK SCRAM creds reused from the existing flexprice-secrets Secret
+check "SASL password via secretKeyRef"            has 'key: kafka-sasl-password'
+check "SASL username via secretKeyRef"            has 'key: kafka-sasl-username'
+check "secret ref points at flexprice secret"     has 'name: t-flexprice-secrets'
+# Bento HTTP port + probes on :4195 (bento default)
+check "bento http port 4195"                      has 'containerPort: 4195'
+check "liveness on /ping"                          has '/ping'
+check "readiness on /ready"                        has '/ready'
+
+echo "== bento honors replicaCount + free-form env =="
+OUT="$(helm template t "$CHART_DIR" "${BASE[@]}" \
+  --set bento.enabled=true \
+  --set bento.replicaCount=2 \
+  --set bento.env.AWS_KAFKA_TOPIC=events \
+  2>/dev/null)"
+check "replicaCount honored"     has 'replicas: 2'
+check "free-form env rendered"   has 'AWS_KAFKA_TOPIC'
+
+echo
+if [[ "$fail" -gt 0 ]]; then
+  echo "BENTO TESTS: $pass passed, $fail FAILED"; exit 1
+fi
+echo "BENTO TESTS: all $pass passed"

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -330,6 +330,70 @@ consumer:
 #         - {name: FLEXPRICE_KAFKA_TOPIC, value: "events"}
 consumers: {}
 
+# Bento collector — OPTIONAL stream collector (Kafka/MSK -> in-cluster Flexprice
+# API). Off by default. Not a Flexprice binary: it runs its own image and its
+# own config, so it does NOT share the app's flexprice.env / configmap. It is
+# config-agnostic — you supply the image, the baked config path, and the source
+# connection details via `env`. The container POSTs to the in-cluster api
+# Service (<release>-api on :80, http) so ingest never leaves the cluster.
+#
+# MSK SCRAM creds are reused from the same Secret the app uses
+# (secrets.existingSecret / <release>-secrets), keys `kafka-sasl-username` and
+# `kafka-sasl-password` — BYOC bootstraps those from AWS Secrets Manager. Point
+# bento at a different Secret with `envSecretName` (mounted via envFrom) if your
+# source creds live elsewhere.
+#
+# IRSA (MSK IAM auth instead of SCRAM): set serviceAccount.perComponent=true and
+# put the role ARN under serviceAccount.components.bento.annotations. SCRAM (the
+# default) needs no IAM role.
+bento:
+  enabled: false
+  replicaCount: 1
+  image:
+    repository: ghcr.io/flexprice/bento-collector
+    tag: ""            # defaults to the chart appVersion when empty
+    digest: ""         # pin by digest (wins over tag) where the registry allows
+    pullPolicy: IfNotPresent
+  # Config baked into the image, selected with `-c`. Pick the pipeline for your
+  # source, e.g. /app/internal/aws-kafka-to-flexprice.yaml (MSK -> Flexprice).
+  configPath: /app/internal/aws-kafka-to-flexprice.yaml
+  # In-cluster Flexprice API target. Defaults point at the api Service; override
+  # only to send events somewhere else.
+  apiHost: ""          # empty = <release>-api (in-cluster Service)
+  apiScheme: http      # http for the in-cluster Service (no TLS hop)
+  # Extra Secret mounted wholesale via envFrom (source creds that are NOT the
+  # reused kafka-sasl-* keys). Empty = not mounted.
+  envSecretName: ""
+  # Free-form plain env for the collector (brokers, topic, consumer group, TLS,
+  # mechanism, batching knobs). Non-secret values only — secrets belong in a
+  # Secret referenced above. See docs/BENTO-DEPLOY-SARVAM.md for the var names.
+  env: {}
+  labels: {}
+  podLabels: {}
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"
+  # Bento's HTTP server (health + metrics). 4195 is the bento default.
+  httpPort: 4195
+  terminationGracePeriodSeconds: 60
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+# Per-component ServiceAccount overrides. The `bento` entry is only consumed
+# when serviceAccount.perComponent=true (MSK IAM / IRSA path); with the default
+# SCRAM auth bento uses the shared ServiceAccount and this is ignored.
+# serviceAccount:
+#   perComponent: true
+#   components:
+#     bento:
+#       annotations:
+#         eks.amazonaws.com/role-arn: arn:aws:iam::<acct>:role/flexprice-bento
+
 # Temporal Worker deployment configuration
 worker:
   enabled: true

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -351,7 +351,7 @@ bento:
   replicaCount: 1
   image:
     repository: ghcr.io/flexprice/bento-collector
-    tag: ""            # defaults to the chart appVersion when empty
+    tag: "v1.2.5"      # empty falls back to the chart appVersion
     digest: ""         # pin by digest (wins over tag) where the registry allows
     pullPolicy: IfNotPresent
   # Config baked into the image, selected with `-c`. Pick the pipeline for your


### PR DESCRIPTION
## What

Add an **optional** bento collector as a gated app Deployment in the flexprice helm chart, modeled on the existing consumer/worker deployments.

Bento is a stream collector: it consumes events from an external source (MSK/Kafka, Azure Event Hub, …) and POSTs them to Flexprice. This wires it to run **inside the cluster** as part of the app, off by default.

## Design

- **Gated + off by default** — `{{- if .Values.bento.enabled }}`; nothing renders unless enabled.
- **Config-agnostic** — the client supplies the image, the pipeline config baked into it (`-c`, `configPath`), and the source connection details via `bento.env`. No pipeline is hardcoded.
- **Posts to the in-cluster API Service** — `FLEXPRICE_API_HOST=<release>-api`, scheme `http`, so ingest never leaves the cluster (no external egress hop).
- **Reuses the shared `flexprice-secrets` Secret** for MSK SCRAM creds (`kafka-sasl-username` / `kafka-sasl-password`) via `secretKeyRef` — no new secret. IRSA for MSK IAM auth is available via `serviceAccount.components.bento` when `perComponent=true`, but the default SCRAM path needs no IAM role.
- Health/readiness probes on `:4195` (`/ping`, `/ready`), the bento defaults.

Files:
- `templates/app/deployment-bento.yaml` (new)
- `values.yaml` — new `bento:` block + a commented `serviceAccount.components.bento` example
- `templates/tests/bento.test.sh` (new)

## Tests

`bento.test.sh` (helm-template assertions) — **15/15 pass**:
- disabled by default renders **nothing**;
- enabled renders one Deployment carrying the configured image, `-c` config path, the in-cluster API target, the SASL `secretKeyRef`s, `:4195` probes, `replicaCount`, and free-form `env`.

`helm lint` clean; api/consumer/worker deployments unchanged (no regression).

## Note

The BYOC client package references this via a commented `bento:` stanza in its app values (separate infrastructure-repo PR). To ship, the app repo needs to publish a `bento-collector` image tag clients point at.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Bento stream collector deployment support to the Helm chart.
  * Enables Kafka/MSK data collection and forwarding to the in-cluster Flexprice API.
  * Added configurable image, replicas, environment variables, resources, health checks, and scheduling options.
  * Reuses configured MSK credentials and supports dedicated service account settings.
* **Tests**
  * Added chart validation covering disabled-by-default behavior and Bento configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->