### PR TITLE
security: add webhook retry rate limiting and tenant isolation in meter hash

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flexprice/flexprice/internal/rest/middleware"
 	"github.com/flexprice/flexprice/internal/types"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
 )
 
 type Handlers struct {
@@ -648,7 +649,17 @@ func NewRouter(
 		webhookGroup := v1Private.Group("/webhooks")
 		{
 			webhookGroup.GET("/dashboard", handlers.Webhook.GetDashboardURL)
-			webhookGroup.POST("/retry", write(types.EntityWebhook, types.ActionWrite), handlers.Webhook.RetryOutboundWebhook)
+			retryRateLimit := rate.Limit(5)
+			retryBurst := 10
+			if cfg.Webhook.RateLimit > 0 {
+				retryRateLimit = rate.Limit(cfg.Webhook.RateLimit)
+				retryBurst = int(cfg.Webhook.RateLimit * 2)
+			}
+			webhookGroup.POST("/retry",
+				middleware.RateLimitByTenant(retryRateLimit, retryBurst),
+				write(types.EntityWebhook, types.ActionWrite),
+				handlers.Webhook.RetryOutboundWebhook,
+			)
 		}
 	}
 

--- a/internal/api/v1/webhook_retry_test.go
+++ b/internal/api/v1/webhook_retry_test.go
@@ -1,0 +1,57 @@
+package v1
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/rest/middleware"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+func TestWebhookRetry_RateLimiting(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(middleware.ErrorHandler())
+
+	rateLimitMW := middleware.RateLimitByTenant(rate.Limit(1), 2)
+	handlerCalled := 0
+	router.POST("/v1/webhooks/retry", rateLimitMW, func(c *gin.Context) {
+		handlerCalled++
+		c.JSON(http.StatusAccepted, gin.H{"success": true})
+	})
+
+	makeReq := func(tenantID, envID string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/retry", bytes.NewBufferString(`{"system_event_id":"se_123"}`))
+		req.Header.Set("Content-Type", "application/json")
+		ctx := types.SetTenantID(req.Context(), tenantID)
+		ctx = types.SetEnvironmentID(ctx, envID)
+		req = req.WithContext(ctx)
+		router.ServeHTTP(w, req)
+		return w
+	}
+
+	// 1st request - ok
+	w1 := makeReq("tenant_test", "env_test")
+	assert.Equal(t, http.StatusAccepted, w1.Code)
+
+	// 2nd request - ok (burst of 2)
+	w2 := makeReq("tenant_test", "env_test")
+	assert.Equal(t, http.StatusAccepted, w2.Code)
+
+	// 3rd request - rate limited (429)
+	w3 := makeReq("tenant_test", "env_test")
+	assert.Equal(t, http.StatusTooManyRequests, w3.Code)
+
+	// Other tenant is unaffected
+	w4 := makeReq("tenant_other", "env_test")
+	assert.Equal(t, http.StatusAccepted, w4.Code)
+
+	assert.Equal(t, 3, handlerCalled)
+}

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -613,15 +613,15 @@ func (s *meterUsageTrackingService) checkMeterFilters(event *events.Event, filte
 
 // generateUniqueHash returns a SHA-256 hex string used for deduplication.
 // Two cases:
-//  1. COUNT_UNIQUE: hash(eventName + fieldName + fieldValue) — two events with
-//     the same field value produce the same hash and are deduplicated.
-//  2. All other types: hash(eventName + eventID) — every distinct event is unique.
+//  1. COUNT_UNIQUE: hash(tenantID + environmentID + eventName + fieldName + fieldValue) — two events with
+//     the same field value in the same tenant/env produce the same hash and are deduplicated.
+//  2. All other types: empty string (or not used).
 func (s *meterUsageTrackingService) generateUniqueHash(event *events.Event, m *meter.Meter) string {
 	var hashStr string
 
 	if m.Aggregation.Type == types.AggregationCountUnique {
 		if fieldValue, ok := event.Properties[m.Aggregation.Field]; ok {
-			hashStr = fmt.Sprintf("%s:%s:%v", event.EventName, m.Aggregation.Field, fieldValue)
+			hashStr = fmt.Sprintf("%s:%s:%s:%s:%v", event.TenantID, event.EnvironmentID, event.EventName, m.Aggregation.Field, fieldValue)
 		}
 	}
 

--- a/internal/ee/service/meter_usage_tracking_test.go
+++ b/internal/ee/service/meter_usage_tracking_test.go
@@ -157,8 +157,10 @@ func (s *MeterUsageTrackingSuite) TestGenerateUniqueHash_NonCountUnique() {
 
 func (s *MeterUsageTrackingSuite) TestGenerateUniqueHash_CountUnique() {
 	event := &events.Event{
-		ID:        "evt_123",
-		EventName: "api_call",
+		ID:            "evt_123",
+		TenantID:      types.DefaultTenantID,
+		EnvironmentID: "env_1",
+		EventName:     "api_call",
 		Properties: map[string]interface{}{
 			"user_id": "user_456",
 		},
@@ -167,23 +169,49 @@ func (s *MeterUsageTrackingSuite) TestGenerateUniqueHash_CountUnique() {
 
 	hash := s.svc.generateUniqueHash(event, m)
 
-	// Different event with same user_id should produce same hash (field-based)
+	// Different event with same user_id, tenant, env, event_name should produce same hash (field-based)
 	event2 := &events.Event{
-		ID:         "evt_789",
-		EventName:  "api_call",
-		Properties: map[string]interface{}{"user_id": "user_456"},
+		ID:            "evt_789",
+		TenantID:      types.DefaultTenantID,
+		EnvironmentID: "env_1",
+		EventName:     "api_call",
+		Properties:    map[string]interface{}{"user_id": "user_456"},
 	}
 	hash2 := s.svc.generateUniqueHash(event2, m)
 	assert.Equal(s.T(), hash, hash2)
 
 	// Different user_id should produce different hash
 	event3 := &events.Event{
-		ID:         "evt_789",
-		EventName:  "api_call",
-		Properties: map[string]interface{}{"user_id": "user_000"},
+		ID:            "evt_789",
+		TenantID:      types.DefaultTenantID,
+		EnvironmentID: "env_1",
+		EventName:     "api_call",
+		Properties:    map[string]interface{}{"user_id": "user_000"},
 	}
 	hash3 := s.svc.generateUniqueHash(event3, m)
 	assert.NotEqual(s.T(), hash, hash3)
+
+	// Different tenant should produce different hash (defense in depth)
+	event4 := &events.Event{
+		ID:            "evt_789",
+		TenantID:      "tenant_other",
+		EnvironmentID: "env_1",
+		EventName:     "api_call",
+		Properties:    map[string]interface{}{"user_id": "user_456"},
+	}
+	hash4 := s.svc.generateUniqueHash(event4, m)
+	assert.NotEqual(s.T(), hash, hash4)
+
+	// Different environment should produce different hash (defense in depth)
+	event5 := &events.Event{
+		ID:            "evt_789",
+		TenantID:      types.DefaultTenantID,
+		EnvironmentID: "env_other",
+		EventName:     "api_call",
+		Properties:    map[string]interface{}{"user_id": "user_456"},
+	}
+	hash5 := s.svc.generateUniqueHash(event5, m)
+	assert.NotEqual(s.T(), hash, hash5)
 }
 
 // --- extractQuantity tests ---

--- a/internal/rest/middleware/rate_limit.go
+++ b/internal/rest/middleware/rate_limit.go
@@ -1,0 +1,96 @@
+package middleware
+
+import (
+	"sync"
+	"time"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+// RateLimiter manages keyed token-bucket rate limiters in memory.
+type RateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*clientLimiter
+	rate     rate.Limit
+	burst    int
+	ttl      time.Duration
+}
+
+type clientLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// NewRateLimiter creates a new RateLimiter instance.
+func NewRateLimiter(r rate.Limit, burst int, ttl time.Duration) *RateLimiter {
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	return &RateLimiter{
+		limiters: make(map[string]*clientLimiter),
+		rate:     r,
+		burst:    burst,
+		ttl:      ttl,
+	}
+}
+
+func (rl *RateLimiter) getLimiter(key string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	// Periodic cleanup of idle limiters when map grows
+	if len(rl.limiters) > 1000 {
+		for k, cl := range rl.limiters {
+			if now.Sub(cl.lastSeen) > rl.ttl {
+				delete(rl.limiters, k)
+			}
+		}
+	}
+
+	cl, exists := rl.limiters[key]
+	if !exists {
+		cl = &clientLimiter{
+			limiter: rate.NewLimiter(rl.rate, rl.burst),
+		}
+		rl.limiters[key] = cl
+	}
+	cl.lastSeen = now
+	return cl.limiter
+}
+
+// RateLimitByTenant returns a Gin middleware that enforces token-bucket rate limiting
+// keyed by tenant ID and environment ID (falling back to client IP if tenant ID is empty).
+func RateLimitByTenant(r rate.Limit, burst int) gin.HandlerFunc {
+	rl := NewRateLimiter(r, burst, 10*time.Minute)
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		tenantID := types.GetTenantID(ctx)
+		envID := types.GetEnvironmentID(ctx)
+
+		var key string
+		if tenantID != "" {
+			if envID != "" {
+				key = tenantID + ":" + envID
+			} else {
+				key = tenantID
+			}
+		} else {
+			key = c.ClientIP()
+		}
+
+		limiter := rl.getLimiter(key)
+		if !limiter.Allow() {
+			_ = c.Error(ierr.NewError("rate limit exceeded").
+				WithHint("Too many requests, please slow down.").
+				Mark(ierr.ErrTooManyRequests))
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/rest/middleware/rate_limit_test.go
+++ b/internal/rest/middleware/rate_limit_test.go
@@ -1,0 +1,110 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+)
+
+func TestRateLimitByTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("allows requests within burst and throttles exceeding requests", func(t *testing.T) {
+		router := gin.New()
+		router.Use(ErrorHandler())
+		// 1 req/sec with burst of 2
+		router.POST("/test", RateLimitByTenant(rate.Limit(1), 2), func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		})
+
+		makeReq := func(tenantID, envID string) *httptest.ResponseRecorder {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/test", nil)
+			if tenantID != "" {
+				ctx := types.SetTenantID(req.Context(), tenantID)
+				if envID != "" {
+					ctx = types.SetEnvironmentID(ctx, envID)
+				}
+				req = req.WithContext(ctx)
+			}
+			router.ServeHTTP(w, req)
+			return w
+		}
+
+		// First two requests should pass (burst = 2)
+		w1 := makeReq("tenant_1", "env_1")
+		assert.Equal(t, http.StatusOK, w1.Code)
+
+		w2 := makeReq("tenant_1", "env_1")
+		assert.Equal(t, http.StatusOK, w2.Code)
+
+		// Third request should be rate limited (429)
+		w3 := makeReq("tenant_1", "env_1")
+		assert.Equal(t, http.StatusTooManyRequests, w3.Code)
+
+		// Different tenant should not be affected by tenant_1's rate limit
+		w4 := makeReq("tenant_2", "env_1")
+		assert.Equal(t, http.StatusOK, w4.Code)
+	})
+
+	t.Run("falls back to client IP when tenant ID is absent", func(t *testing.T) {
+		router := gin.New()
+		router.Use(ErrorHandler())
+		router.POST("/test", RateLimitByTenant(rate.Limit(1), 1), func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		})
+
+		req1 := httptest.NewRequest(http.MethodPost, "/test", nil)
+		req1.RemoteAddr = "192.0.2.1:1234"
+		w1 := httptest.NewRecorder()
+		router.ServeHTTP(w1, req1)
+		assert.Equal(t, http.StatusOK, w1.Code)
+
+		// Second request from same IP exceeds burst=1
+		req2 := httptest.NewRequest(http.MethodPost, "/test", nil)
+		req2.RemoteAddr = "192.0.2.1:1234"
+		w2 := httptest.NewRecorder()
+		router.ServeHTTP(w2, req2)
+		assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+
+		// Different IP passes
+		req3 := httptest.NewRequest(http.MethodPost, "/test", nil)
+		req3.RemoteAddr = "192.0.2.2:1234"
+		w3 := httptest.NewRecorder()
+		router.ServeHTTP(w3, req3)
+		assert.Equal(t, http.StatusOK, w3.Code)
+	})
+
+	t.Run("cleans up expired limiters", func(t *testing.T) {
+		rl := NewRateLimiter(rate.Limit(1), 1, 10*time.Millisecond)
+		rl.getLimiter("key1")
+
+		assert.Len(t, rl.limiters, 1)
+
+		time.Sleep(20 * time.Millisecond)
+
+		// Populate dummy entries to exceed the 1000 threshold to trigger cleanup
+		rl.mu.Lock()
+		for i := 0; i < 1001; i++ {
+			rl.limiters[string(rune(i+100))] = &clientLimiter{
+				limiter:  rate.NewLimiter(rate.Limit(1), 1),
+				lastSeen: time.Now().Add(-1 * time.Hour),
+			}
+		}
+		rl.mu.Unlock()
+
+		// Trigger getLimiter which triggers cleanup
+		rl.getLimiter("key_new")
+
+		rl.mu.Lock()
+		// All expired entries should be deleted
+		assert.Less(t, len(rl.limiters), 5)
+		rl.mu.Unlock()
+	})
+}


### PR DESCRIPTION
## Summary

This PR addresses two security enhancements:
1. **Webhook retry rate limiting**: Introduces a token-bucket rate limiting middleware (`RateLimitByTenant`) and attaches it to the `POST /v1/webhooks/retry` endpoint to prevent retry storms or abuse.
2. **Meter `COUNT_UNIQUE` tenant & env isolation**: Incorporates `TenantID` and `EnvironmentID` into the `COUNT_UNIQUE` hash computation for defense-in-depth isolation across tenants/environments.

## Changes
- Added [rate_limit.go](file:///Users/abhipra/Developer/Github/flexprice/internal/rest/middleware/rate_limit.go) with token bucket rate limiting per tenant/environment.
- Applied rate limiting to `/v1/webhooks/retry` in [router.go](file:///Users/abhipra/Developer/Github/flexprice/internal/api/router.go).
- Updated `generateUniqueHash` in [meter_usage_tracking.go](file:///Users/abhipra/Developer/Github/flexprice/internal/ee/service/meter_usage_tracking.go) to include tenant ID and environment ID.
- Added comprehensive unit tests for rate limiting middleware, retry endpoint, and hash calculations.

Fixes #2490
Fixes #2489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-tenant rate limiting for webhook retry requests.
  * Rate limits can be configured, with sensible default limits applied automatically.
  * Tenant and environment usage tracking is now isolated for unique-count metrics.

* **Bug Fixes**
  * Prevented unique-count data from being shared across tenants or environments.
  * Excessive webhook retry requests now return a “Too Many Requests” response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->