### PR TITLE
chore(deploy): retire the AWS staging ECS target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,6 +160,19 @@ jobs:
   #   PROD_DEPLOY_TARGETS / STAGING_DEPLOY_TARGETS
   #   (GitHub Actions → Settings → Variables)
   #
+  # STAGING_DEPLOY_TARGETS is deliberately `[]`. There is no AWS staging: the
+  # `fp-staging-backend` cluster was decommissioned and staging runs on GCP,
+  # deployed by ArgoCD from the Helm chart rather than by this workflow. Every
+  # develop merge failed for days against that dead cluster before it was
+  # cleared, so if you are tempted to repopulate it, confirm the cluster exists
+  # first.
+  #
+  # A develop push still runs the `build` job on purpose — it publishes
+  # ghcr.io/flexprice/flexprice:develop, which GCP staging's argocd-image-updater
+  # watches. Only the ECS jobs below skip, because their matrices expand to zero
+  # entries. `[]` and not blank: resolve-config leaves `targets` as an empty
+  # STRING when the variable is unset, and `fromJson('')` throws.
+  #
   #   Format (one object per region):
   #   [
   #     {

--- a/docs/architecture/DEPLOY_SETUP.md
+++ b/docs/architecture/DEPLOY_SETUP.md
@@ -19,7 +19,7 @@ Configure these in the repo: **Settings → Secrets and variables → Actions**.
 |------|----------------|-------------|
 | `ECR_REGISTRY` | `123456789012.dkr.ecr.ap-south-1.amazonaws.com` | ECR registry host (no `https://`, no trailing slash). |
 | `ECR_REPOSITORY` | `my-app` | ECR repository name. Image tag is `${{ github.sha }}`. |
-| `STAGING_DEPLOY_TARGETS` | See JSON below | JSON array of ECS targets for **staging** (used on `develop` and when manual run chooses staging). |
+| `STAGING_DEPLOY_TARGETS` | `[]` | **Retired.** There is no AWS staging — the `fp-staging-backend` cluster is gone and staging runs on GCP via ArgoCD. Keep this `[]`; see below. |
 | `PROD_DEPLOY_TARGETS` | See JSON below | JSON array of ECS targets for **production** (used on `main` and when manual run chooses production). |
 
 ---
@@ -77,7 +77,22 @@ One object per region. Each object must have: `region`, `cluster`, `api_service`
 ]
 ```
 
-Paste the full JSON (no comments, valid JSON) into the Variable value for `STAGING_DEPLOY_TARGETS` and `PROD_DEPLOY_TARGETS`.
+Paste the full JSON (no comments, valid JSON) into the Variable value for `PROD_DEPLOY_TARGETS`.
+
+### Staging is not deployed by this workflow
+
+`STAGING_DEPLOY_TARGETS` is `[]` and should stay that way. The AWS staging
+cluster (`fp-staging-backend`) was decommissioned; staging now runs on GCP and is
+deployed by ArgoCD from the Helm chart in
+`internal/ee/infrastructure/helm/flexprice`.
+
+A push to `develop` still runs this workflow, and that is intentional — the
+`build` job publishes `ghcr.io/flexprice/flexprice:develop`, which GCP staging's
+`argocd-image-updater` watches for new digests. Everything after `build` skips,
+because the deploy and migration matrices expand to zero entries.
+
+Use `[]` rather than clearing the variable: `resolve-config` leaves `targets` as
+an empty **string** when the variable is unset, and `fromJson('')` fails the run.
 
 ---
 
@@ -87,4 +102,5 @@ Paste the full JSON (no comments, valid JSON) into the Variable value for `STAGI
 - [ ] **Variables:** `ECR_REGISTRY`, `ECR_REPOSITORY`
 - [ ] **Variables:** `STAGING_DEPLOY_TARGETS`, `PROD_DEPLOY_TARGETS` (valid JSON)
 - [ ] **AWS:** IAM role `github-cicd` with OIDC trust for your repo; permissions for ECR push and ECS `DescribeServices`, `DescribeTaskDefinition`, `RegisterTaskDefinition`, `UpdateService`
+- [ ] **AWS:** the same role also needs `ecs:RunTask` and `ecs:DescribeTasks` for the database-migration task, plus `iam:PassRole` for the task and execution roles it inherits. `RunTask` is scoped to task definitions matching `*-migrate:*` in the backend cluster — see the `ECSRunMigrationTask` / `ECSPollMigrationTask` statements on `GitHubActionsECRDeployPolicy`
 - [ ] **Runners:** Workflow uses `runs-on: self-hosted`; ensure a self-hosted runner is registered


### PR DESCRIPTION
`STAGING_DEPLOY_TARGETS` pointed at `fp-staging-backend` — a cluster that no longer exists. Staging runs on GCP, deployed by ArgoCD from the Helm chart, not by this workflow.

Every `develop` merge had been failing against that dead cluster for days (#2687, #2657, #2665 all failed at `Deploy API`). After #2688 it surfaced as a failed **Migrate Database** job instead, which reads like a migration problem and isn't one:

```
aws: [ERROR]: An error occurred (ClusterNotFoundException) when calling
the DescribeServices operation: Cluster not found.
CLUSTER: fp-staging-backend
```

## What changed

The variable itself is already set to `[]` — it's a repository variable, not a file here. This PR records **why**, in the two places someone would look before repopulating it: the `resolve-config` comment block in `deploy.yml`, and `docs/architecture/DEPLOY_SETUP.md`.

Two details worth keeping:

- **`[]`, not blank.** `resolve-config` only forces `preprod_targets` to `[]` when the variable is unset; `targets` stays an empty *string*, and `fromJson('')` throws.
- **`build` still runs on develop, deliberately.** It publishes `ghcr.io/flexprice/flexprice:develop`, which GCP staging's `argocd-image-updater` watches for new digests. Only the ECS jobs skip, their matrices expanding to zero entries.

Also adds the two IAM actions the migration task needs to the setup checklist — `ecs:RunTask` and `ecs:DescribeTasks` — which it didn't previously mention.

## Effect

| Job on a develop push | Before | After |
|---|---|---|
| `build` | runs | runs |
| `migrate` | **fails** — cluster not found | skipped |
| `deploy-preprod` / `api` / `consumer` / `worker` | fail or skip | skipped |

`PROD_DEPLOY_TARGETS` is untouched.

## Note

Documentation only — no behaviour change, since the variable was already updated. Worth confirming on the next develop merge that the zero-entry matrices genuinely skip rather than error; that path is reasoned through, not yet observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that AWS staging deployments are retired and staging now runs on GCP through ArgoCD.
  * Documented the required empty staging target configuration and its impact on deployment workflows.
  * Added guidance on required AWS permissions for database migration tasks.
  * Explained how develop builds continue publishing images for staging use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->