### PR TITLE
fix(helm): verify ClickHouse over the HTTP port, not the native one

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
+++ b/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
@@ -9,6 +9,27 @@ Chart versions are independent of the application (`appVersion`) version —
 `Chart.yaml#version` bumps on every chart change, `appVersion` follows the
 FlexPrice app release.
 
+## [1.4.1] - 2026-08-31
+
+### Fixed
+- **The migration Job's `verify` step queried ClickHouse over HTTP on the NATIVE
+  protocol port.** In `mode: external` the port came from splitting
+  `clickhouse.address`, which is the endpoint the application uses natively
+  (9000). The HTTP GET failed, `|| echo 0` turned that into `n=0`, and every
+  table was reported `MISSING` against a ClickHouse that was healthy.
+  - Surfaced on GCP staging the first time migrations were enabled there:
+    `❌ MISSING ClickHouse table: events`, while the table existed with 20
+    others. Proven directly — the same query returns `1` on 8123 and fails on
+    9000.
+  - `external` now uses `clickhouse.httpPort` (default `8123`), matching what
+    `altinity` mode already hardcoded. Set `clickhouse.httpPort` if a deployment
+    moves it.
+- **A failed query is no longer reported as a missing table.** `|| echo 0`
+  collapsed every failure — unreachable host, wrong port, bad credentials — into
+  `MISSING`, sending whoever is on call to inspect a schema that was never the
+  problem. Connectivity failures now say so, print what `wget` returned, and name
+  the likely causes; a genuine miss reports the count it actually saw.
+
 ## [1.4.0] - 2026-08-30
 
 ### Changed

--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -733,7 +733,19 @@ spec:
               {{- if .Values.migration.steps.clickhouse }}
               echo "verify: ClickHouse tables"
               CH_HTTP_HOST="{{ if eq .Values.clickhouse.mode "external" }}{{ index (splitList ":" .Values.clickhouse.address) 0 }}{{ else if eq .Values.clickhouse.mode "altinity" }}chi-{{ include "flexprice.fullname" . }}-flexprice-0-0{{ if .Values.clickhouse.namespace }}.{{ .Values.clickhouse.namespace }}.svc.cluster.local{{ end }}{{ else }}{{ include "flexprice.clickhouseServiceHost" . }}{{ end }}"
-              CH_HTTP_PORT="{{ if eq .Values.clickhouse.mode "external" }}{{ index (splitList ":" .Values.clickhouse.address) 1 }}{{ else if eq .Values.clickhouse.mode "altinity" }}8123{{ else }}{{ .Values.clickhouse.standalone.service.httpPort }}{{ end }}"
+              {{- /*
+                External mode used to take this port from clickhouse.address by
+                splitting on ":". That address is the NATIVE protocol endpoint the
+                application connects with (9000), not the HTTP one, so this check
+                issued an HTTP GET against a native-protocol port. wget failed,
+                the `|| echo 0` below turned that into n=0, and every table was
+                reported MISSING against a ClickHouse that was perfectly healthy.
+                Cost half an investigation on GCP staging, 2026-08-31.
+
+                8123 matches what altinity mode already hardcodes. Override with
+                clickhouse.httpPort if a deployment moves it.
+              */}}
+              CH_HTTP_PORT="{{ if eq .Values.clickhouse.mode "external" }}{{ .Values.clickhouse.httpPort | default 8123 }}{{ else if eq .Values.clickhouse.mode "altinity" }}{{ .Values.clickhouse.httpPort | default 8123 }}{{ else }}{{ .Values.clickhouse.standalone.service.httpPort }}{{ end }}"
               CH_SCHEME="{{ if .Values.clickhouse.tls }}https{{ else }}http{{ end }}"
               # Resolved into a variable instead of templated inline at the end of
               # the wget call. Inline, the left-chomp on the conditional eats the
@@ -751,12 +763,24 @@ spec:
               {{- if $.Values.clickhouse.tlsSkipVerify }}
               CH_INSECURE="--no-check-certificate"
               {{- end }}
+              # A failed query is NOT a missing table. `|| echo 0` used to collapse
+              # every failure -- unreachable host, wrong port, bad credentials --
+              # into "MISSING", which sends whoever is on call to look at a schema
+              # that was never the problem. Separate the two outcomes and say which.
               for t in events meter_usage; do
-                n=$(wget -qO- "${CH_SCHEME}://${CH_HTTP_HOST}:${CH_HTTP_PORT}/?query=SELECT+count()+FROM+system.tables+WHERE+database='{{ .Values.clickhouse.database }}'+AND+name='${t}'" \
+                if ! n=$(wget -qO- "${CH_SCHEME}://${CH_HTTP_HOST}:${CH_HTTP_PORT}/?query=SELECT+count()+FROM+system.tables+WHERE+database='{{ .Values.clickhouse.database }}'+AND+name='${t}'" \
                     --header="X-ClickHouse-User: ${FLEXPRICE_CLICKHOUSE_USERNAME}" \
                     --header="X-ClickHouse-Key: ${FLEXPRICE_CLICKHOUSE_PASSWORD}" \
-                    ${CH_INSECURE} 2>/dev/null || echo 0)
-                [ "$n" = "1" ] || { echo "❌ MISSING ClickHouse table: ${t}"; exit 1; }
+                    ${CH_INSECURE} 2>&1); then
+                  echo "❌ CANNOT QUERY ClickHouse at ${CH_SCHEME}://${CH_HTTP_HOST}:${CH_HTTP_PORT}"
+                  echo "   This is a connectivity/auth failure, NOT a missing table."
+                  echo "   wget said: ${n}"
+                  echo "   Check clickhouse.address, clickhouse.httpPort (HTTP is 8123,"
+                  echo "   the native protocol is 9000) and the credentials."
+                  exit 1
+                fi
+                n="$(echo "$n" | tr -d '[:space:]')"
+                [ "$n" = "1" ] || { echo "❌ MISSING ClickHouse table: ${t} (database '{{ .Values.clickhouse.database }}' returned count=${n})"; exit 1; }
                 echo "  ✅ ${t}"
               done
               {{- end }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -802,6 +802,11 @@ postgres:
 #                           Install: kubectl apply -f shared/clickhouse/operator/install-bundle.yaml
 #   external              — point to ClickHouse Cloud or any self-managed endpoint.
 clickhouse:
+  # HTTP port used ONLY by the migration Job's verify step, which queries over
+  # HTTP rather than the native protocol. `address` below is the NATIVE endpoint
+  # (9000) the application uses; the two are not interchangeable, and deriving
+  # one from the other is what made verify report healthy tables as MISSING.
+  httpPort: 8123
   mode: standalone   # standalone | altinity | external
 
   # Namespace for the in-cluster ClickHouse (standalone/altinity modes). Empty =


### PR DESCRIPTION
The migration Job's `verify` step issued an HTTP GET against ClickHouse's **native protocol port**. In `mode: external`, `CH_HTTP_PORT` came from splitting `clickhouse.address` on `":"` — but that address is the endpoint the application connects with natively (`9000`), not the HTTP one (`8123`). `wget` failed, the `|| echo 0` fallback turned that into `n=0`, and every table was reported `MISSING` against a ClickHouse that was entirely healthy.

## How it surfaced

GCP staging, the first time migrations were ever enabled there (infrastructure#349):

```
verify: ClickHouse tables
❌ MISSING ClickHouse table: events
```

`events` existed the whole time, in the `flexprice` database alongside 20 other tables. Proven directly against the cluster:

```
port 8123 →  1          ← table exists, HTTP works
port 9000 →  exit 8     ← wget fails against the native protocol port
```

And the rendered manifest staging actually received:

```
CH_HTTP_HOST="clickhouse-staging.clickhouse.svc.cluster.local"
CH_HTTP_PORT="9000"      ← should be 8123
```

The `8123` literal already in the template applies only to `mode: altinity`, so it never evaluated here.

## Two fixes

**1. `external` now uses `clickhouse.httpPort` (default `8123`)**, matching what `altinity` already hardcoded. The new value is documented next to `address`, because the two ports are not interchangeable and deriving one from the other is exactly what caused this.

**2. A failed query is no longer reported as a missing table.** `|| echo 0` collapsed every failure — unreachable host, wrong port, bad credentials — into `MISSING`, which sends whoever is on call to inspect a schema that was never the problem. Connectivity failures now say so, print what `wget` returned, and name the likely causes; a genuine miss reports the count it actually saw.

The second one is the more valuable of the two. The port bug cost an investigation only because the error message confidently pointed at the wrong thing — and the template already carried a comment about a *previous* false-`MISSING` bug of the same shape.

## Verified

| | |
|---|---|
| external mode renders | `CH_HTTP_PORT="8123"` |
| production region renders | `CH_HTTP_PORT="8123"` |
| `--set clickhouse.httpPort=9443` | `CH_HTTP_PORT="9443"` |
| generated script | passes `sh -n` |
| `helm lint` | clean |

Chart `1.4.0` → `1.4.1`.

## Note

This blocks GCP staging right now — the Job fails at `verify` (step 7 of 7) even though the Postgres migration itself succeeded at step 5 (`Applied: 7 / Pending: 0`, zero DDL). Staging picks this up from `develop` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration verification for external ClickHouse deployments by using the correct HTTP connection port.
  * Deployment checks now distinguish connection or authentication failures from genuinely missing tables.
  * Added clearer diagnostic output when ClickHouse verification cannot connect, making deployment issues easier to troubleshoot.

* **Configuration**
  * Added a configurable ClickHouse HTTP port, defaulting to `8123`.

* **Chores**
  * Updated the FlexPrice Helm chart version to `1.4.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->