### PR TITLE
feat(storage) 4/5: platform storage + Resolver + config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,8 +228,8 @@ func (c *FlexpriceS3ExportsConfig) Validate() error {
 	switch c.ResolvedCredentialSource() {
 	case CredentialSourceFederation:
 		if !hasFederation {
-			return ierr.NewError("federation_enabled is true but federation_role_arn is not set").
-				WithHint("Set flexprice_s3_exports.federation_role_arn when enabling federation").
+			return ierr.NewError("federation credentials are selected but federation_role_arn is not set").
+				WithHint("Set flexprice_s3_exports.federation_role_arn, or change credential_source/federation_enabled to another source").
 				Mark(ierr.ErrValidation)
 		}
 	case CredentialSourceAmbient:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,19 +133,13 @@ type BucketConfig struct {
 	KeyPrefix             string `mapstructure:"key_prefix" validate:"omitempty"`
 }
 
-// Credential source constants for FlexpriceS3ExportsConfig.CredentialSource /
-// ResolvedCredentialSource(). Exactly one value is active per deployment.
+// Credential sources for FlexpriceS3ExportsConfig. Exactly one is active per
+// deployment. "ambient" covers every AWS-default-chain shape (IRSA, Pod Identity,
+// ECS task role, EC2 instance profile) with no per-mechanism value.
 const (
-	// CredentialSourceStatic uses explicit AWSAccessKeyID/AWSSecretAccessKey.
-	CredentialSourceStatic = "static"
-	// CredentialSourceAmbient covers ALL ambient-credential deployment shapes —
-	// EKS IRSA, EKS Pod Identity, ECS task roles, EC2 instance profiles — which
-	// all resolve through the same AWS default credential chain
-	// (awsConfig.LoadDefaultConfig) with no explicit credentials configured here.
-	// There is deliberately no per-mechanism value or config.
-	CredentialSourceAmbient = "ambient"
-	// CredentialSourceFederation uses GCP-to-AWS OIDC federation (AssumeRoleWithWebIdentity).
-	CredentialSourceFederation = "federation"
+	CredentialSourceStatic     = "static"
+	CredentialSourceAmbient    = "ambient"
+	CredentialSourceFederation = "federation" // GCP-to-AWS OIDC
 )
 
 type FlexpriceS3ExportsConfig struct {
@@ -154,26 +148,16 @@ type FlexpriceS3ExportsConfig struct {
 	AWSAccessKeyID     string `mapstructure:"aws_access_key_id" validate:"omitempty"`
 	AWSSecretAccessKey string `mapstructure:"aws_secret_access_key" validate:"omitempty"`
 	AWSSessionToken    string `mapstructure:"aws_session_token,omitempty"`
-	// FederationRoleARN enables GCP-to-AWS OIDC federation (AssumeRoleWithWebIdentity)
-	// in place of static keys. Empty means federation is not configured.
-	FederationRoleARN string `mapstructure:"federation_role_arn,omitempty"`
-	FederationEnabled bool   `mapstructure:"federation_enabled" default:"false"`
-	// CredentialSource selects how AWS credentials are obtained: "static" (explicit
-	// keys), "ambient" (EKS IRSA / EKS Pod Identity / ECS task role / EC2 instance
-	// profile — all resolved by the AWS default credential chain), or "federation"
-	// (GCP-to-AWS OIDC). Empty is derived for backward compatibility.
+	FederationRoleARN  string `mapstructure:"federation_role_arn,omitempty"`
+	FederationEnabled  bool   `mapstructure:"federation_enabled" default:"false"`
+	// CredentialSource selects how AWS credentials are obtained; empty is derived
+	// by ResolvedCredentialSource for backward compatibility.
 	CredentialSource string `mapstructure:"credential_source" validate:"omitempty,oneof=static ambient federation"`
 }
 
-// ResolvedCredentialSource derives the effective credential source so no existing
-// deployment must change config to keep working:
-//   - CredentialSource, if explicitly set, always wins.
-//   - Otherwise FederationEnabled=true, or a FederationRoleARN is present (the
-//     historic signal, predating the FederationEnabled flag), means "federation".
-//   - Otherwise both static keys present means "static".
-//   - Otherwise "ambient" — this is the mode that lets a managed connection run with
-//     no credentials configured at all (EKS IRSA / Pod Identity / ECS task role / EC2
-//     instance profile), rather than treating "nothing configured" as an error.
+// ResolvedCredentialSource derives the effective source so existing deployments
+// need no config change: explicit CredentialSource wins; else federation (flag or
+// legacy FederationRoleARN); else static (both keys present); else ambient.
 func (c *FlexpriceS3ExportsConfig) ResolvedCredentialSource() string {
 	if c.CredentialSource != "" {
 		return c.CredentialSource
@@ -187,29 +171,11 @@ func (c *FlexpriceS3ExportsConfig) ResolvedCredentialSource() string {
 	return CredentialSourceAmbient
 }
 
-// Validate enforces the requirements of the resolved credential source (see
-// ResolvedCredentialSource). "ambient" is a first-class mode here: when explicitly
-// selected (CredentialSource == "ambient"), it deliberately requires no credentials
-// at all, because that is the entire point of the AWS default credential chain
-// (EKS IRSA / EKS Pod Identity / ECS task role / EC2 instance profile) —
-// config-load time cannot and should not require secrets that ambient compute
-// identity supplies for free.
-//
-// Backward compatibility: when CredentialSource is left empty AND neither static
-// keys nor federation are configured, this preserves the historic behavior of
-// erroring ("no credential source configured") rather than silently resolving to
-// ambient. That keeps existing deployments that rely on this error (e.g. to catch
-// a genuinely unconfigured section) failing exactly as before. Ambient must be
-// requested explicitly via credential_source: "ambient" to skip the credential
-// requirement — callers that intentionally run ambient (e.g. the managed-S3
-// factory/connection-create paths) set that explicitly.
-//
-// NOTE: this method is not invoked from Configuration.Validate() — see
-// task-6-report.md for why (Configuration.Validate() is dead code on the real boot
-// path; NewValidatedConfig() deliberately skips it after a prior incident where dormant
-// `validate:"required"` tags crashlooped non-local pods). Callers that actually consume
-// this section (platform storage bootstrap, the managed-S3 factory branch, managed-S3
-// connection creation) call FlexpriceS3Exports.Validate() explicitly themselves.
+// Validate enforces the resolved credential source's requirements. Explicit
+// "ambient" requires no credentials (that's the point of the default chain); an
+// empty source with nothing configured still errors, preserving historic behavior
+// rather than silently resolving to ambient. Consumers call this explicitly —
+// it is not reached from Configuration.Validate() (dead on the boot path).
 func (c *FlexpriceS3ExportsConfig) Validate() error {
 	if c.Bucket == "" {
 		return ierr.NewError("flexprice S3 exports bucket is not configured").
@@ -233,17 +199,13 @@ func (c *FlexpriceS3ExportsConfig) Validate() error {
 				Mark(ierr.ErrValidation)
 		}
 	case CredentialSourceAmbient:
+		// Derived ambient (nothing configured) still errors; only explicit ambient
+		// skips the credential requirement.
 		if c.CredentialSource != CredentialSourceAmbient {
-			// Nothing configured and ambient was not explicitly requested: preserve
-			// the historic error rather than silently falling back to the AWS
-			// default credential chain.
 			return ierr.NewError("no credential source configured for flexprice_s3_exports").
 				WithHint("Set either aws_access_key_id/aws_secret_access_key, federation_role_arn, or credential_source: \"ambient\" to explicitly use the AWS default credential chain").
 				Mark(ierr.ErrValidation)
 		}
-		// Explicitly requested ambient: no credential requirement. The AWS default
-		// credential chain supplies them (EKS IRSA / EKS Pod Identity / ECS task
-		// role / EC2 instance profile).
 	case CredentialSourceStatic:
 		if !hasStaticKeys {
 			return ierr.NewError("no credential source configured for flexprice_s3_exports").
@@ -251,11 +213,8 @@ func (c *FlexpriceS3ExportsConfig) Validate() error {
 				Mark(ierr.ErrValidation)
 		}
 	default:
-		// ResolvedCredentialSource returns CredentialSource verbatim when set, so an
-		// unrecognized value (a typo like "amibent") reaches here. Reject it rather
-		// than falling through to unintended ambient credentials — the boot path
-		// skips Configuration.Validate() and its oneof struct tag, so this is the
-		// only place a direct caller catches the typo.
+		// A typo'd credential_source reaches here (the boot path skips the oneof
+		// tag); reject rather than fall through to ambient.
 		return ierr.NewError("invalid flexprice_s3_exports.credential_source").
 			WithHint("credential_source must be one of \"static\", \"ambient\", or \"federation\"").
 			Mark(ierr.ErrValidation)
@@ -273,12 +232,9 @@ type StorageConfig struct {
 type GCSConfig struct {
 	Enabled             bool         `mapstructure:"enabled" default:"false"`
 	InvoiceBucketConfig BucketConfig `mapstructure:"invoice" validate:"omitempty"`
-	// SignerServiceAccountEmail is the identity used to sign presigned GET URLs
-	// for invoice PDFs. Under Workload Identity the ambient credentials cannot
-	// self-sign, so this must name a service account the running identity may
-	// impersonate (roles/iam.serviceAccountTokenCreator). Empty means invoice
-	// PDFs upload fine but every presigned download link fails, so the resolver
-	// rejects an empty value when the resolved provider is GCS.
+	// SignerServiceAccountEmail signs presigned GET URLs (Workload Identity can't
+	// self-sign; needs roles/iam.serviceAccountTokenCreator). The resolver rejects
+	// an empty value under GCS.
 	SignerServiceAccountEmail string `mapstructure:"signer_service_account_email" validate:"omitempty"`
 }
 
@@ -286,19 +242,12 @@ type GCSConfig struct {
 // the Flexprice-owned bucket that Flexprice-managed export connections write to
 // when the deployment runs on GCP.
 //
-// There is deliberately no service-account-key field. On GCP, Flexprice's own
-// identity comes from Workload Identity (ambient ADC), and projects commonly
-// enforce constraints/iam.disableServiceAccountKeyCreation, which makes exported
-// SA keys unavailable. Customer BYO GCS connections still require an explicit
-// key on the connection row — see Factory.buildGCSStorage.
+// No SA-key field by design: on GCP Flexprice uses Workload Identity, and
+// iam.disableServiceAccountKeyCreation commonly blocks exported keys. Customer
+// BYO GCS connections still carry a key on the connection row.
 type FlexpriceGCSExportsConfig struct {
 	Bucket string `mapstructure:"bucket" validate:"omitempty"`
-	// SignerServiceAccountEmail is the identity used to sign presigned GET URLs.
-	// Under Workload Identity the ambient credentials cannot self-sign, so this
-	// must name a service account the running identity may impersonate
-	// (roles/iam.serviceAccountTokenCreator). Empty means export uploads succeed
-	// but every presigned download link fails, so the resolver rejects an empty
-	// value when the resolved provider is GCS (mirrors the invoice signer).
+	// See GCSConfig.SignerServiceAccountEmail; same signer requirement for exports.
 	SignerServiceAccountEmail string `mapstructure:"signer_service_account_email" validate:"omitempty"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/Shopify/sarama"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/flexprice/flexprice/internal/validator"
 	"github.com/joho/godotenv"
@@ -44,7 +45,10 @@ type Configuration struct {
 	Secrets                SecretsConfig                `validate:"required"`
 	Billing                BillingConfig                `validate:"omitempty"`
 	S3                     S3Config                     `validate:"required"`
+	Storage                StorageConfig                `mapstructure:"storage" validate:"omitempty"`
+	GCS                    GCSConfig                    `mapstructure:"gcs" validate:"omitempty"`
 	FlexpriceS3Exports     FlexpriceS3ExportsConfig     `mapstructure:"flexprice_s3_exports" validate:"omitempty"`
+	FlexpriceGCSExports    FlexpriceGCSExportsConfig    `mapstructure:"flexprice_gcs_exports" validate:"omitempty"`
 	Marketplace            MarketplaceConfig            `mapstructure:"marketplace" validate:"omitempty"`
 	Cache                  CacheConfig                  `validate:"required"`
 	EventProcessing        EventProcessingConfig        `mapstructure:"event_processing" validate:"required"`
@@ -129,12 +133,184 @@ type BucketConfig struct {
 	KeyPrefix             string `mapstructure:"key_prefix" validate:"omitempty"`
 }
 
+// Credential source constants for FlexpriceS3ExportsConfig.CredentialSource /
+// ResolvedCredentialSource(). Exactly one value is active per deployment.
+const (
+	// CredentialSourceStatic uses explicit AWSAccessKeyID/AWSSecretAccessKey.
+	CredentialSourceStatic = "static"
+	// CredentialSourceAmbient covers ALL ambient-credential deployment shapes —
+	// EKS IRSA, EKS Pod Identity, ECS task roles, EC2 instance profiles — which
+	// all resolve through the same AWS default credential chain
+	// (awsConfig.LoadDefaultConfig) with no explicit credentials configured here.
+	// There is deliberately no per-mechanism value or config.
+	CredentialSourceAmbient = "ambient"
+	// CredentialSourceFederation uses GCP-to-AWS OIDC federation (AssumeRoleWithWebIdentity).
+	CredentialSourceFederation = "federation"
+)
+
 type FlexpriceS3ExportsConfig struct {
 	Bucket             string `mapstructure:"bucket" validate:"required"`
 	Region             string `mapstructure:"region" validate:"required"`
-	AWSAccessKeyID     string `mapstructure:"aws_access_key_id" validate:"required"`
-	AWSSecretAccessKey string `mapstructure:"aws_secret_access_key" validate:"required"`
+	AWSAccessKeyID     string `mapstructure:"aws_access_key_id" validate:"omitempty"`
+	AWSSecretAccessKey string `mapstructure:"aws_secret_access_key" validate:"omitempty"`
 	AWSSessionToken    string `mapstructure:"aws_session_token,omitempty"`
+	// FederationRoleARN enables GCP-to-AWS OIDC federation (AssumeRoleWithWebIdentity)
+	// in place of static keys. Empty means federation is not configured.
+	FederationRoleARN string `mapstructure:"federation_role_arn,omitempty"`
+	FederationEnabled bool   `mapstructure:"federation_enabled" default:"false"`
+	// CredentialSource selects how AWS credentials are obtained: "static" (explicit
+	// keys), "ambient" (EKS IRSA / EKS Pod Identity / ECS task role / EC2 instance
+	// profile — all resolved by the AWS default credential chain), or "federation"
+	// (GCP-to-AWS OIDC). Empty is derived for backward compatibility.
+	CredentialSource string `mapstructure:"credential_source" validate:"omitempty,oneof=static ambient federation"`
+}
+
+// ResolvedCredentialSource derives the effective credential source so no existing
+// deployment must change config to keep working:
+//   - CredentialSource, if explicitly set, always wins.
+//   - Otherwise FederationEnabled=true, or a FederationRoleARN is present (the
+//     historic signal, predating the FederationEnabled flag), means "federation".
+//   - Otherwise both static keys present means "static".
+//   - Otherwise "ambient" — this is the mode that lets a managed connection run with
+//     no credentials configured at all (EKS IRSA / Pod Identity / ECS task role / EC2
+//     instance profile), rather than treating "nothing configured" as an error.
+func (c *FlexpriceS3ExportsConfig) ResolvedCredentialSource() string {
+	if c.CredentialSource != "" {
+		return c.CredentialSource
+	}
+	if c.FederationEnabled || c.FederationRoleARN != "" {
+		return CredentialSourceFederation
+	}
+	if c.AWSAccessKeyID != "" && c.AWSSecretAccessKey != "" {
+		return CredentialSourceStatic
+	}
+	return CredentialSourceAmbient
+}
+
+// Validate enforces the requirements of the resolved credential source (see
+// ResolvedCredentialSource). "ambient" is a first-class mode here: when explicitly
+// selected (CredentialSource == "ambient"), it deliberately requires no credentials
+// at all, because that is the entire point of the AWS default credential chain
+// (EKS IRSA / EKS Pod Identity / ECS task role / EC2 instance profile) —
+// config-load time cannot and should not require secrets that ambient compute
+// identity supplies for free.
+//
+// Backward compatibility: when CredentialSource is left empty AND neither static
+// keys nor federation are configured, this preserves the historic behavior of
+// erroring ("no credential source configured") rather than silently resolving to
+// ambient. That keeps existing deployments that rely on this error (e.g. to catch
+// a genuinely unconfigured section) failing exactly as before. Ambient must be
+// requested explicitly via credential_source: "ambient" to skip the credential
+// requirement — callers that intentionally run ambient (e.g. the managed-S3
+// factory/connection-create paths) set that explicitly.
+//
+// NOTE: this method is not invoked from Configuration.Validate() — see
+// task-6-report.md for why (Configuration.Validate() is dead code on the real boot
+// path; NewValidatedConfig() deliberately skips it after a prior incident where dormant
+// `validate:"required"` tags crashlooped non-local pods). Callers that actually consume
+// this section (platform storage bootstrap, the managed-S3 factory branch, managed-S3
+// connection creation) call FlexpriceS3Exports.Validate() explicitly themselves.
+func (c *FlexpriceS3ExportsConfig) Validate() error {
+	if c.Bucket == "" {
+		return ierr.NewError("flexprice S3 exports bucket is not configured").
+			WithHint("Set flexprice_s3_exports.bucket (FLEXPRICE_FLEXPRICE_S3_EXPORTS_BUCKET)").
+			Mark(ierr.ErrValidation)
+	}
+	if c.Region == "" {
+		return ierr.NewError("flexprice S3 exports region is not configured").
+			WithHint("Set flexprice_s3_exports.region (FLEXPRICE_FLEXPRICE_S3_EXPORTS_REGION)").
+			Mark(ierr.ErrValidation)
+	}
+
+	hasStaticKeys := c.AWSAccessKeyID != "" && c.AWSSecretAccessKey != ""
+	hasFederation := c.FederationRoleARN != ""
+
+	switch c.ResolvedCredentialSource() {
+	case CredentialSourceFederation:
+		if !hasFederation {
+			return ierr.NewError("federation_enabled is true but federation_role_arn is not set").
+				WithHint("Set flexprice_s3_exports.federation_role_arn when enabling federation").
+				Mark(ierr.ErrValidation)
+		}
+	case CredentialSourceAmbient:
+		if c.CredentialSource != CredentialSourceAmbient {
+			// Nothing configured and ambient was not explicitly requested: preserve
+			// the historic error rather than silently falling back to the AWS
+			// default credential chain.
+			return ierr.NewError("no credential source configured for flexprice_s3_exports").
+				WithHint("Set either aws_access_key_id/aws_secret_access_key, federation_role_arn, or credential_source: \"ambient\" to explicitly use the AWS default credential chain").
+				Mark(ierr.ErrValidation)
+		}
+		// Explicitly requested ambient: no credential requirement. The AWS default
+		// credential chain supplies them (EKS IRSA / EKS Pod Identity / ECS task
+		// role / EC2 instance profile).
+	case CredentialSourceStatic:
+		if !hasStaticKeys {
+			return ierr.NewError("no credential source configured for flexprice_s3_exports").
+				WithHint("Set both aws_access_key_id and aws_secret_access_key (FLEXPRICE_FLEXPRICE_S3_EXPORTS_AWS_ACCESS_KEY_ID / FLEXPRICE_FLEXPRICE_S3_EXPORTS_AWS_SECRET_ACCESS_KEY), or set credential_source to \"ambient\" or \"federation\"").
+				Mark(ierr.ErrValidation)
+		}
+	default:
+		// ResolvedCredentialSource returns CredentialSource verbatim when set, so an
+		// unrecognized value (a typo like "amibent") reaches here. Reject it rather
+		// than falling through to unintended ambient credentials — the boot path
+		// skips Configuration.Validate() and its oneof struct tag, so this is the
+		// only place a direct caller catches the typo.
+		return ierr.NewError("invalid flexprice_s3_exports.credential_source").
+			WithHint("credential_source must be one of \"static\", \"ambient\", or \"federation\"").
+			Mark(ierr.ErrValidation)
+	}
+
+	return nil
+}
+
+// StorageConfig lets deployments explicitly pin the platform storage backend,
+// overriding CloudDetector's auto-detection. Empty Provider means "auto-detect".
+type StorageConfig struct {
+	Provider string `mapstructure:"provider" validate:"omitempty,oneof=s3 gcs"`
+}
+
+type GCSConfig struct {
+	Enabled             bool         `mapstructure:"enabled" default:"false"`
+	InvoiceBucketConfig BucketConfig `mapstructure:"invoice" validate:"omitempty"`
+	// SignerServiceAccountEmail is the identity used to sign presigned GET URLs
+	// for invoice PDFs. Under Workload Identity the ambient credentials cannot
+	// self-sign, so this must name a service account the running identity may
+	// impersonate (roles/iam.serviceAccountTokenCreator). Empty means invoice
+	// PDFs upload fine but every presigned download link fails, so the resolver
+	// rejects an empty value when the resolved provider is GCS.
+	SignerServiceAccountEmail string `mapstructure:"signer_service_account_email" validate:"omitempty"`
+}
+
+// FlexpriceGCSExportsConfig is the GCS counterpart to FlexpriceS3ExportsConfig:
+// the Flexprice-owned bucket that Flexprice-managed export connections write to
+// when the deployment runs on GCP.
+//
+// There is deliberately no service-account-key field. On GCP, Flexprice's own
+// identity comes from Workload Identity (ambient ADC), and projects commonly
+// enforce constraints/iam.disableServiceAccountKeyCreation, which makes exported
+// SA keys unavailable. Customer BYO GCS connections still require an explicit
+// key on the connection row — see Factory.buildGCSStorage.
+type FlexpriceGCSExportsConfig struct {
+	Bucket string `mapstructure:"bucket" validate:"omitempty"`
+	// SignerServiceAccountEmail is the identity used to sign presigned GET URLs.
+	// Under Workload Identity the ambient credentials cannot self-sign, so this
+	// must name a service account the running identity may impersonate
+	// (roles/iam.serviceAccountTokenCreator). Empty means export uploads succeed
+	// but every presigned download link fails, so the resolver rejects an empty
+	// value when the resolved provider is GCS (mirrors the invoice signer).
+	SignerServiceAccountEmail string `mapstructure:"signer_service_account_email" validate:"omitempty"`
+}
+
+// Validate ensures the section is usable when a Flexprice-managed GCS export
+// connection actually consumes it.
+func (c *FlexpriceGCSExportsConfig) Validate() error {
+	if c.Bucket == "" {
+		return ierr.NewError("flexprice GCS exports bucket is not configured").
+			WithHint("Set flexprice_gcs_exports.bucket (FLEXPRICE_FLEXPRICE_GCS_EXPORTS_BUCKET) to the Flexprice-owned GCS bucket").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
 }
 
 // MarketplaceConfig groups Flexprice's own credentials/identity for each marketplace it reports

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -410,6 +410,9 @@ flexprice_s3_exports:
   # credential chain, no per-mechanism config), or "federation" (GCP->AWS OIDC via
   # federation_role_arn). Left empty, it is derived: federation_enabled=true -> "federation",
   # both AWS keys set -> "static", otherwise -> "ambient".
+  # NOTE: a *derived* "ambient" is rejected by validation — to run ambient you must set
+  # credential_source: "ambient" explicitly (this preserves the historic "no credential
+  # source configured" error for an otherwise-empty config).
 
 # GCS counterpart of flexprice_s3_exports, used when the deployment runs on GCP.
 # Authentication is ambient Workload Identity — there is deliberately no service

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -378,12 +378,49 @@ s3:
     presign_expiry_duration: "1h"
     key_prefix: ""
 
+storage:
+  # provider: "" auto-detects via CloudDetector (GCP metadata -> gcs, AWS metadata -> s3).
+  # Set explicitly ("s3" or "gcs") to override detection.
+  provider: ""
+
+gcs:
+  enabled: false
+  invoice:
+    bucket: "" # Set via FLEXPRICE_GCS_INVOICE_BUCKET env var
+    presign_expiry_duration: "1h"
+    key_prefix: ""
+  # Identity used to sign presigned invoice PDF links. Ambient Workload Identity
+  # credentials cannot self-sign, so this must name a service account the workload
+  # may impersonate (roles/iam.serviceAccountTokenCreator). Required when the
+  # resolved storage provider is GCS — without it PDFs upload but every download
+  # link fails.
+  signer_service_account_email: "" # Set via FLEXPRICE_GCS_SIGNER_SERVICE_ACCOUNT_EMAIL
+
 flexprice_s3_exports:
   bucket: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_BUCKET env var
   region: "ap-south-1"
-  aws_access_key_id: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_ACCESS_KEY_ID env var
-  aws_secret_access_key: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_SECRET_ACCESS_KEY env var
-  aws_session_token: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_SESSION_TOKEN env var
+  aws_access_key_id: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_AWS_ACCESS_KEY_ID env var (optional if federation_role_arn is set)
+  aws_secret_access_key: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_AWS_SECRET_ACCESS_KEY env var (optional if federation_role_arn is set)
+  aws_session_token: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_AWS_SESSION_TOKEN env var
+  federation_enabled: false # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_FEDERATION_ENABLED — GKE->AWS OIDC federation (see infrastructure repo s3-federation module)
+  federation_role_arn: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_FEDERATION_ROLE_ARN
+  # credential_source: "" # Set via FLEXPRICE_FLEXPRICE_S3_EXPORTS_CREDENTIAL_SOURCE — one of
+  # "static" (use aws_access_key_id/aws_secret_access_key), "ambient" (EKS IRSA / EKS Pod
+  # Identity / ECS task role / EC2 instance profile — all resolved via the AWS default
+  # credential chain, no per-mechanism config), or "federation" (GCP->AWS OIDC via
+  # federation_role_arn). Left empty, it is derived: federation_enabled=true -> "federation",
+  # both AWS keys set -> "static", otherwise -> "ambient".
+
+# GCS counterpart of flexprice_s3_exports, used when the deployment runs on GCP.
+# Authentication is ambient Workload Identity — there is deliberately no service
+# account key setting (projects commonly enforce
+# constraints/iam.disableServiceAccountKeyCreation).
+flexprice_gcs_exports:
+  bucket: "" # Set via FLEXPRICE_FLEXPRICE_GCS_EXPORTS_BUCKET env var
+  # Identity used to sign presigned GET URLs. Ambient Workload Identity credentials
+  # cannot self-sign, so this must name a service account the workload may
+  # impersonate (roles/iam.serviceAccountTokenCreator). Empty disables presigning.
+  signer_service_account_email: "" # Set via FLEXPRICE_FLEXPRICE_GCS_EXPORTS_SIGNER_SERVICE_ACCOUNT_EMAIL
 
 # Flexprice's own AWS identity — the principal that assumes each tenant's marketplace IAM role.
 # This is the caller named in the tenant's trust policy, NOT the tenant's role (that lives per

--- a/internal/config/config_federation_test.go
+++ b/internal/config/config_federation_test.go
@@ -1,0 +1,159 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlexpriceS3ExportsConfig_AllowsEmptyStaticCredsWhenFederationConfigured(t *testing.T) {
+	cfg := config.FlexpriceS3ExportsConfig{
+		Bucket:            "flexprice-exports",
+		Region:            "ap-south-1",
+		FederationRoleARN: "arn:aws:iam::123456789012:role/flexprice-gke-federation",
+		FederationEnabled: true,
+		// AWSAccessKeyID / AWSSecretAccessKey intentionally empty
+	}
+
+	v := validator.New()
+	err := v.Struct(cfg)
+	require.NoError(t, err, "struct-tag validation must not require static keys once they're omitempty")
+
+	assert.NoError(t, cfg.Validate(), "custom Validate() must accept federation-only config")
+}
+
+func TestFlexpriceS3ExportsConfig_RejectsNoCredentialSourceAtAll(t *testing.T) {
+	cfg := config.FlexpriceS3ExportsConfig{
+		Bucket: "flexprice-exports",
+		Region: "ap-south-1",
+		// no static keys, no federation role ARN, no explicit credential_source —
+		// must fail custom Validate() to preserve historic behavior.
+	}
+
+	assert.Error(t, cfg.Validate(), "must reject config with zero credential sources when ambient is not explicitly requested")
+}
+
+func TestResolvedCredentialSource(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.FlexpriceS3ExportsConfig
+		want string
+	}{
+		{
+			name: "explicit credential_source wins",
+			cfg: config.FlexpriceS3ExportsConfig{
+				CredentialSource:   config.CredentialSourceStatic,
+				FederationEnabled:  true,
+				FederationRoleARN:  "arn:aws:iam::123456789012:role/x",
+				AWSAccessKeyID:     "",
+				AWSSecretAccessKey: "",
+			},
+			want: config.CredentialSourceStatic,
+		},
+		{
+			name: "federation enabled derives federation",
+			cfg: config.FlexpriceS3ExportsConfig{
+				FederationEnabled: true,
+				FederationRoleARN: "arn:aws:iam::123456789012:role/x",
+			},
+			want: config.CredentialSourceFederation,
+		},
+		{
+			name: "both static keys present derives static",
+			cfg: config.FlexpriceS3ExportsConfig{
+				AWSAccessKeyID:     "AKIAEXAMPLE",
+				AWSSecretAccessKey: "secret",
+			},
+			want: config.CredentialSourceStatic,
+		},
+		{
+			name: "nothing configured derives ambient",
+			cfg:  config.FlexpriceS3ExportsConfig{},
+			want: config.CredentialSourceAmbient,
+		},
+		{
+			name: "explicit ambient overrides what would otherwise derive static",
+			cfg: config.FlexpriceS3ExportsConfig{
+				CredentialSource:   config.CredentialSourceAmbient,
+				AWSAccessKeyID:     "AKIAEXAMPLE",
+				AWSSecretAccessKey: "secret",
+			},
+			want: config.CredentialSourceAmbient,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.ResolvedCredentialSource())
+		})
+	}
+}
+
+func TestFlexpriceS3ExportsConfig_Validate_TableDriven(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.FlexpriceS3ExportsConfig
+		wantErr bool
+	}{
+		{
+			name: "ambient explicit with no credentials passes",
+			cfg: config.FlexpriceS3ExportsConfig{
+				Bucket:           "flexprice-exports",
+				Region:           "ap-south-1",
+				CredentialSource: config.CredentialSourceAmbient,
+			},
+			wantErr: false,
+		},
+		{
+			name: "static with missing secret key fails",
+			cfg: config.FlexpriceS3ExportsConfig{
+				Bucket:         "flexprice-exports",
+				Region:         "ap-south-1",
+				AWSAccessKeyID: "AKIAEXAMPLE",
+				// AWSSecretAccessKey intentionally empty
+			},
+			wantErr: true,
+		},
+		{
+			name: "federation with no role ARN fails",
+			cfg: config.FlexpriceS3ExportsConfig{
+				Bucket:            "flexprice-exports",
+				Region:            "ap-south-1",
+				FederationEnabled: true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "static with both keys passes",
+			cfg: config.FlexpriceS3ExportsConfig{
+				Bucket:             "flexprice-exports",
+				Region:             "ap-south-1",
+				AWSAccessKeyID:     "AKIAEXAMPLE",
+				AWSSecretAccessKey: "secret",
+			},
+			wantErr: false,
+		},
+		{
+			name: "nothing configured and ambient not explicit fails",
+			cfg: config.FlexpriceS3ExportsConfig{
+				Bucket: "flexprice-exports",
+				Region: "ap-south-1",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/storage/platform.go
+++ b/internal/storage/platform.go
@@ -19,10 +19,17 @@ import (
 // resolve once at bootstrap and pass the result down rather than calling this
 // per request. Resolver does exactly that.
 func ResolveProvider(ctx context.Context, cfg *config.Configuration) Provider {
+	return resolveProviderWith(ctx, cfg, NewDefaultCloudDetector())
+}
+
+// resolveProviderWith is the injectable core of ResolveProvider; tests supply a
+// detector pointed at controlled endpoints so the fallback path does not depend
+// on the ambient cloud metadata of whatever host the test runs on.
+func resolveProviderWith(ctx context.Context, cfg *config.Configuration, detector *CloudDetector) Provider {
 	if provider := Provider(cfg.Storage.Provider); provider != "" {
 		return provider
 	}
-	if provider := NewDefaultCloudDetector().Detect(ctx); provider != "" {
+	if provider := detector.Detect(ctx); provider != "" {
 		return provider
 	}
 	return ProviderS3
@@ -80,7 +87,7 @@ func NewPlatformStorage(ctx context.Context, cfg *config.Configuration, provider
 			s3Cfg.AWSSecretAccessKey = cfg.FlexpriceS3Exports.AWSSecretAccessKey
 			s3Cfg.AWSSessionToken = cfg.FlexpriceS3Exports.AWSSessionToken
 		}
-		if purpose == PurposeExport && cfg.FlexpriceS3Exports.FederationEnabled {
+		if purpose == PurposeExport && cfg.FlexpriceS3Exports.ResolvedCredentialSource() == config.CredentialSourceFederation {
 			// FederationTokenSource is wired in Plan 2 once the companion
 			// Terraform+Go GCP-identity-token-minting implementation exists.
 			// Until then there is no way to actually federate, and letting

--- a/internal/storage/platform.go
+++ b/internal/storage/platform.go
@@ -1,0 +1,104 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/flexprice/flexprice/internal/config"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/storage/gcsbackend"
+	"github.com/flexprice/flexprice/internal/storage/s3backend"
+)
+
+// ResolveProvider determines which backend platform storage uses: an explicit
+// cfg.Storage.Provider wins, otherwise CloudDetector probes the cloud metadata
+// endpoints, falling back to S3 when detection is inconclusive (local dev, bare
+// metal).
+//
+// Detection performs blocking HTTP probes (500ms timeout each), so callers must
+// resolve once at bootstrap and pass the result down rather than calling this
+// per request. Resolver does exactly that.
+func ResolveProvider(ctx context.Context, cfg *config.Configuration) Provider {
+	if provider := Provider(cfg.Storage.Provider); provider != "" {
+		return provider
+	}
+	if provider := NewDefaultCloudDetector().Detect(ctx); provider != "" {
+		return provider
+	}
+	return ProviderS3
+}
+
+// NewPlatformStorage constructs the Storage instance used for Flexprice-owned
+// buckets (invoice PDFs, Flexprice-managed exports). provider/bucket/region and
+// signerEmail are passed explicitly because invoice storage and export storage
+// may use different buckets and different signing identities even though both
+// are platform-owned, and because provider detection must happen once at
+// bootstrap (see ResolveProvider) rather than on each construction.
+//
+// signerEmail applies to GCS only and is ignored for S3, where presigned URLs
+// are signed with the request credentials themselves. Mapping a purpose to its
+// signer is the Resolver's job, which is why signerEmail is a plain string.
+//
+// purpose is taken separately because credential validation is purpose-scoped:
+// only PurposeExport reads the flexprice_s3_exports section, so only it may
+// enforce that section's requirements (see the S3 branch).
+func NewPlatformStorage(ctx context.Context, cfg *config.Configuration, provider Provider, purpose Purpose, bucket, region, signerEmail string, log *logger.Logger) (Storage, error) {
+	switch provider {
+	case ProviderGCS:
+		return gcsbackend.New(ctx, &gcsbackend.Config{
+			Bucket:                    bucket,
+			SignerServiceAccountEmail: signerEmail,
+		}, log)
+	case ProviderS3:
+		// FlexpriceS3Exports.Validate() is not invoked anywhere on the boot path
+		// (Configuration.Validate() is dead code — see task-6-report.md), so this
+		// is the only place credential wiring for the platform S3 backend is
+		// actually validated. Must run before constructing s3Cfg so a
+		// misconfigured credential source fails loudly here rather than lazily
+		// inside the AWS SDK's ambient credential chain resolution.
+		//
+		// Scoped to PurposeExport deliberately. Invoice storage draws its bucket
+		// and region from cfg.S3 and never reads flexprice_s3_exports, so
+		// validating that section for PurposeInvoice would break every existing
+		// deployment that serves invoice PDFs without having enabled exports —
+		// the section is legitimately empty there.
+		if purpose == PurposeExport {
+			if err := cfg.FlexpriceS3Exports.Validate(); err != nil {
+				return nil, err
+			}
+		}
+
+		s3Cfg := &s3backend.Config{
+			Bucket: bucket,
+			Region: region,
+		}
+		// Static keys from flexprice_s3_exports are export-scoped (see the
+		// purpose comment above): PurposeInvoice must not pick them up, or an
+		// export-bucket-only credential would break invoice PDF upload/presign.
+		if purpose == PurposeExport && cfg.FlexpriceS3Exports.AWSAccessKeyID != "" {
+			s3Cfg.AWSAccessKeyID = cfg.FlexpriceS3Exports.AWSAccessKeyID
+			s3Cfg.AWSSecretAccessKey = cfg.FlexpriceS3Exports.AWSSecretAccessKey
+			s3Cfg.AWSSessionToken = cfg.FlexpriceS3Exports.AWSSessionToken
+		}
+		if purpose == PurposeExport && cfg.FlexpriceS3Exports.FederationEnabled {
+			// FederationTokenSource is wired in Plan 2 once the companion
+			// Terraform+Go GCP-identity-token-minting implementation exists.
+			// Until then there is no way to actually federate, and letting
+			// s3backend.New() warn-and-fall-through to the ambient AWS
+			// credential chain is a worse failure mode here than failing
+			// loud: on non-AWS compute (e.g. GKE, which is exactly why
+			// federation is being built) the ambient chain resolves nothing,
+			// so the operator would see no actionable error until every S3
+			// call starts failing deep inside the SDK. Fail bootstrap now
+			// with a clear, actionable message instead.
+			return nil, ierr.NewError("OIDC federation is enabled but not yet fully wired").
+				WithHint("FederationEnabled requires a companion Terraform+Go token-source implementation that has not landed yet; either set static AWS credentials, or wait for federation support to complete").
+				Mark(ierr.ErrValidation)
+		}
+		return s3backend.New(ctx, s3Cfg, log)
+	default:
+		return nil, ierr.NewErrorf("unsupported storage provider: %s", provider).
+			WithHint("storage.provider must be 's3' or 'gcs'").
+			Mark(ierr.ErrValidation)
+	}
+}

--- a/internal/storage/platform.go
+++ b/internal/storage/platform.go
@@ -10,21 +10,13 @@ import (
 	"github.com/flexprice/flexprice/internal/storage/s3backend"
 )
 
-// ResolveProvider determines which backend platform storage uses: an explicit
-// cfg.Storage.Provider wins, otherwise CloudDetector probes the cloud metadata
-// endpoints, falling back to S3 when detection is inconclusive (local dev, bare
-// metal).
-//
-// Detection performs blocking HTTP probes (500ms timeout each), so callers must
-// resolve once at bootstrap and pass the result down rather than calling this
-// per request. Resolver does exactly that.
+// ResolveProvider picks the backend: explicit cfg.Storage.Provider wins, else
+// CloudDetector probes metadata endpoints, falling back to S3. Detection blocks
+// on HTTP probes, so callers resolve once at bootstrap (Resolver does this).
 func ResolveProvider(ctx context.Context, cfg *config.Configuration) Provider {
 	return resolveProviderWith(ctx, cfg, NewDefaultCloudDetector())
 }
 
-// resolveProviderWith is the injectable core of ResolveProvider; tests supply a
-// detector pointed at controlled endpoints so the fallback path does not depend
-// on the ambient cloud metadata of whatever host the test runs on.
 func resolveProviderWith(ctx context.Context, cfg *config.Configuration, detector *CloudDetector) Provider {
 	if provider := Provider(cfg.Storage.Provider); provider != "" {
 		return provider
@@ -35,20 +27,9 @@ func resolveProviderWith(ctx context.Context, cfg *config.Configuration, detecto
 	return ProviderS3
 }
 
-// NewPlatformStorage constructs the Storage instance used for Flexprice-owned
-// buckets (invoice PDFs, Flexprice-managed exports). provider/bucket/region and
-// signerEmail are passed explicitly because invoice storage and export storage
-// may use different buckets and different signing identities even though both
-// are platform-owned, and because provider detection must happen once at
-// bootstrap (see ResolveProvider) rather than on each construction.
-//
-// signerEmail applies to GCS only and is ignored for S3, where presigned URLs
-// are signed with the request credentials themselves. Mapping a purpose to its
-// signer is the Resolver's job, which is why signerEmail is a plain string.
-//
-// purpose is taken separately because credential validation is purpose-scoped:
-// only PurposeExport reads the flexprice_s3_exports section, so only it may
-// enforce that section's requirements (see the S3 branch).
+// NewPlatformStorage constructs Storage for a Flexprice-owned bucket. Invoice and
+// export storage may differ in bucket, region and signer, so those are explicit
+// args. signerEmail applies to GCS only (S3 signs with the request credentials).
 func NewPlatformStorage(ctx context.Context, cfg *config.Configuration, provider Provider, purpose Purpose, bucket, region, signerEmail string, log *logger.Logger) (Storage, error) {
 	switch provider {
 	case ProviderGCS:
@@ -57,18 +38,10 @@ func NewPlatformStorage(ctx context.Context, cfg *config.Configuration, provider
 			SignerServiceAccountEmail: signerEmail,
 		}, log)
 	case ProviderS3:
-		// FlexpriceS3Exports.Validate() is not invoked anywhere on the boot path
-		// (Configuration.Validate() is dead code — see task-6-report.md), so this
-		// is the only place credential wiring for the platform S3 backend is
-		// actually validated. Must run before constructing s3Cfg so a
-		// misconfigured credential source fails loudly here rather than lazily
-		// inside the AWS SDK's ambient credential chain resolution.
-		//
-		// Scoped to PurposeExport deliberately. Invoice storage draws its bucket
-		// and region from cfg.S3 and never reads flexprice_s3_exports, so
-		// validating that section for PurposeInvoice would break every existing
-		// deployment that serves invoice PDFs without having enabled exports —
-		// the section is legitimately empty there.
+		// Only the export path reads flexprice_s3_exports, so only it validates
+		// that section; validating it for invoices would break deployments that
+		// serve invoice PDFs without exports enabled. This is the sole validation
+		// point (Configuration.Validate() is not on the boot path).
 		if purpose == PurposeExport {
 			if err := cfg.FlexpriceS3Exports.Validate(); err != nil {
 				return nil, err
@@ -79,25 +52,16 @@ func NewPlatformStorage(ctx context.Context, cfg *config.Configuration, provider
 			Bucket: bucket,
 			Region: region,
 		}
-		// Static keys from flexprice_s3_exports are export-scoped (see the
-		// purpose comment above): PurposeInvoice must not pick them up, or an
-		// export-bucket-only credential would break invoice PDF upload/presign.
+		// Export-scoped static keys: invoices must not pick them up.
 		if purpose == PurposeExport && cfg.FlexpriceS3Exports.AWSAccessKeyID != "" {
 			s3Cfg.AWSAccessKeyID = cfg.FlexpriceS3Exports.AWSAccessKeyID
 			s3Cfg.AWSSecretAccessKey = cfg.FlexpriceS3Exports.AWSSecretAccessKey
 			s3Cfg.AWSSessionToken = cfg.FlexpriceS3Exports.AWSSessionToken
 		}
 		if purpose == PurposeExport && cfg.FlexpriceS3Exports.ResolvedCredentialSource() == config.CredentialSourceFederation {
-			// FederationTokenSource is wired in Plan 2 once the companion
-			// Terraform+Go GCP-identity-token-minting implementation exists.
-			// Until then there is no way to actually federate, and letting
-			// s3backend.New() warn-and-fall-through to the ambient AWS
-			// credential chain is a worse failure mode here than failing
-			// loud: on non-AWS compute (e.g. GKE, which is exactly why
-			// federation is being built) the ambient chain resolves nothing,
-			// so the operator would see no actionable error until every S3
-			// call starts failing deep inside the SDK. Fail bootstrap now
-			// with a clear, actionable message instead.
+			// Federation has no token source yet (Plan 2). Fail loudly at boot
+			// rather than let s3backend fall through to the ambient chain, which
+			// resolves nothing on non-AWS compute and fails deep in the SDK.
 			return nil, ierr.NewError("OIDC federation is enabled but not yet fully wired").
 				WithHint("FederationEnabled requires a companion Terraform+Go token-source implementation that has not landed yet; either set static AWS credentials, or wait for federation support to complete").
 				Mark(ierr.ErrValidation)

--- a/internal/storage/platform_test.go
+++ b/internal/storage/platform_test.go
@@ -147,7 +147,7 @@ func TestNewPlatformStorage_S3Provider_FederationEnabledWithoutRoleARN(t *testin
 	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderS3, storage.PurposeExport, "flexprice-exports", "ap-south-1", "", logger.NewNoopLogger())
 	require.Error(t, err)
 	require.Nil(t, s)
-	require.Contains(t, err.Error(), "federation_enabled is true but federation_role_arn is not set")
+	require.Contains(t, err.Error(), "federation credentials are selected but federation_role_arn is not set")
 }
 
 // TestNewPlatformStorage_S3Provider_FederationEnabledWithRoleARN_FailsLoud verifies

--- a/internal/storage/platform_test.go
+++ b/internal/storage/platform_test.go
@@ -1,0 +1,246 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPlatformStorage_S3Provider_ExplicitOverride(t *testing.T) {
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "s3"},
+		S3: config.S3Config{
+			Enabled: true,
+			Region:  "ap-south-1",
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "flexprice-invoices",
+				PresignExpiryDuration: "1h",
+			},
+		},
+		FlexpriceS3Exports: config.FlexpriceS3ExportsConfig{
+			Bucket:             "flexprice-exports",
+			Region:             "ap-south-1",
+			AWSAccessKeyID:     "AKIAEXAMPLE",
+			AWSSecretAccessKey: "secret",
+		},
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderS3, storage.PurposeInvoice, "flexprice-invoices", "ap-south-1", "", logger.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, storage.ProviderS3, s.Provider())
+}
+
+// TestNewPlatformStorage_GCSProvider proves the GCS branch constructs
+// successfully without explicit credentials, matching a real GKE pod that
+// relies on ambient Workload Identity / Application Default Credentials.
+// NewPlatformStorage's GCS branch has no config knob to inject a fake
+// EndpointURL (unlike gcsbackend.Config directly), so gcsbackend.New's
+// underlying cloud.google.com/go storage.NewClient would otherwise try to
+// resolve REAL Application Default Credentials at construction time — which
+// only "works" on a machine that happens to have `gcloud auth
+// application-default login` already run, and fails on CI / a real GKE pod
+// without ADC configured. Setting STORAGE_EMULATOR_HOST makes the GCS client
+// library skip ADC resolution entirely (it switches to
+// option.WithoutAuthentication() internally — see cloud.google.com/go/storage
+// NewClient), so this test's result never depends on ambient real-world GCP
+// credentials.
+func TestNewPlatformStorage_GCSProvider(t *testing.T) {
+	t.Setenv("STORAGE_EMULATOR_HOST", "127.0.0.1:1")
+
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "gcs"},
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderGCS, storage.PurposeInvoice, "flexprice-invoices", "", "", logger.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, storage.ProviderGCS, s.Provider())
+}
+
+// TestNewPlatformStorage_GCSProvider_WithSigner proves signerEmail is forwarded
+// into the gcsbackend config for the GCS branch (the resolver validates a
+// non-empty signer for invoice storage before ever calling here, but
+// NewPlatformStorage itself must still thread whatever it is given through).
+func TestNewPlatformStorage_GCSProvider_WithSigner(t *testing.T) {
+	t.Setenv("STORAGE_EMULATOR_HOST", "127.0.0.1:1")
+
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "gcs"},
+		GCS: config.GCSConfig{
+			SignerServiceAccountEmail: "signer@flexprice-project.iam.gserviceaccount.com",
+		},
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderGCS, storage.PurposeInvoice, "flexprice-invoices", "", cfg.GCS.SignerServiceAccountEmail, logger.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, storage.ProviderGCS, s.Provider())
+}
+
+func TestNewPlatformStorage_UnsupportedProvider_ReturnsError(t *testing.T) {
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "azure"},
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.Provider("azure"), storage.PurposeInvoice, "bucket", "region", "", logger.NewNoopLogger())
+	require.Error(t, err)
+	require.Nil(t, s)
+}
+
+// TestNewPlatformStorage_S3Provider_InvalidFlexpriceS3ExportsCreds verifies the
+// handoff obligation from Task 6's review: FlexpriceS3ExportsConfig.Validate()
+// must actually be invoked at the point platform S3 storage is constructed from
+// FlexpriceS3Exports config, since Configuration.Validate() is dead code on the
+// real boot path. Neither static keys nor federation are configured here, so
+// Validate() must return an error and NewPlatformStorage must propagate it.
+func TestNewPlatformStorage_S3Provider_InvalidFlexpriceS3ExportsCreds(t *testing.T) {
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "s3"},
+		S3: config.S3Config{
+			Enabled: true,
+			Region:  "ap-south-1",
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "flexprice-invoices",
+				PresignExpiryDuration: "1h",
+			},
+		},
+		FlexpriceS3Exports: config.FlexpriceS3ExportsConfig{
+			Bucket: "flexprice-exports",
+			Region: "ap-south-1",
+			// No static keys, no federation role ARN configured.
+		},
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderS3, storage.PurposeExport, "flexprice-exports", "ap-south-1", "", logger.NewNoopLogger())
+	require.Error(t, err)
+	require.Nil(t, s)
+	require.Contains(t, err.Error(), "no credential source configured")
+}
+
+// TestNewPlatformStorage_S3Provider_FederationEnabledWithoutRoleARN verifies the
+// FederationEnabled-but-no-role-ARN branch of FlexpriceS3ExportsConfig.Validate()
+// is also enforced through NewPlatformStorage.
+func TestNewPlatformStorage_S3Provider_FederationEnabledWithoutRoleARN(t *testing.T) {
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "s3"},
+		S3: config.S3Config{
+			Enabled: true,
+			Region:  "ap-south-1",
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "flexprice-invoices",
+				PresignExpiryDuration: "1h",
+			},
+		},
+		FlexpriceS3Exports: config.FlexpriceS3ExportsConfig{
+			Bucket:            "flexprice-exports",
+			Region:            "ap-south-1",
+			FederationEnabled: true,
+			// FederationRoleARN intentionally left empty.
+		},
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderS3, storage.PurposeExport, "flexprice-exports", "ap-south-1", "", logger.NewNoopLogger())
+	require.Error(t, err)
+	require.Nil(t, s)
+	require.Contains(t, err.Error(), "federation_enabled is true but federation_role_arn is not set")
+}
+
+// TestNewPlatformStorage_S3Provider_FederationEnabledWithRoleARN_FailsLoud verifies
+// the fix for the "silent fallback to ambient AWS credentials" finding: when
+// FederationEnabled is true AND FederationRoleARN is set (passing
+// FlexpriceS3ExportsConfig.Validate()), NewPlatformStorage must NOT proceed to
+// construct an s3backend client with FederationTokenSource left nil — doing so
+// would let s3backend.New() warn-and-fall-through to the ambient AWS credential
+// chain, which resolves nothing on non-AWS compute (e.g. GKE) and looks
+// indistinguishable from "just broken". Federation isn't fully wired until the
+// companion Terraform+Go token-source implementation lands, so this must fail
+// bootstrap loudly instead.
+func TestNewPlatformStorage_S3Provider_FederationEnabledWithRoleARN_FailsLoud(t *testing.T) {
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "s3"},
+		S3: config.S3Config{
+			Enabled: true,
+			Region:  "ap-south-1",
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "flexprice-invoices",
+				PresignExpiryDuration: "1h",
+			},
+		},
+		FlexpriceS3Exports: config.FlexpriceS3ExportsConfig{
+			Bucket:            "flexprice-exports",
+			Region:            "ap-south-1",
+			FederationEnabled: true,
+			FederationRoleARN: "arn:aws:iam::123456789012:role/flexprice-gke-federation",
+		},
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderS3, storage.PurposeExport, "flexprice-exports", "ap-south-1", "", logger.NewNoopLogger())
+	require.Error(t, err)
+	require.Nil(t, s)
+	require.Contains(t, err.Error(), "OIDC federation is enabled but not yet fully wired")
+}
+
+// TestNewPlatformStorage_S3Provider_InvoiceIgnoresEmptyExportsConfig is the
+// regression guard for a backward-compatibility break: invoice storage draws its
+// bucket from cfg.S3 and its region from cfg.S3.Region, and never reads
+// flexprice_s3_exports at all. Validating that section for PurposeInvoice broke
+// every pre-existing AWS deployment that serves invoice PDFs but never enabled
+// exports — a legitimately empty section made GetInvoicePDFUrl fail with
+// "flexprice S3 exports bucket is not configured".
+//
+// The failure was lazy rather than at boot (Resolver caches per purpose), so it
+// surfaced only on the first invoice-PDF request.
+func TestNewPlatformStorage_S3Provider_InvoiceIgnoresEmptyExportsConfig(t *testing.T) {
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "s3"},
+		S3: config.S3Config{
+			Enabled: true,
+			Region:  "ap-south-1",
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "flexprice-invoices",
+				PresignExpiryDuration: "1h",
+			},
+		},
+		// FlexpriceS3Exports deliberately zero-valued: exports never enabled.
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderS3, storage.PurposeInvoice, "flexprice-invoices", "ap-south-1", "", logger.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, storage.ProviderS3, s.Provider())
+}
+
+// TestNewPlatformStorage_S3Provider_InvoiceIgnoresFederationEnabled pins the
+// other half of the same scoping rule: federation is an exports-credential
+// concern, so a federation setting left over in config must not make the invoice
+// path fail loud. Without the purpose scope this returned "OIDC federation is
+// enabled but not yet fully wired" for invoice PDFs.
+func TestNewPlatformStorage_S3Provider_InvoiceIgnoresFederationEnabled(t *testing.T) {
+	cfg := &config.Configuration{
+		Storage: config.StorageConfig{Provider: "s3"},
+		S3: config.S3Config{
+			Enabled: true,
+			Region:  "ap-south-1",
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "flexprice-invoices",
+				PresignExpiryDuration: "1h",
+			},
+		},
+		FlexpriceS3Exports: config.FlexpriceS3ExportsConfig{
+			Bucket:            "flexprice-exports",
+			Region:            "ap-south-1",
+			FederationEnabled: true,
+			FederationRoleARN: "arn:aws:iam::123456789012:role/flexprice-gke-federation",
+		},
+	}
+
+	s, err := storage.NewPlatformStorage(context.Background(), cfg, storage.ProviderS3, storage.PurposeInvoice, "flexprice-invoices", "ap-south-1", "", logger.NewNoopLogger())
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, storage.ProviderS3, s.Provider())
+}

--- a/internal/storage/resolver.go
+++ b/internal/storage/resolver.go
@@ -1,0 +1,304 @@
+package storage
+
+import (
+	"context"
+	"sync"
+
+	"github.com/flexprice/flexprice/internal/config"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+// Purpose identifies which Flexprice-owned bucket a platform storage request
+// targets. Invoice PDFs and exports live in different buckets even though both
+// are platform-owned, and each has its own key prefix and presign expiry.
+type Purpose string
+
+const (
+	PurposeInvoice Purpose = "invoice"
+	PurposeExport  Purpose = "export"
+)
+
+// Resolver answers "which Storage for this operation?" for both storage classes.
+//
+// Platform storage (invoice PDFs, Flexprice-managed exports) is same-cloud by
+// definition: the bucket follows the deployment's own cloud, and credentials
+// come from that cloud's ambient identity or configured keys. It is resolved
+// once and cached.
+//
+// Connection storage (customer bring-your-own-bucket) is resolved per call
+// against the database, because credentials live on the connection row and may
+// change between calls.
+type Resolver interface {
+	ForPlatform(ctx context.Context, purpose Purpose) (Storage, error)
+	ForConnection(ctx context.Context, connectionID string) (Storage, error)
+	// Provider reports the resolved platform storage provider.
+	Provider() Provider
+	// BucketConfigFor returns the bucket settings (key prefix, presign expiry)
+	// for a platform purpose under the resolved provider. Callers need this
+	// because key layout and presign expiry are provider-specific config, and
+	// reading cfg.S3.* directly is what hardcoded the invoice path to S3.
+	BucketConfigFor(purpose Purpose) (config.BucketConfig, error)
+}
+
+// ConnectionStorageProvider is the narrow slice of internal/integration.Factory
+// that the resolver needs. Declared here rather than imported because
+// internal/integration already imports this package; depending on it directly
+// would create a cycle. cmd/server wires the concrete factory in.
+type ConnectionStorageProvider interface {
+	GetStorageProvider(ctx context.Context, connectionID string) (Storage, error)
+}
+
+type resolver struct {
+	cfg      *config.Configuration
+	provider Provider
+	connSvc  ConnectionStorageProvider
+	logger   *logger.Logger
+
+	mu       sync.Mutex
+	platform map[Purpose]Storage
+}
+
+// NewResolver constructs the Resolver. The platform storage provider is resolved
+// once here, at application bootstrap: CloudDetector performs blocking metadata
+// probes (500ms timeout each), so resolving per call would add that latency to
+// every request and could yield inconsistent answers if a probe flaked.
+func NewResolver(ctx context.Context, cfg *config.Configuration, connSvc ConnectionStorageProvider, log *logger.Logger) Resolver {
+	provider := ResolveProvider(ctx, cfg)
+	log.Info(ctx, "resolved platform storage provider", "provider", string(provider))
+
+	return &resolver{
+		cfg:      cfg,
+		provider: provider,
+		connSvc:  connSvc,
+		logger:   log,
+		platform: make(map[Purpose]Storage),
+	}
+}
+
+// Provider returns the resolved platform storage provider. Callers that need to
+// select provider-specific configuration (bucket, key prefix, presign expiry)
+// use this rather than re-running detection.
+func (r *resolver) Provider() Provider { return r.provider }
+
+func (r *resolver) ForPlatform(ctx context.Context, purpose Purpose) (Storage, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if s, ok := r.platform[purpose]; ok {
+		return s, nil
+	}
+
+	if err := r.checkProviderEnabled(purpose); err != nil {
+		return nil, err
+	}
+
+	bucket, region, err := r.platformBucket(purpose)
+	if err != nil {
+		return nil, err
+	}
+
+	signerEmail, err := r.signerFor(purpose)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := NewPlatformStorage(ctx, r.cfg, r.provider, purpose, bucket, region, signerEmail, r.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	r.platform[purpose] = s
+	return s, nil
+}
+
+func (r *resolver) ForConnection(ctx context.Context, connectionID string) (Storage, error) {
+	if r.connSvc == nil {
+		return nil, ierr.NewError("connection storage is not configured").
+			WithHint("No connection storage provider was wired into the storage resolver").
+			Mark(ierr.ErrSystem)
+	}
+	return r.connSvc.GetStorageProvider(ctx, connectionID)
+}
+
+// signerFor selects the signing identity for a purpose under the resolved
+// provider. GCS presigned GET URLs need a service account the ambient
+// Workload Identity credentials can impersonate (they cannot self-sign);
+// invoice and export buckets can be signed by different identities even
+// though both are platform-owned, so this mirrors platformBucket/
+// BucketConfigFor's purpose-to-config mapping rather than living in
+// NewPlatformStorage. S3 returns empty: presigned S3 URLs are signed with the
+// request credentials themselves, with no separate signer identity.
+//
+// GCS+invoice with an empty signer is rejected here rather than left to fail
+// silently at first presign: uploads would succeed (no signer needed to PUT),
+// but every presigned GET for an invoice PDF would fail, which otherwise only
+// surfaces the first time a customer clicks a download link.
+func (r *resolver) signerFor(purpose Purpose) (string, error) {
+	if r.provider != ProviderGCS {
+		return "", nil
+	}
+
+	switch purpose {
+	case PurposeInvoice:
+		signer := r.cfg.GCS.SignerServiceAccountEmail
+		if signer == "" {
+			// The env var name goes in the message, not just the hint: ierr's
+			// Error() renders only "Code: Message", so a hint-only name is
+			// invisible in logs and in any error string a caller inspects.
+			return "", ierr.NewError("no GCS signer service account configured for invoice storage; set FLEXPRICE_GCS_SIGNER_SERVICE_ACCOUNT_EMAIL").
+				WithHint("Set gcs.signer_service_account_email (FLEXPRICE_GCS_SIGNER_SERVICE_ACCOUNT_EMAIL) to a service account with roles/iam.serviceAccountTokenCreator; uploads would succeed but every presigned invoice PDF download link would fail without it").
+				Mark(ierr.ErrValidation)
+		}
+		return signer, nil
+	case PurposeExport:
+		signer := r.cfg.FlexpriceGCSExports.SignerServiceAccountEmail
+		if signer == "" {
+			// Same asymmetry as invoice: managed GCS export uploads succeed with no
+			// signer, but every presigned download URL (task download endpoint) then
+			// fails under ambient Workload Identity, which cannot self-sign. Reject
+			// at construction rather than at first download.
+			return "", ierr.NewError("no GCS signer service account configured for export storage; set FLEXPRICE_FLEXPRICE_GCS_EXPORTS_SIGNER_SERVICE_ACCOUNT_EMAIL").
+				WithHint("Set flexprice_gcs_exports.signer_service_account_email (FLEXPRICE_FLEXPRICE_GCS_EXPORTS_SIGNER_SERVICE_ACCOUNT_EMAIL) to a service account with roles/iam.serviceAccountTokenCreator; uploads would succeed but every presigned export download link would fail without it").
+				Mark(ierr.ErrValidation)
+		}
+		return signer, nil
+	default:
+		return "", unsupportedPurpose(purpose)
+	}
+}
+
+// checkProviderEnabled enforces the s3.enabled / gcs.enabled kill switch for
+// invoice storage.
+//
+// Before the storage refactor, s3.NewService returned a nil Service when
+// s3.enabled was false and GetInvoicePDFUrl failed fast with "s3 is not
+// enabled". Routing invoice PDFs through the Resolver dropped that gate, so a
+// deployment that had deliberately turned storage off would instead construct a
+// live backend and issue real bucket calls against whatever bucket the config
+// defaults happened to name.
+//
+// Scoped to PurposeInvoice: the flag has only ever gated invoice PDFs. Exports
+// are governed by their own flexprice_*_exports config and by whether an export
+// connection exists, and were never covered by s3.enabled — gating them here
+// would disable working export deployments that never set the flag.
+func (r *resolver) checkProviderEnabled(purpose Purpose) error {
+	if purpose != PurposeInvoice {
+		return nil
+	}
+
+	switch r.provider {
+	case ProviderS3:
+		if !r.cfg.S3.Enabled {
+			return ierr.NewError("s3 is not enabled").
+				WithHint("s3 is not enabled but is required to generate invoice pdf url.").
+				Mark(ierr.ErrSystem)
+		}
+	case ProviderGCS:
+		if !r.cfg.GCS.Enabled {
+			return ierr.NewError("gcs is not enabled").
+				WithHint("gcs is not enabled but is required to generate invoice pdf url.").
+				Mark(ierr.ErrSystem)
+		}
+	}
+
+	return nil
+}
+
+// platformBucket selects the bucket and region for a purpose under the resolved
+// provider. Region is meaningless for GCS — a bucket's location is fixed at
+// creation — so it is returned empty there.
+func (r *resolver) platformBucket(purpose Purpose) (bucket, region string, err error) {
+	bc, err := r.BucketConfigFor(purpose)
+	if err != nil {
+		return "", "", err
+	}
+
+	switch r.provider {
+	case ProviderS3:
+		if purpose == PurposeInvoice {
+			region = r.cfg.S3.Region
+		} else {
+			region = r.cfg.FlexpriceS3Exports.Region
+		}
+	}
+
+	return bc.Bucket, region, nil
+}
+
+// BucketConfigFor returns the bucket settings for a platform purpose under the
+// resolved provider.
+//
+// Invoice buckets already carry a full config.BucketConfig (bucket, key prefix,
+// presign expiry) in the S3/GCS config sections. Export buckets do not: the
+// Flexprice-managed exports config (FlexpriceS3ExportsConfig /
+// FlexpriceGCSExportsConfig) is a flat struct describing the Flexprice-owned
+// bucket and its credentials/identity, with no KeyPrefix or
+// PresignExpiryDuration fields — export key prefixes are per-connection
+// (SyncConfig), not global. So for PurposeExport this synthesizes a
+// BucketConfig: bucket from the exports config, empty KeyPrefix, and
+// PresignExpiryDuration hardcoded to "30m" to match defaultPresignExpiry in
+// both s3backend and gcsbackend.
+func (r *resolver) BucketConfigFor(purpose Purpose) (config.BucketConfig, error) {
+	var bc config.BucketConfig
+
+	switch r.provider {
+	case ProviderGCS:
+		switch purpose {
+		case PurposeInvoice:
+			bc = r.cfg.GCS.InvoiceBucketConfig
+		case PurposeExport:
+			bc = config.BucketConfig{
+				Bucket:                r.cfg.FlexpriceGCSExports.Bucket,
+				PresignExpiryDuration: "30m",
+			}
+		default:
+			return config.BucketConfig{}, unsupportedPurpose(purpose)
+		}
+	case ProviderS3:
+		switch purpose {
+		case PurposeInvoice:
+			bc = r.cfg.S3.InvoiceBucketConfig
+		case PurposeExport:
+			bc = config.BucketConfig{
+				Bucket:                r.cfg.FlexpriceS3Exports.Bucket,
+				PresignExpiryDuration: "30m",
+			}
+		default:
+			return config.BucketConfig{}, unsupportedPurpose(purpose)
+		}
+	default:
+		return config.BucketConfig{}, ierr.NewErrorf("unsupported storage provider: %s", r.provider).
+			WithHint("storage.provider must be 's3' or 'gcs'").
+			Mark(ierr.ErrValidation)
+	}
+
+	if bc.Bucket == "" {
+		return config.BucketConfig{}, ierr.NewErrorf("no %s bucket configured for storage provider %s", purpose, r.provider).
+			WithHint(missingBucketHint(r.provider, purpose)).
+			Mark(ierr.ErrValidation)
+	}
+
+	return bc, nil
+}
+
+func unsupportedPurpose(purpose Purpose) error {
+	return ierr.NewErrorf("unsupported storage purpose: %s", purpose).
+		WithHint("purpose must be 'invoice' or 'export'").
+		Mark(ierr.ErrValidation)
+}
+
+// missingBucketHint names the exact env var an operator must set, since the
+// config key differs per provider and purpose.
+func missingBucketHint(provider Provider, purpose Purpose) string {
+	switch {
+	case provider == ProviderGCS && purpose == PurposeInvoice:
+		return "Set gcs.invoice.bucket (FLEXPRICE_GCS_INVOICE_BUCKET)"
+	case provider == ProviderGCS && purpose == PurposeExport:
+		return "Set flexprice_gcs_exports.bucket (FLEXPRICE_FLEXPRICE_GCS_EXPORTS_BUCKET)"
+	case provider == ProviderS3 && purpose == PurposeInvoice:
+		return "Set s3.invoice.bucket (FLEXPRICE_S3_INVOICE_BUCKET)"
+	default:
+		return "Set flexprice_s3_exports.bucket (FLEXPRICE_FLEXPRICE_S3_EXPORTS_BUCKET)"
+	}
+}

--- a/internal/storage/resolver.go
+++ b/internal/storage/resolver.go
@@ -9,9 +9,8 @@ import (
 	"github.com/flexprice/flexprice/internal/logger"
 )
 
-// Purpose identifies which Flexprice-owned bucket a platform storage request
-// targets. Invoice PDFs and exports live in different buckets even though both
-// are platform-owned, and each has its own key prefix and presign expiry.
+// Purpose selects which Flexprice-owned bucket a request targets. Invoice PDFs
+// and exports live in different buckets with their own prefix and presign expiry.
 type Purpose string
 
 const (
@@ -19,32 +18,23 @@ const (
 	PurposeExport  Purpose = "export"
 )
 
-// Resolver answers "which Storage for this operation?" for both storage classes.
-//
-// Platform storage (invoice PDFs, Flexprice-managed exports) is same-cloud by
-// definition: the bucket follows the deployment's own cloud, and credentials
-// come from that cloud's ambient identity or configured keys. It is resolved
-// once and cached.
-//
-// Connection storage (customer bring-your-own-bucket) is resolved per call
-// against the database, because credentials live on the connection row and may
-// change between calls.
+// Resolver selects the Storage for an operation. Platform storage (invoices,
+// managed exports) follows the deployment's own cloud and is resolved once and
+// cached; connection storage (customer BYOB) is resolved per call from the DB,
+// since credentials live on the connection row.
 type Resolver interface {
 	ForPlatform(ctx context.Context, purpose Purpose) (Storage, error)
 	ForConnection(ctx context.Context, connectionID string) (Storage, error)
-	// Provider reports the resolved platform storage provider.
 	Provider() Provider
-	// BucketConfigFor returns the bucket settings (key prefix, presign expiry)
-	// for a platform purpose under the resolved provider. Callers need this
-	// because key layout and presign expiry are provider-specific config, and
-	// reading cfg.S3.* directly is what hardcoded the invoice path to S3.
+	// BucketConfigFor returns provider-specific bucket settings (prefix, presign
+	// expiry) for a purpose. Reading cfg.S3.* directly is what hardcoded the
+	// invoice path to S3.
 	BucketConfigFor(purpose Purpose) (config.BucketConfig, error)
 }
 
 // ConnectionStorageProvider is the narrow slice of internal/integration.Factory
-// that the resolver needs. Declared here rather than imported because
-// internal/integration already imports this package; depending on it directly
-// would create a cycle. cmd/server wires the concrete factory in.
+// the resolver needs. Declared here, not imported, to avoid an import cycle
+// (internal/integration already imports this package). cmd/server wires it in.
 type ConnectionStorageProvider interface {
 	GetStorageProvider(ctx context.Context, connectionID string) (Storage, error)
 }
@@ -59,10 +49,8 @@ type resolver struct {
 	platform map[Purpose]Storage
 }
 
-// NewResolver constructs the Resolver. The platform storage provider is resolved
-// once here, at application bootstrap: CloudDetector performs blocking metadata
-// probes (500ms timeout each), so resolving per call would add that latency to
-// every request and could yield inconsistent answers if a probe flaked.
+// NewResolver resolves the platform provider once at bootstrap (CloudDetector
+// blocks on metadata probes, so it must not run per call).
 func NewResolver(ctx context.Context, cfg *config.Configuration, connSvc ConnectionStorageProvider, log *logger.Logger) Resolver {
 	provider := ResolveProvider(ctx, cfg)
 	log.Info(ctx, "resolved platform storage provider", "provider", string(provider))
@@ -76,9 +64,6 @@ func NewResolver(ctx context.Context, cfg *config.Configuration, connSvc Connect
 	}
 }
 
-// Provider returns the resolved platform storage provider. Callers that need to
-// select provider-specific configuration (bucket, key prefix, presign expiry)
-// use this rather than re-running detection.
 func (r *resolver) Provider() Provider { return r.provider }
 
 func (r *resolver) ForPlatform(ctx context.Context, purpose Purpose) (Storage, error) {
@@ -121,19 +106,10 @@ func (r *resolver) ForConnection(ctx context.Context, connectionID string) (Stor
 	return r.connSvc.GetStorageProvider(ctx, connectionID)
 }
 
-// signerFor selects the signing identity for a purpose under the resolved
-// provider. GCS presigned GET URLs need a service account the ambient
-// Workload Identity credentials can impersonate (they cannot self-sign);
-// invoice and export buckets can be signed by different identities even
-// though both are platform-owned, so this mirrors platformBucket/
-// BucketConfigFor's purpose-to-config mapping rather than living in
-// NewPlatformStorage. S3 returns empty: presigned S3 URLs are signed with the
-// request credentials themselves, with no separate signer identity.
-//
-// GCS+invoice with an empty signer is rejected here rather than left to fail
-// silently at first presign: uploads would succeed (no signer needed to PUT),
-// but every presigned GET for an invoice PDF would fail, which otherwise only
-// surfaces the first time a customer clicks a download link.
+// signerFor returns the GCS signing identity for a purpose (S3 signs with the
+// request credentials, so it returns empty). A missing signer is rejected here,
+// not at first presign: uploads would still succeed, but every presigned GET
+// would fail — surfacing only when a customer clicks a download link.
 func (r *resolver) signerFor(purpose Purpose) (string, error) {
 	if r.provider != ProviderGCS {
 		return "", nil
@@ -143,9 +119,8 @@ func (r *resolver) signerFor(purpose Purpose) (string, error) {
 	case PurposeInvoice:
 		signer := r.cfg.GCS.SignerServiceAccountEmail
 		if signer == "" {
-			// The env var name goes in the message, not just the hint: ierr's
-			// Error() renders only "Code: Message", so a hint-only name is
-			// invisible in logs and in any error string a caller inspects.
+			// Env var name goes in the message: ierr's Error() renders only
+			// "Code: Message", so a hint-only name is invisible in logs.
 			return "", ierr.NewError("no GCS signer service account configured for invoice storage; set FLEXPRICE_GCS_SIGNER_SERVICE_ACCOUNT_EMAIL").
 				WithHint("Set gcs.signer_service_account_email (FLEXPRICE_GCS_SIGNER_SERVICE_ACCOUNT_EMAIL) to a service account with roles/iam.serviceAccountTokenCreator; uploads would succeed but every presigned invoice PDF download link would fail without it").
 				Mark(ierr.ErrValidation)
@@ -154,10 +129,6 @@ func (r *resolver) signerFor(purpose Purpose) (string, error) {
 	case PurposeExport:
 		signer := r.cfg.FlexpriceGCSExports.SignerServiceAccountEmail
 		if signer == "" {
-			// Same asymmetry as invoice: managed GCS export uploads succeed with no
-			// signer, but every presigned download URL (task download endpoint) then
-			// fails under ambient Workload Identity, which cannot self-sign. Reject
-			// at construction rather than at first download.
 			return "", ierr.NewError("no GCS signer service account configured for export storage; set FLEXPRICE_FLEXPRICE_GCS_EXPORTS_SIGNER_SERVICE_ACCOUNT_EMAIL").
 				WithHint("Set flexprice_gcs_exports.signer_service_account_email (FLEXPRICE_FLEXPRICE_GCS_EXPORTS_SIGNER_SERVICE_ACCOUNT_EMAIL) to a service account with roles/iam.serviceAccountTokenCreator; uploads would succeed but every presigned export download link would fail without it").
 				Mark(ierr.ErrValidation)
@@ -168,20 +139,10 @@ func (r *resolver) signerFor(purpose Purpose) (string, error) {
 	}
 }
 
-// checkProviderEnabled enforces the s3.enabled / gcs.enabled kill switch for
-// invoice storage.
-//
-// Before the storage refactor, s3.NewService returned a nil Service when
-// s3.enabled was false and GetInvoicePDFUrl failed fast with "s3 is not
-// enabled". Routing invoice PDFs through the Resolver dropped that gate, so a
-// deployment that had deliberately turned storage off would instead construct a
-// live backend and issue real bucket calls against whatever bucket the config
-// defaults happened to name.
-//
-// Scoped to PurposeInvoice: the flag has only ever gated invoice PDFs. Exports
-// are governed by their own flexprice_*_exports config and by whether an export
-// connection exists, and were never covered by s3.enabled — gating them here
-// would disable working export deployments that never set the flag.
+// checkProviderEnabled enforces the s3.enabled / gcs.enabled kill switch, which
+// has only ever gated invoice PDFs (exports have their own config). Preserves the
+// pre-refactor behavior where storage-off deployments failed fast instead of
+// issuing live bucket calls.
 func (r *resolver) checkProviderEnabled(purpose Purpose) error {
 	if purpose != PurposeInvoice {
 		return nil
@@ -205,9 +166,8 @@ func (r *resolver) checkProviderEnabled(purpose Purpose) error {
 	return nil
 }
 
-// platformBucket selects the bucket and region for a purpose under the resolved
-// provider. Region is meaningless for GCS — a bucket's location is fixed at
-// creation — so it is returned empty there.
+// platformBucket returns the bucket and region for a purpose. Region is empty
+// for GCS (bucket location is fixed at creation).
 func (r *resolver) platformBucket(purpose Purpose) (bucket, region string, err error) {
 	bc, err := r.BucketConfigFor(purpose)
 	if err != nil {
@@ -226,19 +186,9 @@ func (r *resolver) platformBucket(purpose Purpose) (bucket, region string, err e
 	return bc.Bucket, region, nil
 }
 
-// BucketConfigFor returns the bucket settings for a platform purpose under the
-// resolved provider.
-//
-// Invoice buckets already carry a full config.BucketConfig (bucket, key prefix,
-// presign expiry) in the S3/GCS config sections. Export buckets do not: the
-// Flexprice-managed exports config (FlexpriceS3ExportsConfig /
-// FlexpriceGCSExportsConfig) is a flat struct describing the Flexprice-owned
-// bucket and its credentials/identity, with no KeyPrefix or
-// PresignExpiryDuration fields — export key prefixes are per-connection
-// (SyncConfig), not global. So for PurposeExport this synthesizes a
-// BucketConfig: bucket from the exports config, empty KeyPrefix, and
-// PresignExpiryDuration hardcoded to "30m" to match defaultPresignExpiry in
-// both s3backend and gcsbackend.
+// BucketConfigFor returns bucket settings for a purpose. Invoice buckets carry a
+// full config.BucketConfig; export config is flat (no prefix/expiry fields), so
+// export synthesizes one with expiry "30m" to match defaultPresignExpiry.
 func (r *resolver) BucketConfigFor(purpose Purpose) (config.BucketConfig, error) {
 	var bc config.BucketConfig
 

--- a/internal/storage/resolver_test.go
+++ b/internal/storage/resolver_test.go
@@ -1,0 +1,274 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveProvider(t *testing.T) {
+	t.Run("explicit provider wins over detection", func(t *testing.T) {
+		cfg := &config.Configuration{
+			Storage: config.StorageConfig{Provider: "gcs"},
+		}
+		got := ResolveProvider(context.Background(), cfg)
+		assert.Equal(t, ProviderGCS, got)
+	})
+
+	t.Run("falls back to S3 when provider empty and detection inconclusive", func(t *testing.T) {
+		// No cloud metadata server is reachable in the test environment, so
+		// CloudDetector.Detect returns "" and ResolveProvider falls back to S3.
+		cfg := &config.Configuration{
+			Storage: config.StorageConfig{Provider: ""},
+		}
+		got := ResolveProvider(context.Background(), cfg)
+		assert.Equal(t, ProviderS3, got)
+	})
+}
+
+func testConfig() *config.Configuration {
+	return &config.Configuration{
+		S3: config.S3Config{
+			Enabled: true,
+			Region:  "us-east-1",
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "s3-invoice-bucket",
+				PresignExpiryDuration: "15m",
+				KeyPrefix:             "invoices/",
+			},
+		},
+		GCS: config.GCSConfig{
+			Enabled: true,
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "gcs-invoice-bucket",
+				PresignExpiryDuration: "20m",
+				KeyPrefix:             "invoices/",
+			},
+		},
+		FlexpriceS3Exports: config.FlexpriceS3ExportsConfig{
+			Bucket:             "s3-exports-bucket",
+			Region:             "us-west-2",
+			AWSAccessKeyID:     "id",
+			AWSSecretAccessKey: "secret",
+		},
+		FlexpriceGCSExports: config.FlexpriceGCSExportsConfig{
+			Bucket: "gcs-exports-bucket",
+		},
+	}
+}
+
+func newTestResolver(t *testing.T, provider Provider, cfg *config.Configuration) *resolver {
+	t.Helper()
+	return &resolver{
+		cfg:      cfg,
+		provider: provider,
+		logger:   logger.NewNoopLogger(),
+		platform: make(map[Purpose]Storage),
+	}
+}
+
+func TestResolver_BucketConfigFor(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   Provider
+		purpose    Purpose
+		wantBucket string
+	}{
+		{"s3 invoice", ProviderS3, PurposeInvoice, "s3-invoice-bucket"},
+		{"s3 export", ProviderS3, PurposeExport, "s3-exports-bucket"},
+		{"gcs invoice", ProviderGCS, PurposeInvoice, "gcs-invoice-bucket"},
+		{"gcs export", ProviderGCS, PurposeExport, "gcs-exports-bucket"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestResolver(t, tt.provider, testConfig())
+			bc, err := r.BucketConfigFor(tt.purpose)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBucket, bc.Bucket)
+
+			if tt.purpose == PurposeExport {
+				assert.Equal(t, "30m", bc.PresignExpiryDuration)
+				assert.Empty(t, bc.KeyPrefix)
+			}
+		})
+	}
+}
+
+func TestResolver_BucketConfigFor_EmptyBucket(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    Provider
+		purpose     Purpose
+		wantHintSub string
+	}{
+		{"s3 invoice missing", ProviderS3, PurposeInvoice, "FLEXPRICE_S3_INVOICE_BUCKET"},
+		{"s3 export missing", ProviderS3, PurposeExport, "FLEXPRICE_FLEXPRICE_S3_EXPORTS_BUCKET"},
+		{"gcs invoice missing", ProviderGCS, PurposeInvoice, "FLEXPRICE_GCS_INVOICE_BUCKET"},
+		{"gcs export missing", ProviderGCS, PurposeExport, "FLEXPRICE_FLEXPRICE_GCS_EXPORTS_BUCKET"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Configuration{} // all buckets empty
+			r := newTestResolver(t, tt.provider, cfg)
+			_, err := r.BucketConfigFor(tt.purpose)
+			require.Error(t, err)
+			assert.Contains(t, missingBucketHint(tt.provider, tt.purpose), tt.wantHintSub)
+		})
+	}
+}
+
+func TestResolver_BucketConfigFor_UnknownPurpose(t *testing.T) {
+	r := newTestResolver(t, ProviderS3, testConfig())
+	_, err := r.BucketConfigFor(Purpose("bogus"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported storage purpose")
+}
+
+func TestResolver_SignerFor(t *testing.T) {
+	cfg := testConfig()
+	cfg.GCS.SignerServiceAccountEmail = "invoice-signer@flexprice-project.iam.gserviceaccount.com"
+	cfg.FlexpriceGCSExports.SignerServiceAccountEmail = "export-signer@flexprice-project.iam.gserviceaccount.com"
+
+	tests := []struct {
+		name       string
+		provider   Provider
+		purpose    Purpose
+		wantSigner string
+	}{
+		{"gcs invoice uses GCS.SignerServiceAccountEmail", ProviderGCS, PurposeInvoice, "invoice-signer@flexprice-project.iam.gserviceaccount.com"},
+		{"gcs export uses FlexpriceGCSExports.SignerServiceAccountEmail", ProviderGCS, PurposeExport, "export-signer@flexprice-project.iam.gserviceaccount.com"},
+		{"s3 invoice has no signer", ProviderS3, PurposeInvoice, ""},
+		{"s3 export has no signer", ProviderS3, PurposeExport, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestResolver(t, tt.provider, cfg)
+			signer, err := r.signerFor(tt.purpose)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSigner, signer)
+		})
+	}
+}
+
+// TestResolver_SignerFor_GCSInvoiceEmptySigner proves an unset GCS invoice
+// signer fails loud and names the env var, rather than silently resolving
+// to a resolver that can upload but never presign a download link.
+func TestResolver_SignerFor_GCSInvoiceEmptySigner(t *testing.T) {
+	cfg := testConfig() // GCS.SignerServiceAccountEmail left empty
+	r := newTestResolver(t, ProviderGCS, cfg)
+
+	signer, err := r.signerFor(PurposeInvoice)
+	require.Error(t, err)
+	assert.Empty(t, signer)
+	assert.Contains(t, err.Error(), "FLEXPRICE_GCS_SIGNER_SERVICE_ACCOUNT_EMAIL")
+}
+
+// TestResolver_ForPlatform_GCSInvoiceEmptySigner proves ForPlatform surfaces
+// the signer error end to end (not just the unexported signerFor helper).
+func TestResolver_ForPlatform_GCSInvoiceEmptySigner(t *testing.T) {
+	cfg := testConfig() // GCS.SignerServiceAccountEmail left empty
+	r := newTestResolver(t, ProviderGCS, cfg)
+
+	s, err := r.ForPlatform(context.Background(), PurposeInvoice)
+	require.Error(t, err)
+	assert.Nil(t, s)
+	assert.Contains(t, err.Error(), "FLEXPRICE_GCS_SIGNER_SERVICE_ACCOUNT_EMAIL")
+}
+
+// TestResolver_ForPlatform_InvoiceWorksWithoutExportsConfig exercises the real
+// call path that regressed: an existing AWS deployment with invoice S3 fully
+// configured and flexprice_s3_exports never set. ForPlatform(PurposeInvoice)
+// must construct successfully, because invoice storage does not read that
+// section. Previously it failed with "flexprice S3 exports bucket is not
+// configured" on the first invoice-PDF request.
+func TestResolver_ForPlatform_InvoiceWorksWithoutExportsConfig(t *testing.T) {
+	cfg := &config.Configuration{
+		S3: config.S3Config{
+			Enabled: true,
+			Region:  "us-east-1",
+			InvoiceBucketConfig: config.BucketConfig{
+				Bucket:                "s3-invoice-bucket",
+				PresignExpiryDuration: "15m",
+			},
+		},
+		// FlexpriceS3Exports deliberately zero-valued.
+	}
+	r := newTestResolver(t, ProviderS3, cfg)
+
+	s, err := r.ForPlatform(context.Background(), PurposeInvoice)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, ProviderS3, s.Provider())
+
+	// The export purpose still enforces the exports config, so a deployment that
+	// actually uses exports keeps failing loud instead of silently misresolving.
+	_, err = r.ForPlatform(context.Background(), PurposeExport)
+	require.Error(t, err)
+}
+
+// TestResolver_ForPlatform_InvoiceRespectsEnabledFlag pins the s3.enabled /
+// gcs.enabled kill switch for invoice PDFs.
+//
+// Before the storage refactor, s3.NewService returned nil when s3.enabled was
+// false and GetInvoicePDFUrl failed fast with "s3 is not enabled". Routing
+// invoice PDFs through the Resolver dropped that gate, so a deployment that had
+// deliberately turned storage off would construct a live backend and issue real
+// bucket calls against whatever bucket the config defaults named.
+func TestResolver_ForPlatform_InvoiceRespectsEnabledFlag(t *testing.T) {
+	t.Run("s3 disabled rejects invoice storage", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.S3.Enabled = false
+		r := newTestResolver(t, ProviderS3, cfg)
+
+		s, err := r.ForPlatform(context.Background(), PurposeInvoice)
+		require.Error(t, err)
+		assert.Nil(t, s)
+		assert.Contains(t, err.Error(), "s3 is not enabled")
+	})
+
+	t.Run("gcs disabled rejects invoice storage", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.GCS.Enabled = false
+		cfg.GCS.SignerServiceAccountEmail = "signer@example.iam.gserviceaccount.com"
+		r := newTestResolver(t, ProviderGCS, cfg)
+
+		s, err := r.ForPlatform(context.Background(), PurposeInvoice)
+		require.Error(t, err)
+		assert.Nil(t, s)
+		assert.Contains(t, err.Error(), "gcs is not enabled")
+	})
+
+	// Exports were never covered by s3.enabled — they are governed by their own
+	// flexprice_*_exports config. Gating them on this flag would disable working
+	// export deployments that never set it.
+	t.Run("s3 disabled does not block exports", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.S3.Enabled = false
+		r := newTestResolver(t, ProviderS3, cfg)
+
+		s, err := r.ForPlatform(context.Background(), PurposeExport)
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+}
+
+func TestResolver_ForPlatform_Caches(t *testing.T) {
+	cfg := testConfig()
+	r := newTestResolver(t, ProviderS3, cfg)
+
+	s1, err := r.ForPlatform(context.Background(), PurposeExport)
+	require.NoError(t, err)
+	require.NotNil(t, s1)
+
+	s2, err := r.ForPlatform(context.Background(), PurposeExport)
+	require.NoError(t, err)
+
+	assert.Same(t, s1, s2)
+}

--- a/internal/storage/resolver_test.go
+++ b/internal/storage/resolver_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -20,12 +21,14 @@ func TestResolveProvider(t *testing.T) {
 	})
 
 	t.Run("falls back to S3 when provider empty and detection inconclusive", func(t *testing.T) {
-		// No cloud metadata server is reachable in the test environment, so
-		// CloudDetector.Detect returns "" and ResolveProvider falls back to S3.
+		// Inject a detector pointed at dead endpoints so detection is
+		// inconclusive regardless of the host's real cloud metadata (a GCP
+		// CI runner would otherwise detect GCS and fail this fallback test).
 		cfg := &config.Configuration{
 			Storage: config.StorageConfig{Provider: ""},
 		}
-		got := ResolveProvider(context.Background(), cfg)
+		detector := NewCloudDetector("http://127.0.0.1:1", "http://127.0.0.1:2", 100*time.Millisecond)
+		got := resolveProviderWith(context.Background(), cfg, detector)
 		assert.Equal(t, ProviderS3, got)
 	})
 }

--- a/internal/storage/resolver_test.go
+++ b/internal/storage/resolver_test.go
@@ -2,9 +2,11 @@ package storage
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	cockroachErrors "github.com/cockroachdb/errors"
 	"github.com/flexprice/flexprice/internal/config"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/stretchr/testify/assert"
@@ -121,7 +123,10 @@ func TestResolver_BucketConfigFor_EmptyBucket(t *testing.T) {
 			r := newTestResolver(t, tt.provider, cfg)
 			_, err := r.BucketConfigFor(tt.purpose)
 			require.Error(t, err)
-			assert.Contains(t, missingBucketHint(tt.provider, tt.purpose), tt.wantHintSub)
+			// Assert the hint on the emitted error, not a recomputed one, so a
+			// generic error or a wrong hint from BucketConfigFor fails here.
+			hints := strings.Join(cockroachErrors.GetAllHints(err), " ")
+			assert.Contains(t, hints, tt.wantHintSub)
 		})
 	}
 }

--- a/internal/storage/s3backend/client.go
+++ b/internal/storage/s3backend/client.go
@@ -26,14 +26,8 @@ const defaultPresignExpiry = 30 * time.Minute
 
 // Config holds everything needed to construct an S3-backed storagetypes.Storage.
 type Config struct {
-	Bucket string
-	Region string
-	// KeyPrefix is NOT applied by this backend. Prefixing is the caller's
-	// responsibility: build the full key via storage.ObjectKey(prefix, ...)
-	// before calling Upload/Download/Exists/PresignGet. This field exists so
-	// callers that plumb a full job/connection config through can populate it
-	// for their own bookkeeping, but the backend never reads it.
-	KeyPrefix          string
+	Bucket             string
+	Region             string
 	CompressionGzip    bool
 	ServerSideEncrypt  string // "", "AES256", "aws:kms", "aws:kms:dsse"
 	EndpointURL        string // custom endpoint (MinIO etc.)


### PR DESCRIPTION
**Base:** `stack/storage-3-gcsbackend` (#2681) — merge #2679–#2681 first. Shows only its own diff (stacked).

### Stack order (merge strictly in order, all target `develop`)
1. #2679 — storage core interface, keys, url, detector
2. #2680 — S3 backend
3. #2681 — GCS backend + SDK deps
4. #2682 — platform storage + Resolver + config
5. #2683 — migrate callers, drop legacy `internal/s3` *(draft — holds the one breaking change; live-verified before review)*

Replaces #2237 (draft). Stack tip is byte-identical to #2237 HEAD.

---

## Stack 4/5 — Platform storage + Resolver + config

Part of the #2237 split. **Base: stack 3. Merge after it.**

### What
The wiring layer that unifies the two backends:
- `NewPlatformStorage` — builds Flexprice-owned bucket storage (invoice/export), picks S3 or GCS backend by provider
- `Resolver` (`ForPlatform` / `ForConnection`) — one entry point for platform and per-connection storage; `BucketConfigFor` replaces the three hardcoded invoice values
- config: federation + GCS fields, `ResolvedCredentialSource()` derivation, validation (unknown `credential_source` rejected; GCS region-not-required)

Still no external callers — added in stack 5. Compiles + tests green on top of the backends.

### Stack (all → `develop`, merge in order): 1 · 2 · 3 · **4 ←** · 5
Replaces #2237. Testing plan attached before un-drafting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable storage support for Amazon S3 and Google Cloud Storage.
  * Added separate invoice and export storage settings, including bucket selection and optional signing identities.
  * Added static, ambient, and federated AWS credential options for exports.
  * Added automatic storage-provider detection when no provider is configured.
  * Added analytics settings, including usage-meter sink configuration.
  * Added storage operations such as uploads, downloads, existence checks, and presigned links.

* **Bug Fixes**
  * Improved validation and error messages for incomplete or unsupported storage configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->