### PR TITLE
fix(kafka): default 0-partition topics + remove redundant create-kafka-topics CLI step

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/jobs/migration.yaml
@@ -437,15 +437,24 @@ spec:
 
         {{- if .Values.migration.steps.kafka }}
         # ── Run Kafka migration: topic reconcile + allow-all ACL seed ─────────
-        # `migrate kafka` reconciles topics against the desired spec (partition
-        # growth, retention, FLEXPRICE_KAFKA_TOPICS) AND seeds the allow-all
-        # ACLs in one pass. Run it for EVERY kafka-enabled deploy so topic
-        # reconcile happens everywhere; the ACL seed is gated to SASL/SCRAM
-        # (MSK) internally, a no-op on plaintext and OAUTHBEARER clusters.
-        # SCRAM clusters (MSK) enforce ACLs once SASL is on; without an
-        # allow-all rule set, every client -- including the app itself -- is
-        # locked out the moment auth is enabled. OAUTHBEARER clusters use
-        # IAM-style authz, not Kafka ACLs, so the seed skips them.
+        # `migrate kafka` is the SOLE topic-creation path (the old separate
+        # create-kafka-topics CLI init container was removed -- it duplicated
+        # this step's coverage, hardcoded 10 topic names, and could drift from
+        # the binary's config.yaml `kafka.topics` map). It reconciles topics
+        # against the desired spec (create, partition growth, retention,
+        # FLEXPRICE_KAFKA_TOPICS) AND seeds the allow-all ACLs in one pass. Run
+        # it for EVERY kafka-enabled deploy so topic reconcile happens
+        # everywhere; the ACL seed is gated to SASL/SCRAM (MSK) internally, a
+        # no-op on plaintext and OAUTHBEARER clusters. SCRAM clusters (MSK)
+        # enforce ACLs once SASL is on; without an allow-all rule set, every
+        # client -- including the app itself -- is locked out the moment auth
+        # is enabled. OAUTHBEARER clusters use IAM-style authz, not Kafka
+        # ACLs, so the seed skips them.
+        #
+        # Extra client-declared topics used to be supported via
+        # migration.kafkaTopics.topics (CLI step, now removed). That path is
+        # gone: any topic not in config.yaml's `kafka.topics` map must now be
+        # added via FLEXPRICE_KAFKA_TOPICS (JSON) instead.
         - name: run-kafka-migrate
           image: "{{ include "flexprice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -542,183 +551,6 @@ spec:
               memory: "32Mi"
         {{- end }}
 
-        {{- if .Values.migration.steps.kafka }}
-        # ── 9. Create Kafka topics ────────────────────────────────────────────
-        # Topics are NOT auto-created by the broker (autoCreateTopicsEnable: false).
-        # This init container creates all required topics idempotently.
-        - name: create-kafka-topics
-          image: "{{ if .Values.kafkaConfig.enabled }}bitnami/kafka:latest{{ else }}confluentinc/cp-kafka:{{ .Values.kafkaConfig.internal.image.tag | default "7.7.1" }}{{ end }}"
-          env:
-            # The JVM sizes its default max heap from the cgroup memory limit --
-            # roughly a quarter of it. At the 256Mi limit this container used to
-            # carry, that is ~64Mi, and the admin client exhausts it while
-            # reading broker metadata over TLS:
-            #
-            #   java.lang.OutOfMemoryError: Java heap space
-            #     at org.apache.kafka.common.network.NetworkReceive.readFrom
-            #   ERROR ... The AdminClient thread has exited. Call: createTopics
-            #
-            # Every topic then fails in turn, so the step reports errors per
-            # topic rather than one cause, and none of them mention memory.
-            # Setting the heap explicitly decouples it from the limit.
-            - name: KAFKA_HEAP_OPTS
-              value: {{ .Values.migration.kafkaTopics.heapOpts | default "-Xmx512m -Xms256m" | quote }}
-            {{- if and .Values.kafkaConfig.useSASL (ne .Values.kafkaConfig.saslMechanism "OAUTHBEARER") }}
-            # Injected rather than templated into the properties file, so the
-            # password is not readable in the rendered Job spec.
-            - name: KAFKA_SASL_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "flexprice.secretName" . }}
-                  key: kafka-sasl-password
-            {{- end }}
-          command:
-            - sh
-            - -c
-            - |
-              KAFKA_BROKER="{{ include "flexprice.kafkaBrokers" . }}"
-              echo "Creating Kafka topics on ${KAFKA_BROKER}..."
-
-              # cp-kafka uses /usr/bin/kafka-topics; bitnami uses kafka-topics.sh
-              KAFKA_TOPICS_CMD="kafka-topics"
-              if command -v kafka-topics.sh >/dev/null 2>&1; then
-                KAFKA_TOPICS_CMD="kafka-topics.sh"
-              fi
-
-              CMD_CONFIG=""
-              {{- if or .Values.kafkaConfig.useSASL .Values.kafkaConfig.tls }}
-              # Client config for the admin protocol.
-              #
-              # The app pods get SASL/TLS from their env, but kafka-topics is a
-              # separate JVM tool that reads NONE of that -- it needs a
-              # properties file. Without one it dials a SASL listener (MSK's
-              # 9096) with PLAINTEXT and no credentials.
-              #
-              # The failure does not look like auth. The TCP connect succeeds,
-              # so the wait-for-kafka port check passes and reports the broker
-              # ready; the handshake then never completes and the tool reports
-              #
-              #   Timed out waiting for a node assignment. Call: createTopics
-              #
-              # or, worse, reads the TLS server response as a Kafka frame
-              # length and allocates against it:
-              #
-              #   java.lang.OutOfMemoryError: Java heap space
-              #
-              # which sends you tuning the heap for a credentials problem.
-              CMD_CONFIG=/tmp/kafka-admin.properties
-              {{- if .Values.kafkaConfig.useSASL }}
-              cat > "${CMD_CONFIG}" <<'PROPS'
-              security.protocol={{ if .Values.kafkaConfig.tls }}SASL_SSL{{ else }}SASL_PLAINTEXT{{ end }}
-              sasl.mechanism={{ .Values.kafkaConfig.saslMechanism }}
-              PROPS
-              {{- $jaas := ternary "org.apache.kafka.common.security.scram.ScramLoginModule" "org.apache.kafka.common.security.plain.PlainLoginModule" (hasPrefix "SCRAM" .Values.kafkaConfig.saslMechanism) }}
-              # Written separately: the password comes from the environment and
-              # must not be baked into the rendered manifest, where it would be
-              # readable by anyone who can get the Job spec.
-              printf 'sasl.jaas.config=%s required username="%s" password="%s";\n' \
-                '{{ $jaas }}' \
-                '{{ .Values.kafkaConfig.saslUser }}' \
-                "${KAFKA_SASL_PASSWORD}" >> "${CMD_CONFIG}"
-              {{- else }}
-              cat > "${CMD_CONFIG}" <<'PROPS'
-              security.protocol=SSL
-              PROPS
-              {{- end }}
-              # The heredocs above are indented for template readability; strip
-              # it, or every key is parsed with leading spaces and ignored.
-              sed -i 's/^[[:space:]]*//' "${CMD_CONFIG}"
-              CMD_CONFIG="--command-config ${CMD_CONFIG}"
-              {{- end }}
-
-              # Count failures rather than swallowing them.
-              #
-              # `|| true` on its own makes this step report success no matter
-              # what: a run where the admin client died on the FIRST topic and
-              # created none still printed "✅ Kafka topics ready" and exited 0.
-              # The app then starts against a broker with no topics and, where
-              # auto-creation is off (the MSK default), fails at first publish
-              # -- a long way from the step that was actually at fault.
-              #
-              # --if-not-exists already makes a re-run a no-op, so a non-zero
-              # exit here means a real failure and not a pre-existing topic.
-              FAILED=0
-              # $1=topic $2=partitions $3=replication-factor, followed by zero
-              # or more "key=value" pairs turned into repeated --config flags
-              # (retention.ms, cleanup.policy, min.insync.replicas, ...).
-              create_topic() {
-                TOPIC=$1
-                PARTITIONS=${2:-1}
-                REPLICATION=${3:-1}
-                # All call sites below always pass topic/partitions/replication,
-                # so there are always >=3 positional args to drop here before
-                # collecting the optional trailing key=value config pairs.
-                shift 3
-                CONFIG_ARGS=""
-                for KV in "$@"; do
-                  CONFIG_ARGS="${CONFIG_ARGS} --config ${KV}"
-                done
-                echo "→ Creating topic: ${TOPIC} (partitions=${PARTITIONS}, replication=${REPLICATION}${CONFIG_ARGS:+, configs:${CONFIG_ARGS}})"
-                if ! $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" ${CMD_CONFIG} \
-                  --create --if-not-exists \
-                  --topic "${TOPIC}" \
-                  --partitions "${PARTITIONS}" \
-                  --replication-factor "${REPLICATION}" \
-                  ${CONFIG_ARGS}; then
-                  echo "  ✗ FAILED to create ${TOPIC}"
-                  FAILED=$((FAILED + 1))
-                fi
-              }
-
-              # All built-in topics used by FlexPrice. These 10 calls are
-              # unconditional and always run with today's names/defaults —
-              # migration.kafkaTopics.topics (below) is purely additive, so
-              # leaving it empty (the default) changes nothing here.
-              create_topic "{{ .Values.kafkaConfig.topic }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              create_topic "{{ .Values.kafkaConfig.topicLazy }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              {{- with .Values.kafkaConfig.topicBulk }}
-              create_topic "{{ . }}" "{{ $.Values.migration.kafkaTopics.partitions | default 3 }}" "{{ $.Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              {{- end }}
-              create_topic "{{ .Values.kafkaConfig.topicDLQ | default "events_dlq" }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              create_topic "{{ .Values.eventPostProcessing.topic }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              create_topic "{{ .Values.eventPostProcessing.topicBackfill }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              create_topic "{{ .Values.webhook.topic }}" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              create_topic "events_backfill" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              create_topic "wallet_alert" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-              create_topic "onboarding_events" "{{ .Values.migration.kafkaTopics.partitions | default 3 }}" "{{ .Values.migration.kafkaTopics.replicationFactor | default 1 }}"
-
-              # Client-declared extra/override topics (migration.kafkaTopics.topics).
-              # Empty by default -- this loop then emits nothing and behavior
-              # is identical to before this feature existed.
-              {{- range .Values.migration.kafkaTopics.topics }}
-              create_topic "{{ .name }}" \
-                "{{ .partitions | default $.Values.migration.kafkaTopics.partitions | default 3 }}" \
-                "{{ .replicationFactor | default $.Values.migration.kafkaTopics.replicationFactor | default 1 }}"{{ range $k, $v := .configs }} "{{ $k }}={{ $v }}"{{ end }}
-              {{- end }}
-
-              if [ "${FAILED}" -ne 0 ]; then
-                echo "❌ ${FAILED} topic(s) could not be created."
-                echo "   OutOfMemoryError above means the admin client heap is too"
-                echo "   small: raise migration.kafkaTopics.heapOpts (and keep"
-                echo "   resources.limits.memory comfortably above it)."
-                exit 1
-              fi
-
-              echo "✅ Kafka topics ready"
-
-              # Listing is diagnostic only. It is a second admin-client session
-              # and can OOM on its own after every topic was created, which
-              # would fail the whole migration over a log line.
-              $KAFKA_TOPICS_CMD --bootstrap-server "${KAFKA_BROKER}" ${CMD_CONFIG} --list || \
-                echo "(could not list topics; creation already succeeded)"
-          # Must stay comfortably above KAFKA_HEAP_OPTS above: the limit has to
-          # cover the heap plus JVM overhead (metaspace, thread stacks, direct
-          # buffers), or the kernel OOM-kills the container instead of the JVM
-          # throwing -- which surfaces as exit code 137 and no log line at all.
-          resources:
-            {{- toYaml .Values.migration.kafkaTopics.resources | nindent 12 }}
-        {{- end }}
-
         {{- if .Values.migration.steps.verify }}
         # ── 10. Post-migration sanity check ───────────────────────────────────
         # Fatal gate: asserts the ClickHouse tables and Kafka topics the prior
@@ -808,18 +640,18 @@ spec:
               elif command -v kafka-topics.sh >/dev/null 2>&1; then
                 KAFKA_TOPICS_CMD="kafka-topics.sh"
               fi
-              # Unlike create-kafka-topics, which runs in the cp-kafka image, this
-              # step runs in the APPLICATION image -- which ships no Kafka CLI. The
-              # previous default assumed `kafka-topics` was present. When it is not,
-              # the --list below fails, its stderr is swallowed by 2>/dev/null,
-              # EXISTING comes back empty, and every topic is reported MISSING
-              # against a broker that holds all of them.
+              # This step runs in the APPLICATION image -- which ships no Kafka
+              # CLI. The previous default assumed `kafka-topics` was present.
+              # When it is not, the --list below fails, its stderr is
+              # swallowed by 2>/dev/null, EXISTING comes back empty, and every
+              # topic is reported MISSING against a broker that holds all of
+              # them.
               #
               # A verification that cannot run is worse than one that is skipped: it
               # fails the deploy and blames the infrastructure. Skip and say so.
               if [ -z "${KAFKA_TOPICS_CMD}" ]; then
                 echo "  (kafka CLI not present in this image -- skipping topic verification)"
-                echo "  topics are created and listed by the create-kafka-topics step"
+                echo "  topics are created and listed by the run-kafka-migrate step"
               else
               # NOTE: this branch is deliberately NOT indented. It contains a
               # <<'PROPS' heredoc whose terminator must land at column 0 after YAML

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -1074,57 +1074,6 @@ migration:
     seed: false          # Run seed data (optional, set to true to enable)
     verify: true         # Fatally assert CH tables + kafka topics exist post-migration
 
-  # The create-kafka-topics init container runs the JVM-based kafka-topics
-  # tool. Its heap is set explicitly rather than left to the JVM's default,
-  # which derives from the cgroup limit (~1/4 of it) and at the previous
-  # hardcoded 256Mi came to ~64Mi -- too little for the admin client to read
-  # broker metadata over TLS. It died with OutOfMemoryError once per topic, and
-  # no message named memory as the cause.
-  #
-  # Keep `resources.limits.memory` well above the -Xmx value: the limit must
-  # cover heap plus JVM overhead, or the kernel OOM-kills the container (exit
-  # 137, no logs) instead of the JVM reporting it.
-  kafkaTopics:
-    # Partitions for every one of the built-in topics the create-kafka-topics
-    # step makes (events, events_lazy, events_bulk, events_dlq,
-    # events_post_processing, events_post_processing_backfill, system_events,
-    # events_backfill, wallet_alert, onboarding_events). Default 3 so even dev
-    # has room to parallelise consumers; 1 was too few. Fresh topics only —
-    # raising an existing topic's partitions needs kafka-topics --alter.
-    partitions: 3
-    # Replication factor for the same built-in topics. Default 1 to match a
-    # single-broker dev/Bitnami-subchart Kafka; raise it (e.g. 3) once the
-    # client points at a real multi-broker/MSK cluster.
-    replicationFactor: 1
-    # Extra client-declared topics, created IN ADDITION to the built-in list
-    # above. Leave empty (the default) to change nothing about today's
-    # behavior — this list is purely additive/override, never a replacement
-    # for the built-in topics.
-    #
-    # Each entry:
-    #   name:              (required) topic name
-    #   partitions:         optional, falls back to kafkaTopics.partitions above
-    #   replicationFactor:  optional, falls back to kafkaTopics.replicationFactor above
-    #   configs:            optional map of `kafka-topics --config key=value` pairs,
-    #                       e.g. retention.ms, cleanup.policy, min.insync.replicas
-    #
-    # Example:
-    # topics:
-    #   - name: custom_topic
-    #     partitions: 6
-    #     replicationFactor: 3
-    #     configs:
-    #       retention.ms: "604800000"
-    #       cleanup.policy: "delete"
-    topics: []
-    heapOpts: "-Xmx512m -Xms256m"
-    resources:
-      limits:
-        cpu: "500m"
-        memory: "1Gi"
-      requests:
-        cpu: "100m"
-        memory: "512Mi"
   # Pinned helper images used by the migration Job init containers. Override
   # `registry` per image if your cluster only allows pulls from a private
   # mirror (common in regulated AWS accounts). All three images are multi-arch.

--- a/internal/kafka/topicspec/spec.go
+++ b/internal/kafka/topicspec/spec.go
@@ -40,12 +40,24 @@ func ParseJSON(data []byte) (*Spec, error) {
 	return &s, nil
 }
 
+// defaultPartitions is used when a topic spec omits partitions (0) — most
+// often a bare "analytics" entry from an older/partial FLEXPRICE_KAFKA_TOPICS
+// JSON that predates the dotted analytics.meter_usage.sink.realtime rename.
+// Rather than reject the whole desired set, fall back to a sane partition
+// count so `migrate kafka` still succeeds; matches the other small topics
+// (events_dlq, system_events, wallet_alert, onboarding_events).
+const defaultPartitions = 3
+
 func (s *Spec) Resolve() ([]ResolvedTopic, error) {
 	out := make([]ResolvedTopic, 0, len(s.Topics))
 	for name, t := range s.Topics {
+		partitions := t.Partitions
+		if partitions == 0 {
+			partitions = defaultPartitions
+		}
 		r := ResolvedTopic{
 			Name:              name,
-			Partitions:        t.Partitions,
+			Partitions:        partitions,
 			ReplicationFactor: s.Defaults.ReplicationFactor,
 			RetentionMs:       s.Defaults.RetentionMs,
 		}

--- a/internal/kafka/topicspec/spec_test.go
+++ b/internal/kafka/topicspec/spec_test.go
@@ -39,10 +39,14 @@ func TestParseJSON(t *testing.T) {
 	assert.Equal(t, 6, find(t, got, "prod_system_events").Partitions)
 }
 
-func TestSpec_RejectsZeroPartitions(t *testing.T) {
-	spec := &Spec{Topics: map[string]TopicSpec{"bad": {Partitions: 0}}}
-	_, err := spec.Resolve()
-	assert.Error(t, err)
+func TestSpec_ZeroPartitionsFallsBackToDefault(t *testing.T) {
+	spec := &Spec{
+		Defaults: Defaults{ReplicationFactor: 3, RetentionMs: 604800000},
+		Topics:   map[string]TopicSpec{"analytics": {Partitions: 0}},
+	}
+	got, err := spec.Resolve()
+	require.NoError(t, err)
+	assert.Equal(t, defaultPartitions, find(t, got, "analytics").Partitions)
 }
 
 func TestSpec_RejectsZeroReplicationFactor(t *testing.T) {


### PR DESCRIPTION
## Problem
`migrate kafka` fails with `load desired topics: topic "analytics": partitions must be >= 1 (got 0)` when a topic spec omits partitions (a bare `analytics` entry from an older/partial `FLEXPRICE_KAFKA_TOPICS` JSON or image config predating the `analytics.meter_usage.sink.realtime` rename). This blocks BOTH topic reconcile AND the `--seed-acls` MSK ACL seeding in one pass.

Separately, the migration Job runs two overlapping topic-creation steps: the `migrate kafka` binary (reconcile + ACLs) AND a legacy `create-kafka-topics` CLI init container.

## Changes
1. **`fix(kafka)`** — `topicspec.Spec.Resolve()`: when a topic's partitions is 0, fall back to `defaultPartitions = 3` (matches sibling small topics) instead of failing the whole desired set. One choke point, covers env-JSON and config.yaml sources.
2. **`feat(chart)`** — remove the redundant `create-kafka-topics` CLI init container. The `migrate kafka` binary becomes the single source of topic creation (create + grow + retention + RF checks + ACLs). Parity verified: the binary's config.yaml covers every topic the CLI created.

## Note
`migration.kafkaTopics.topics` (Helm value for client extra topics) had no path into the binary and is removed. Extra topics must now be declared via `FLEXPRICE_KAFKA_TOPICS` (JSON). No deployment currently sets it non-empty.

## Verified
- `go build -mod=mod ./internal/kafka/... ./cmd/migrate/...` — pass
- `go test -mod=mod ./internal/kafka/topicspec/...` — pass
- `helm template` migration Job — `run-kafka-migrate` present, `create-kafka-topics` gone
- Live: env-override workaround on ap-south-2 staging created all 12 topics + seeded 4 allow-all MSK ACLs (validated via `kafka-acls --list` against the cluster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kafka topic creation and reconciliation are now handled through the standard migration process.
  * Additional Kafka topics can be configured using `FLEXPRICE_KAFKA_TOPICS` in JSON format.
  * Topics without a specified partition count now default to three partitions.

* **Bug Fixes**
  * Improved compatibility with older or incomplete Kafka topic configurations.
  * Updated migration verification messaging to reflect the current topic-creation process.

* **Refactor**
  * Removed the separate Kafka topic initialization configuration and container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->