### PR TITLE
feat(deploy): make ECS database migrations opt-in

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ on:
         description: "Dry run — validate config & print plan, skip register/deploy"
         type: boolean
         default: false
+      skip_migrations:
+        description: "Skip database migrations for this run (deploy code only)"
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -237,6 +241,32 @@ jobs:
           echo "environment=$ENV" >> $GITHUB_OUTPUT
           echo "dry_run=$DRY_RUN" >> $GITHUB_OUTPUT
 
+      # A skipped job cannot report why it was skipped -- it simply is not in the
+      # run. Without this, "this deploy shipped code without running migrations"
+      # is invisible to anyone reading the run afterwards.
+      - name: Record whether migrations will run
+        if: always()
+        env:
+          ENABLED: ${{ vars.DB_MIGRATIONS_ENABLED }}
+          SKIPPED: ${{ github.event.inputs.skip_migrations }}
+        run: |
+          if [ "$ENABLED" = "true" ] && [ "$SKIPPED" != "true" ]; then
+            echo "### Database migrations: ENABLED" >> "$GITHUB_STEP_SUMMARY"
+            echo "The migrate job runs before any rollout and blocks it on failure." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### :warning: Database migrations: NOT RUNNING" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$SKIPPED" = "true" ]; then
+              echo "Skipped for this run via the \`skip_migrations\` input." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "\`DB_MIGRATIONS_ENABLED\` is not \`true\` (currently: \`${ENABLED:-unset}\`)." >> "$GITHUB_STEP_SUMMARY"
+            fi
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "This deployment ships code without applying schema changes. If this" >> "$GITHUB_STEP_SUMMARY"
+            echo "release contains a migration, apply it by hand or the new code runs" >> "$GITHUB_STEP_SUMMARY"
+            echo "against the old schema." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   # ──────────────────────────────────────────────────────────────────────────
   # Job 3: Database migrations — one ECS task per target, before anything rolls.
   #
@@ -254,8 +284,20 @@ jobs:
   migrate:
     name: Migrate Database (${{ strategy.job-index }})
     needs: [build, resolve-config]
+    # OFF unless DB_MIGRATIONS_ENABLED is exactly "true". Default-off is
+    # deliberate while migrations are still applied by hand: turning this on is
+    # a decision someone makes per environment, after the target database has
+    # been adopted (`make migrate-adopt`). An unadopted database fails the Job
+    # on purpose, which would block deploys.
+    #
+    # Set at Settings > Secrets and variables > Actions > Variables, or
+    #   gh variable set DB_MIGRATIONS_ENABLED --body true
+    #
+    # `vars` and not `env`: the env context is not available in a job-level `if`.
     if: >-
       ${{ always() &&
+          vars.DB_MIGRATIONS_ENABLED == 'true' &&
+          github.event.inputs.skip_migrations != 'true' &&
           needs.build.result == 'success' &&
           needs.resolve-config.result == 'success' &&
           needs.resolve-config.outputs.targets != '[]' }}
@@ -312,7 +354,7 @@ jobs:
       ${{ always() &&
           needs.build.result == 'success' &&
           needs.resolve-config.result == 'success' &&
-          needs.migrate.result == 'success' &&
+          (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
           needs.resolve-config.outputs.preprod_targets != '[]' }}
     runs-on: self-hosted
     strategy:
@@ -434,7 +476,7 @@ jobs:
       ${{ always() &&
           needs.build.result == 'success' &&
           needs.resolve-config.result == 'success' &&
-          needs.migrate.result == 'success' &&
+          (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
           (needs.resolve-config.outputs.environment != 'production' ||
            needs.resolve-config.outputs.dry_run == 'true' ||
            needs.approval-gate.result == 'success') }}
@@ -471,7 +513,7 @@ jobs:
       ${{ always() &&
           needs.build.result == 'success' &&
           needs.resolve-config.result == 'success' &&
-          needs.migrate.result == 'success' &&
+          (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
           (needs.resolve-config.outputs.environment != 'production' ||
            needs.resolve-config.outputs.dry_run == 'true' ||
            needs.approval-gate.result == 'success') }}
@@ -508,7 +550,7 @@ jobs:
       ${{ always() &&
           needs.build.result == 'success' &&
           needs.resolve-config.result == 'success' &&
-          needs.migrate.result == 'success' &&
+          (needs.migrate.result == 'success' || needs.migrate.result == 'skipped') &&
           (needs.resolve-config.outputs.environment != 'production' ||
            needs.resolve-config.outputs.dry_run == 'true' ||
            needs.approval-gate.result == 'success') }}

--- a/docs/architecture/DEPLOY_SETUP.md
+++ b/docs/architecture/DEPLOY_SETUP.md
@@ -21,6 +21,7 @@ Configure these in the repo: **Settings → Secrets and variables → Actions**.
 | `ECR_REPOSITORY` | `my-app` | ECR repository name. Image tag is `${{ github.sha }}`. |
 | `STAGING_DEPLOY_TARGETS` | See JSON below | JSON array of ECS targets for **staging** (used on `develop` and when manual run chooses staging). |
 | `PROD_DEPLOY_TARGETS` | See JSON below | JSON array of ECS targets for **production** (used on `main` and when manual run chooses production). |
+| `DB_MIGRATIONS_ENABLED` | `true` / unset | Whether the `migrate` job runs database migrations before a rollout. **Off unless set to exactly `true`.** Turn it on for an environment only after that database has been adopted (`make migrate-adopt`) — an unadopted database fails the job on purpose and blocks the deploy. A single run can also be exempted with the `skip_migrations` input on a manual dispatch. When migrations do not run, the workflow summary says so. |
 
 ---
 


### PR DESCRIPTION
The Helm path has `migration.enabled`. The ECS path had no equivalent — so merging the migration work to `main` would run migrations against India production whether or not anyone was ready. That database is **not adopted**, so the job would fail on purpose and block every deploy behind it.

## The switch

`DB_MIGRATIONS_ENABLED` gates the `migrate` job, **off unless set to exactly `true`**.

```
gh variable set DB_MIGRATIONS_ENABLED --body true      # enable
gh variable list                                       # check
```

Set at **Settings → Secrets and variables → Actions → Variables**, alongside `PROD_DEPLOY_TARGETS`.

Default-off is deliberate while migrations are still applied by hand: enabling it for an environment should be a decision made *after* that database has been adopted (`make migrate-adopt`), not a side effect of a release.

Read from `vars` rather than `env` — the `env` context isn't available in a job-level `if`.

A single run can also be exempted with a new `skip_migrations` dispatch input, without flipping a repo variable and having to remember to flip it back.

## The bug this would have introduced

The deploy jobs required `needs.migrate.result == 'success'`. **A skipped job doesn't satisfy that**, so turning migrations off would have blocked every deployment — precisely the opposite of the intent.

All four now accept `'success'` or `'skipped'`, and still block on `'failure'`.

## Making the absence visible

A skipped job can't report why it was skipped; it simply isn't in the run. So `resolve-config` records the decision in the workflow summary:

> ### ⚠️ Database migrations: NOT RUNNING
> `DB_MIGRATIONS_ENABLED` is not `true` (currently: `unset`).
>
> This deployment ships code without applying schema changes. If this release contains a migration, apply it by hand or the new code runs against the old schema.

This is an escape hatch from the guarantee the rest of this work builds, which is why using it leaves a trace rather than being silent.

## Effect on the pending release

With this merged, `develop` → `main` becomes safe for both production environments without any prerequisite:

| | Effect |
|---|---|
| GCP us-west1 prod | none — `migration.enabled: false`; renders identically to 1.3.3 apart from the chart-version label (verified, 0 differing lines) |
| AWS India prod | `migrate` skips, deploys proceed exactly as today |

Then adopt India prod and flip the variable when you're ready, as a separate deliberate step.

## Verified

- `deploy.yml` parses; the summary step passes `bash -n`
- `migrate` gated on `vars.DB_MIGRATIONS_ENABLED == 'true'` and the dispatch input
- all four deploy jobs accept `success` **or** `skipped`
- `skip_migrations` present alongside `environment` and `dry_run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to skip database migrations during manually triggered deployments.
  * Deployment summaries now clearly indicate whether migrations will run or be skipped.
  * Deployments can proceed successfully when migrations are intentionally skipped.

* **Documentation**
  * Documented the database migration configuration and manual skip option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->