### PR TITLE
chore(ci): upload coverage to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
@@ -31,7 +33,7 @@ jobs:
           make test-coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: ./coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -43,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,19 @@ on:
   push:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.25.12'
           cache: true
@@ -28,7 +31,7 @@ jobs:
           make test-coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           files: ./coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -39,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: '1.25.12'
           cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,14 @@ jobs:
 
       - name: Run Tests
         run: |
-          make test
+          make test-coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   lint:
     name: Run Loglint

--- a/Makefile
+++ b/Makefile
@@ -202,8 +202,8 @@ test-verbose:
 	$(call run-go-test,-v ./internal/... ./cmd/server)
 
 # Run tests with coverage report
-test-coverage:
-	go test -coverprofile=coverage.out ./internal/... ./cmd/server
+test-coverage: install-typst
+	$(call run-go-test,-race -coverprofile=coverage.out ./internal/... ./cmd/server)
 	go tool cover -html=coverage.out -o coverage.html
 
 # Database related targets


### PR DESCRIPTION
## What

Adds Codecov coverage reporting to the test workflow.

- `test.yml`: test job now runs `make test-coverage` and uploads `coverage.out` via `codecov/codecov-action@v5`.
- `Makefile`: `test-coverage` now runs with `-race` and `install-typst` to match the main `test` target.

## Notes

- `fail_ci_if_error: false` — a Codecov flake won't block PRs. Flip to `true` to make coverage a gate.
- Uses `CODECOV_TOKEN` secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Automated test runs now include race-condition detection and generate coverage reports.
  * Coverage results are uploaded for review without causing workflows to fail when uploads encounter issues.
  * Coverage generation now uses the project’s shared test process and required tooling.

* **Chores**
  * Required tooling is installed before coverage reports are generated.
  * Workflow security and reliability improved through restricted permissions, pinned action versions, and non-persistent credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->