### PR TITLE
fix(helm): keep migration Job logs after it finishes

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
+++ b/internal/ee/infrastructure/helm/flexprice/CHANGELOG.md
@@ -61,6 +61,21 @@ FlexPrice app release.
   - `migrate postgres up` now refuses to start while any index is INVALID,
     naming each one and printing the `DROP INDEX CONCURRENTLY` to run.
 
+- **The migration Job no longer deletes its own logs.** `hook-delete-policy` was
+  `hook-succeeded,hook-failed`, which removed the Job — and its pod — the instant
+  the migration ended, so the one artefact explaining *why* a migration failed
+  disappeared before anyone could read it. During the 2026-08-31 staging bring-up
+  the only way to see a failure was to race the deletion with `kubectl logs`.
+  - New `migration.hookDeletePolicy`, default `before-hook-creation`: the previous
+    Job is removed just before the next one is created. That still prevents the
+    stale-Job collision that stalled the northamerica-northeast2 bring-up, but a
+    finished Job and its pod now survive until `ttlSecondsAfterFinished` (1h) or
+    the next migration.
+  - Set it back to `hook-succeeded,hook-failed` to restore the old behaviour.
+  - This does **not** make a re-Sync re-run migrations: ArgoCD tracks hooks per
+    revision, so an unchanged revision skips the hook whether or not a Job object
+    exists. Migrations run when the image or config changes.
+
 ### ⚠️ `activeDeadlineSeconds` and long index builds
 `activeDeadlineSeconds: 900` is a hard SIGKILL of the Job. In Helm the migration
 and its watcher are the same pod, so the deadline aborts the migration itself —

--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -77,12 +77,27 @@ metadata:
       northamerica-northeast2 bring-up — the migration had failed once, and
       every later sync silently declined to try again.
 
-      ttlSecondsAfterFinished still bounds the window, but only after an hour;
-      this makes the retry immediate. Logs are lost on failure, which is the
-      accepted trade — the Job is re-runnable and the pod logs are the place to
-      look while it is still running.
+      That reasoning still holds, but `hook-failed` is no longer how it is
+      satisfied. It deleted the Job -- and its logs -- the instant the migration
+      ended, so the one artefact explaining WHY a migration failed disappeared
+      before anyone could read it. During the 2026-08-31 staging bring-up the
+      only way to see a failure was to race the deletion with `kubectl logs`.
+      At 3am, against production, nobody wins that race.
+
+      The default is now `before-hook-creation`: the previous Job is removed
+      just before the next one is created, which prevents the same-name
+      collision described above WITHOUT destroying the evidence. A finished Job
+      and its pod survive until ttlSecondsAfterFinished (1h) or the next
+      migration, whichever comes first.
+
+      Set migration.hookDeletePolicy back to "hook-succeeded,hook-failed" to
+      restore the previous behaviour for a deployment that needs it.
+
+      Note this does NOT make a re-Sync re-run migrations. ArgoCD tracks hooks
+      per revision, so an unchanged revision skips the hook whether or not a Job
+      object is present. Migrations run when the image or config changes.
     */}}
-    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+    "helm.sh/hook-delete-policy": {{ .Values.migration.hookDeletePolicy | default "before-hook-creation" | quote }}
     {{- end }}
 spec:
   {{- /* NOT `| default 3`: Helm's default treats 0 as empty, so an explicit

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -1022,6 +1022,24 @@ migration:
   # no longer stops the index from finishing.
   activeDeadlineSeconds: 900
   ttlSecondsAfterFinished: 3600  # Time to keep completed job (1 hour)
+
+  # When the migration Job (and its pod, and therefore its LOGS) is deleted.
+  #
+  # before-hook-creation  the previous Job is removed just before the next one
+  #                       is created. A finished Job survives until
+  #                       ttlSecondsAfterFinished above, so the logs of a failed
+  #                       migration are still there when someone goes looking.
+  #                       This is the default and what you want on call.
+  #
+  # hook-succeeded,hook-failed
+  #                       the previous behaviour: delete the moment the Job ends,
+  #                       either way. Retries never collide with a stale Job, but
+  #                       a failed migration erases the only record of why.
+  #
+  # Either value prevents the stale-Job collision that stalled the
+  # northamerica-northeast2 bring-up; they differ only in when the deletion
+  # happens, and therefore in whether the logs outlive the failure.
+  hookDeletePolicy: before-hook-creation
   command: ""  # Custom command to run (if empty, uses default migration steps)
   # Apply a SINGLE ClickHouse baseline .sql via `migrate clickhouse --file`
   # instead of scanning migrations/clickhouse/. Empty = scan the directory (the


### PR DESCRIPTION
`hook-delete-policy` was `hook-succeeded,hook-failed`, which removed the migration Job — and its pod — **the instant it ended, either way**. The one artefact explaining *why* a migration failed disappeared before anyone could read it.

During the 2026-08-31 staging bring-up, the only way to see a failure was to race the deletion with `kubectl logs`. At 3am against production, nobody wins that race.

## Raising the TTL would not have helped

`ttlSecondsAfterFinished` is already `3600`. The delete policy fires first, so the TTL never applied. That's the trap — the value that looks like it controls this doesn't.

## Why `hook-failed` was there

For a real reason, recorded in the template: a lingering failed Job, named from the env+image checksum, made later syncs either report the hook as already-completed or fail on an immutable Job spec. That's what stalled the `northamerica-northeast2` bring-up.

That reasoning still holds — it's just satisfied differently now.

## The change

New `migration.hookDeletePolicy`, default **`before-hook-creation`**: the previous Job is removed just before the next one is created.

| | before | after |
|---|---|---|
| Logs after success | gone instantly | kept until TTL (1h) or next run |
| Logs after failure | **gone instantly** | kept until TTL (1h) or next run |
| Stale Job blocks retry | prevented by deleting immediately | prevented by deleting before recreate |

Set it back to `hook-succeeded,hook-failed` for any deployment that wants the old behaviour.

## What this does *not* fix

**A re-Sync still won't re-run migrations.** ArgoCD tracks hooks per revision, so an unchanged revision skips the hook whether or not a Job object exists — observed directly today: `successfully synced (no more tasks)` in 2 seconds, no Job, even with `force: true`. Migrations run when the image or config changes.

Worth knowing separately, because "press Sync to re-run the migration" is a reasonable assumption that silently does nothing.

## Verified

| | |
|---|---|
| staging + production values | `"before-hook-creation"` |
| override via values file | `"hook-succeeded,hook-failed"` |
| override via `--set` (comma escaped) | `"hook-succeeded,hook-failed"` |
| empty string | falls back to the default |
| `asHook=false` | no hook annotations rendered |
| `helm lint` | clean |

No chart version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Migration Jobs and their logs now remain available after completion or failure, making troubleshooting easier.
  - Completed Jobs are automatically cleaned up after the configured retention period or before the next migration runs.
  - Re-syncing does not unexpectedly rerun migrations.

- **Configuration**
  - Added an option to control migration Job cleanup behavior.
  - The previous immediate-cleanup behavior can be restored when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->