### PR TITLE
ci(migrations): lock-safety lint, with two blocking rules

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -103,11 +103,15 @@ jobs:
       - name: Sync check — is any schema change missing a migration?
         run: make migrate-check-sync
 
-      # Advisory for now — reports findings without failing the build. Flip to a
-      # gate once a couple of weeks of real PRs show the rule set is tuned.
-      # Enforceable locally today with `make migrate-check-lint`.
+      # Mostly advisory: findings print and do not fail the build. Two rules DO
+      # fail it, because each maps to a failure that reached main here --
+      # adding-required-field and ban-concurrent-index-creation-in-transaction.
+      # See scripts/migrations/lint.sh for why those two and not the rest.
+      #
+      # No continue-on-error: the script decides what blocks, so a genuine
+      # scanner error (missing binary, bad config) also fails rather than
+      # passing silently.
       - name: Lint — is this migration safe to run?
-        continue-on-error: true
         run: ./scripts/migrations/lint.sh origin/${{ github.base_ref || 'develop' }}
 
       - name: Checksum — was a shipped migration edited?

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      - name: Install squawk
+        run: |
+          sudo curl -fsSL -o /usr/local/bin/squawk \
+            https://github.com/sbdchd/squawk/releases/download/v2.63.0/squawk-linux-x86_64
+          sudo chmod +x /usr/local/bin/squawk
+
       - name: Install dbmate and psql
         # Pinned to the same version the deployment image builds (Dockerfile
         # DBMATE_VERSION). `releases/latest` drifts, which would leave CI
@@ -96,6 +102,13 @@ jobs:
 
       - name: Sync check — is any schema change missing a migration?
         run: make migrate-check-sync
+
+      # Advisory for now — reports findings without failing the build. Flip to a
+      # gate once a couple of weeks of real PRs show the rule set is tuned.
+      # Enforceable locally today with `make migrate-check-lint`.
+      - name: Lint — is this migration safe to run?
+        continue-on-error: true
+        run: ./scripts/migrations/lint.sh origin/${{ github.base_ref || 'develop' }}
 
       - name: Checksum — was a shipped migration edited?
         run: make migrate-check-checksum

--- a/.squawk.toml
+++ b/.squawk.toml
@@ -1,0 +1,38 @@
+# Lock-safety lint for migrations. See migrations/versioned/README.md.
+#
+# Only files ADDED by a pull request are linted — the baseline is a 3,700-line
+# pg_dump of production and reports 1,363 findings that describe history, not a
+# decision anyone is making now.
+
+excluded_rules = [
+  # ── Enforced on the connection, not in the file ───────────────────────────
+  # scripts/migrations/apply.sh sets lock_timeout=3s and statement_timeout=0.
+  # They cannot live in the SQL: a `transaction:false` file may contain exactly
+  # one statement, so there is no room for a SET. Squawk cannot see the
+  # connection, so these fire on every concurrent-index migration we write.
+  "require-lock-timeout",
+  "require-statement-timeout",
+  "require-timeout-settings",
+
+  # ── Type opinions Ent owns, not the migration author ──────────────────────
+  # Ent generates `character varying(n)` for every string field. These fire on
+  # essentially every column we will ever add, and the fix is a schema-design
+  # decision, not something to resolve in a migration review.
+  "ban-char-field",
+  "prefer-text-field",
+  "prefer-bigint-over-int",
+  "prefer-bigint-over-smallint",
+  "prefer-timestamptz",
+  "prefer-identity",
+
+  # ── Contradicts a deliberate choice ───────────────────────────────────────
+  # `prefer-robust-stmts` wants IF NOT EXISTS everywhere. For CREATE INDEX
+  # CONCURRENTLY that is actively wrong: it silently skips an INVALID index left
+  # by a failed build, and the next migrations then drop the index that was still
+  # enforcing. See 20260825000100_entitlements_uniq_exclude_parallel.sql.
+  #
+  # It is good advice for ADD COLUMN, so this is a real loss — but the rule
+  # cannot be scoped per statement type, and being wrong about indexes is the
+  # more dangerous half.
+  "prefer-robust-stmts",
+]

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,10 @@ migrate-check: migrate-check-sync migrate-check-checksum migrate-check-order
 migrate-check-sync:
 	@./scripts/migrations/synccheck.sh $(MIGRATIONS_PG)
 
+.PHONY: migrate-check-lint
+migrate-check-lint:
+	@./scripts/migrations/lint.sh
+
 .PHONY: migrate-check-checksum
 migrate-check-checksum:
 	@./scripts/migrations/checksum-check.sh

--- a/migrations/versioned/README.md
+++ b/migrations/versioned/README.md
@@ -193,12 +193,40 @@ a failed connection still exits 0 and hashes the empty string —
 
 | Gate | Runs in | Catches |
 |---|---|---|
+| `migrate-check-lint` | both, **advisory in CI** | a migration that takes a lock it should not |
 | ent codegen current | CI | a schema edit without `make generate-ent` — first, because a stale `ent/` makes every later gate read the wrong schema and pass |
 | `migrate-check-sync` | both | a schema change that shipped without a migration |
 | `migrate-check-checksum` | both | edits to a shipped migration, and migrations missing from `.hashes` |
 | `migrate-check-order` | both | parallel branches merging out of timestamp order |
 | replay from zero | CI | the set does not apply to an empty database |
 | `migrate-check-clickhouse` | neither — disabled | multi-statement ClickHouse files |
+
+## Lock safety
+
+`make migrate-check-lint` runs [squawk](https://squawkhq.com) over migrations this
+branch **adds** — not the whole directory. The baseline is a 3,700-line `pg_dump`
+of production reporting 1,363 findings, all describing history rather than a
+decision anyone is making now; linting it would train everyone to ignore the
+output.
+
+It catches the things that take a lock you did not intend: a `CREATE INDEX` without
+`CONCURRENTLY`, a `DROP INDEX` without it, a constraint added without `NOT VALID`,
+a `NOT NULL` column added to a populated table, a rename.
+
+Advisory in CI for now — it reports and does not fail the build. It **does** fail
+locally, so it is enforceable today; flip the CI step once a few weeks of real PRs
+confirm the rule set is tuned.
+
+Seven rules are disabled in `.squawk.toml`, each for a reason recorded inline.
+Three are worth knowing about:
+
+- **`require-lock-timeout` / `require-statement-timeout`** — set on the connection
+  by `scripts/migrations/apply.sh`, not in the file, because a `transaction:false`
+  file may hold exactly one statement. Squawk cannot see the connection.
+- **`prefer-robust-stmts`** — wants `IF NOT EXISTS` everywhere. For
+  `CREATE INDEX CONCURRENTLY` that is actively wrong: it silently skips an INVALID
+  index left by a failed build. Good advice for `ADD COLUMN`, so disabling it is a
+  real loss, but the rule cannot be scoped per statement type.
 
 `.hashes` is authoritative and is not rewritten by the check. Adding a migration
 means recording it deliberately:

--- a/scripts/migrations/lint.sh
+++ b/scripts/migrations/lint.sh
@@ -5,10 +5,28 @@
 # and reports 1,363 findings — all describing history rather than a decision anyone
 # is making now. Linting it would train everyone to ignore the output.
 #
+# Two tiers. Most findings are advice and print without failing. A short list
+# BLOCKS, because each entry maps to a failure that already happened here:
+#
+#   adding-required-field
+#     ADD COLUMN ... NOT NULL with no DEFAULT. Postgres rejects it outright on
+#     any table that has rows -- "contains null values" -- but succeeds on an
+#     empty one, so the replay-from-zero gate passes it and every real database
+#     fails. Shipped to main on 2026-08-31 and was caught by hand.
+#
+#   ban-concurrent-index-creation-in-transaction
+#     A CONCURRENTLY statement that is not alone in its file. Anything else in
+#     the body gives Postgres an implicit transaction and the statement is
+#     rejected at deploy time. Requires --assume-in-transaction to detect.
+#
+# Everything else stays advisory on purpose: a wall of blocking style rules gets
+# switched off within a month, and then the two that matter go with it.
+#
 #   ./lint.sh [base-ref]     default: origin/develop
 set -euo pipefail
 BASE="${1:-origin/develop}"
 CONF="${SQUAWK_CONFIG:-.squawk.toml}"
+BLOCKING="adding-required-field ban-concurrent-index-creation-in-transaction"
 
 command -v squawk >/dev/null 2>&1 || {
   echo "squawk not installed — https://squawkhq.com/docs/installation" >&2
@@ -26,17 +44,40 @@ if [ -z "$FILES" ]; then
 fi
 
 echo "lint: checking $(echo "$FILES" | wc -l | tr -d ' ') new migration(s) against $BASE"
-rc=0
+
+# --assume-in-transaction: without it squawk cannot know the statement will be
+# wrapped, and ban-concurrent-index-creation-in-transaction never fires. It is
+# correct here because dbmate sends a file body as one string, so any migration
+# with more than one statement runs inside Postgres' implicit transaction.
+OUT="$(mktemp)"; trap 'rm -f "$OUT"' EXIT
+advisory=0
 for f in $FILES; do
   [ -f "$f" ] || continue
-  squawk -c "$CONF" "$f" || rc=1
+  squawk -c "$CONF" --assume-in-transaction "$f" >>"$OUT" 2>&1 || advisory=1
+done
+cat "$OUT"
+
+# Strip ANSI and hyperlink escapes before matching, or the rule name never
+# matches and a blocking finding is reported as advisory.
+CLEAN="$(sed 's/\x1b\[[0-9;]*m//g; s/\x1b]8;;[^\]*\\//g' "$OUT")"
+blocked=""
+for r in $BLOCKING; do
+  echo "$CLEAN" | grep -q "\[$r\]" && blocked="$blocked $r"
 done
 
-if [ $rc -eq 0 ]; then
+if [ -n "$blocked" ]; then
+  echo >&2
+  echo "lint: BLOCKING findings —$blocked" >&2
+  echo "  These are not style preferences. Each one fails at deploy time against a" >&2
+  echo "  database that has data, while passing CI's replay against empty tables." >&2
+  exit 1
+fi
+
+if [ "$advisory" -eq 0 ]; then
   echo "lint: OK"
 else
-  echo >&2
-  echo "lint: findings above. Each links to an explanation of the lock it takes." >&2
-  echo "Rules deliberately disabled for this repo are listed in .squawk.toml." >&2
+  echo
+  echo "lint: advisory findings above — not blocking. Each links to an explanation"
+  echo "of the lock it takes. Rules disabled for this repo are in .squawk.toml."
 fi
-exit $rc
+exit 0

--- a/scripts/migrations/lint.sh
+++ b/scripts/migrations/lint.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Lock-safety lint for migrations added by this branch.
+#
+# Only ADDED files are linted. The baseline is a 3,700-line pg_dump of production
+# and reports 1,363 findings — all describing history rather than a decision anyone
+# is making now. Linting it would train everyone to ignore the output.
+#
+#   ./lint.sh [base-ref]     default: origin/develop
+set -euo pipefail
+BASE="${1:-origin/develop}"
+CONF="${SQUAWK_CONFIG:-.squawk.toml}"
+
+command -v squawk >/dev/null 2>&1 || {
+  echo "squawk not installed — https://squawkhq.com/docs/installation" >&2
+  echo "  brew: not packaged. Download the binary for your platform from" >&2
+  echo "  https://github.com/sbdchd/squawk/releases" >&2
+  exit 127
+}
+
+FILES="$(git diff --name-only --diff-filter=A "$BASE"...HEAD -- \
+         'migrations/versioned/postgres/*.sql' 2>/dev/null || true)"
+
+if [ -z "$FILES" ]; then
+  echo "lint: no new migrations to check"
+  exit 0
+fi
+
+echo "lint: checking $(echo "$FILES" | wc -l | tr -d ' ') new migration(s) against $BASE"
+rc=0
+for f in $FILES; do
+  [ -f "$f" ] || continue
+  squawk -c "$CONF" "$f" || rc=1
+done
+
+if [ $rc -eq 0 ]; then
+  echo "lint: OK"
+else
+  echo >&2
+  echo "lint: findings above. Each links to an explanation of the lock it takes." >&2
+  echo "Rules deliberately disabled for this repo are listed in .squawk.toml." >&2
+fi
+exit $rc


### PR DESCRIPTION
Adds squawk to the migration CI. Most findings are advisory; **two rules fail the build**, because each maps to a failure that has already reached `main` here.

## Why now

On 2026-08-31 this shipped to `main`:

```sql
ALTER TABLE "tax_applieds" ADD COLUMN IF NOT EXISTS "tax_behavior"
  character varying(50) NOT NULL;
```

Postgres rejects `ADD COLUMN … NOT NULL` with no `DEFAULT` on any table with rows:

```
ERROR: column "tax_behavior" of relation "tax_applieds" contains null values
```

…but **accepts it on an empty table**. CI's replay-from-zero builds every table empty, so it passed there and would have failed on both production databases — `tax_applieds` has 1,392 rows on AWS, 69 on GCP. It was caught by reading the file, not by a gate.

## The two blocking rules

**`adding-required-field`** — the case above. Verified it fires on the broken version and not on the fixed one.

**`ban-concurrent-index-creation-in-transaction`** — a `CONCURRENTLY` statement that isn't alone in its file. Anything else in the body gives Postgres an implicit transaction and the statement is rejected at deploy time. Requires `--assume-in-transaction`, now passed — correct here because dbmate sends a file body as one string.

## Everything else stays advisory, deliberately

A wall of blocking style rules gets switched off within a month, and the two that matter go with it. Advisory findings still print, with links explaining the lock each statement takes.

Only **added** files are linted. The baseline is a 3,700-line schema dump reporting 1,363 findings, all describing history rather than a decision anyone is making now.

## Verified

| Migration | Result |
|---|---|
| `NOT NULL`, no default *(the bug that shipped)* | **BLOCKED** — `adding-required-field` |
| `NULL` *(the fix that went to main)* | passes |
| `NOT NULL DEFAULT 'taxable'` | passes |
| `SET` + `CREATE INDEX CONCURRENTLY` | **BLOCKED** — `ban-concurrent-index-creation-in-transaction` |
| `CREATE INDEX CONCURRENTLY` alone | passes |

Also passes against the migrations already on `develop`.

## Notes

`continue-on-error` is dropped so a scanner error (missing binary, bad config) fails rather than passing silently — the script decides what blocks.

ANSI and hyperlink escapes are stripped before matching rule names; without that a blocking finding is misreported as advisory.

## What this does not cover

Squawk is static. It can't catch anything that depends on your data — a unique index that fails on existing duplicates, or `NOT NULL` added to a column that already holds NULLs. Those need a replay against a seeded database, which is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for newly added database migrations to identify potentially unsafe locking and schema changes.
  * Added a local Makefile command for running migration checks.
  * Added configurable migration linting rules and clear handling for advisory versus blocking findings.

* **Documentation**
  * Updated migration documentation with the new check and lock-safety guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->