### PR TITLE
fix(billing): DB price prefetch includes cadences that divide sub cadence

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -3946,9 +3946,10 @@ func filterValidPricesForSubscription(prices []*dto.PriceResponse, subscription 
 			validPrices = append(validPrices, p)
 			continue
 		}
-		periodOK := p.Price.BillingPeriod == subscription.BillingPeriod ||
-			types.IsBillingPeriodMultiple(subscription.BillingPeriod, p.Price.BillingPeriod)
-		if periodOK {
+		// Count-aware cadence compatibility: mirrors the DTO validator and the
+		// invoice-time splitInvoicePeriodByLineItemCadence guard so anything
+		// accepted here cannot later fail at fan-out.
+		if types.IsCadenceCompatible(subscription.BillingPeriod, subscription.BillingPeriodCount, p.Price.BillingPeriod, p.Price.BillingPeriodCount) {
 			validPrices = append(validPrices, p)
 		}
 	}
@@ -3975,10 +3976,11 @@ func (s *subscriptionService) ValidateAndFilterPricesForSubscription(
 		pricesResponse, err = priceService.GetPricesByPlanID(ctx, dto.GetPricesByPlanRequest{
 			PlanID:       entityID,
 			AllowExpired: false,
-			BillingPeriods: []types.BillingPeriod{
-				subscription.BillingPeriod,
-				types.BILLING_PERIOD_ONETIME,
-			},
+			// Prefetch every price whose cadence *could* be compatible with the sub
+			// (equal or strict divisor in months). The in-memory
+			// filterValidPricesForSubscription applies the exact count-aware check
+			// via IsCadenceCompatible after this fetch.
+			BillingPeriods: types.CompatibleBillingPeriodsFor(subscription.BillingPeriod, subscription.BillingPeriodCount),
 		})
 	case types.PRICE_ENTITY_TYPE_ADDON:
 		pricesResponse, err = priceService.GetPricesByAddonID(ctx, entityID)

--- a/internal/types/price.go
+++ b/internal/types/price.go
@@ -331,6 +331,44 @@ func EffectiveMonths(period BillingPeriod, count int) int {
 	return BillingPeriodToMonths(period) * count
 }
 
+// CompatibleBillingPeriodsFor returns the discrete BillingPeriod values whose
+// effective months could equal or divide (subPeriod × subCount) months —
+// enough to be a candidate for a multi-cadence subscription's plan-price
+// prefetch. ONETIME is always included since it's not tied to a cadence.
+//
+// This is a SUPERSET filter for DB queries: it returns every candidate
+// period type, ignoring count. The in-memory IsCadenceCompatible check
+// still applies the exact count-aware filter after prices are loaded.
+//
+// Sub-month sub periods (DAILY/WEEKLY) return only themselves + ONETIME —
+// month math doesn't apply.
+func CompatibleBillingPeriodsFor(subPeriod BillingPeriod, subCount int) []BillingPeriod {
+	if subPeriod == BILLING_PERIOD_ONETIME {
+		return []BillingPeriod{BILLING_PERIOD_ONETIME}
+	}
+	if subCount <= 0 {
+		subCount = 1
+	}
+	if subPeriod == BILLING_PERIOD_DAILY || subPeriod == BILLING_PERIOD_WEEKLY {
+		return []BillingPeriod{subPeriod, BILLING_PERIOD_ONETIME}
+	}
+	subMonths := BillingPeriodToMonths(subPeriod) * subCount
+	out := make([]BillingPeriod, 0, 5)
+	for _, c := range []BillingPeriod{
+		BILLING_PERIOD_MONTHLY,
+		BILLING_PERIOD_QUARTER,
+		BILLING_PERIOD_HALF_YEAR,
+		BILLING_PERIOD_ANNUAL,
+	} {
+		m := BillingPeriodToMonths(c)
+		if m > 0 && subMonths%m == 0 {
+			out = append(out, c)
+		}
+	}
+	out = append(out, BILLING_PERIOD_ONETIME)
+	return out
+}
+
 // IsCadenceCompatible reports whether a line-item cadence
 // (itemPeriod × itemCount) equals or strictly divides a subscription
 // cadence (subPeriod × subCount).

--- a/internal/types/price_test.go
+++ b/internal/types/price_test.go
@@ -125,3 +125,79 @@ func TestIsBillingPeriodMultiple(t *testing.T) {
 		})
 	}
 }
+
+func TestCompatibleBillingPeriodsFor(t *testing.T) {
+	contains := func(list []BillingPeriod, p BillingPeriod) bool {
+		for _, x := range list {
+			if x == p {
+				return true
+			}
+		}
+		return false
+	}
+
+	tests := []struct {
+		name      string
+		subPeriod BillingPeriod
+		subCount  int
+		mustHave  []BillingPeriod
+		mustNot   []BillingPeriod
+	}{
+		{
+			name:      "quarterly_sub_includes_monthly_and_quarterly",
+			subPeriod: BILLING_PERIOD_QUARTER, subCount: 1,
+			mustHave: []BillingPeriod{BILLING_PERIOD_MONTHLY, BILLING_PERIOD_QUARTER, BILLING_PERIOD_ONETIME},
+			mustNot:  []BillingPeriod{BILLING_PERIOD_HALF_YEAR, BILLING_PERIOD_ANNUAL},
+		},
+		{
+			name:      "annual_sub_includes_all_smaller_month_based",
+			subPeriod: BILLING_PERIOD_ANNUAL, subCount: 1,
+			mustHave: []BillingPeriod{BILLING_PERIOD_MONTHLY, BILLING_PERIOD_QUARTER, BILLING_PERIOD_HALF_YEAR, BILLING_PERIOD_ANNUAL, BILLING_PERIOD_ONETIME},
+		},
+		{
+			name:      "monthly_sub_only_monthly",
+			subPeriod: BILLING_PERIOD_MONTHLY, subCount: 1,
+			mustHave: []BillingPeriod{BILLING_PERIOD_MONTHLY, BILLING_PERIOD_ONETIME},
+			mustNot:  []BillingPeriod{BILLING_PERIOD_QUARTER, BILLING_PERIOD_HALF_YEAR, BILLING_PERIOD_ANNUAL},
+		},
+		{
+			name:      "daily_sub_only_daily",
+			subPeriod: BILLING_PERIOD_DAILY, subCount: 1,
+			mustHave: []BillingPeriod{BILLING_PERIOD_DAILY, BILLING_PERIOD_ONETIME},
+			mustNot:  []BillingPeriod{BILLING_PERIOD_MONTHLY, BILLING_PERIOD_WEEKLY},
+		},
+		{
+			name:      "half_year_sub_via_count",
+			subPeriod: BILLING_PERIOD_QUARTER, subCount: 2, // 6 months
+			mustHave: []BillingPeriod{BILLING_PERIOD_MONTHLY, BILLING_PERIOD_QUARTER, BILLING_PERIOD_HALF_YEAR, BILLING_PERIOD_ONETIME},
+			mustNot:  []BillingPeriod{BILLING_PERIOD_ANNUAL},
+		},
+		{
+			name:      "onetime_sub_only_onetime",
+			subPeriod: BILLING_PERIOD_ONETIME, subCount: 1,
+			mustHave: []BillingPeriod{BILLING_PERIOD_ONETIME},
+			mustNot:  []BillingPeriod{BILLING_PERIOD_MONTHLY, BILLING_PERIOD_QUARTER},
+		},
+		{
+			name:      "zero_count_defaults_to_one",
+			subPeriod: BILLING_PERIOD_QUARTER, subCount: 0,
+			mustHave: []BillingPeriod{BILLING_PERIOD_MONTHLY, BILLING_PERIOD_QUARTER, BILLING_PERIOD_ONETIME},
+			mustNot:  []BillingPeriod{BILLING_PERIOD_HALF_YEAR},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CompatibleBillingPeriodsFor(tt.subPeriod, tt.subCount)
+			for _, p := range tt.mustHave {
+				if !contains(got, p) {
+					t.Errorf("CompatibleBillingPeriodsFor(%q, %d) missing expected %q; got %v", tt.subPeriod, tt.subCount, p, got)
+				}
+			}
+			for _, p := range tt.mustNot {
+				if contains(got, p) {
+					t.Errorf("CompatibleBillingPeriodsFor(%q, %d) unexpectedly includes %q; got %v", tt.subPeriod, tt.subCount, p, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up to #2699. The multi-cadence fan-out feature landed with a gap: `ValidateAndFilterPricesForSubscription` prefetches plan prices via a DB query that filtered `BillingPeriods` to only `{sub.BillingPeriod, ONETIME}`. So a quarterly subscription against a plan with monthly-only prices returned zero prices and tripped the `"The entity must have at least one price to create a subscription"` guard — before the in-memory `filterValidPricesForSubscription` cadence check ever ran.

Surfaced by the e2eprobe multi-cadence seed (quarterly sub + plan with monthly fixed + monthly metered prices).

## Fix
- Add `types.CompatibleBillingPeriodsFor(subPeriod, subCount)` returning every discrete `BillingPeriod` whose effective months could equal or divide the sub's effective months. Ignores count intentionally — this is a SUPERSET prefetch filter; the exact count-aware check runs in-memory afterward.
- Wire it into the DB query at `subscription.go:3978`.
- Update `filterValidPricesForSubscription`'s in-memory check to use `IsCadenceCompatible` (count-aware) instead of the count-agnostic `IsBillingPeriodMultiple` — so anything accepted at plan-attach cannot later fail at invoice fan-out.

## Test plan
- [x] Unit: `TestCompatibleBillingPeriodsFor` (7 cases covering quarterly/annual/monthly/daily subs, count > 1, ONETIME, zero-count default)
- [x] Full internal regression: `go test -race ./internal/... -timeout 600s` → exit 0
- [x] `go vet ./internal/...` → clean
- [x] `make lint-ci` → exit 0
- [ ] Manual: run the e2eprobe against local server; confirm `ensureMultiCadenceSubscription` no longer 400s

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription price validation for billing periods with multiple billing cycles.
  * Ensured compatible monthly, sub-monthly, and one-time prices are included when validating subscription plans.
  * Improved handling of unspecified billing-period counts by applying a default count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->