### PR TITLE
fix(imports): route imports through S3 backend on GCS deployments

### DIFF
--- a/internal/storage/resolver.go
+++ b/internal/storage/resolver.go
@@ -71,6 +71,19 @@ func NewResolver(ctx context.Context, cfg *config.Configuration, connSvc Connect
 
 func (r *resolver) Provider() Provider { return r.provider }
 
+// providerFor picks the effective backend for a purpose. It is normally the
+// deployment-wide provider (r.provider, chosen at boot by CloudDetector), but
+// imports are a deliberate exception: CSV Box only writes to S3, so an import
+// running on a GCP-hosted worker still reads its source object from S3 using
+// static credentials from FlexpriceS3Imports. Without this override, GCP
+// deployments hit the GCS branch and can never resolve an S3-backed CSV.
+func (r *resolver) providerFor(purpose Purpose) Provider {
+	if purpose == PurposeImport {
+		return ProviderS3
+	}
+	return r.provider
+}
+
 func (r *resolver) ForPlatform(ctx context.Context, purpose Purpose) (Storage, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -93,7 +106,7 @@ func (r *resolver) ForPlatform(ctx context.Context, purpose Purpose) (Storage, e
 		return nil, err
 	}
 
-	s, err := NewPlatformStorage(ctx, r.cfg, r.provider, purpose, bucket, region, signerEmail, r.logger)
+	s, err := NewPlatformStorage(ctx, r.cfg, r.providerFor(purpose), purpose, bucket, region, signerEmail, r.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -115,8 +128,12 @@ func (r *resolver) ForConnection(ctx context.Context, connectionID string) (Stor
 // request credentials, so it returns empty). A missing signer is rejected here,
 // not at first presign: uploads would still succeed, but every presigned GET
 // would fail — surfacing only when a customer clicks a download link.
+//
+// Imports always go through the S3 branch (providerFor pins them), so this
+// method never has to produce a GCS import signer — the S3 short-circuit at
+// the top handles them.
 func (r *resolver) signerFor(purpose Purpose) (string, error) {
-	if r.provider != ProviderGCS {
+	if r.providerFor(purpose) != ProviderGCS {
 		return "", nil
 	}
 
@@ -139,13 +156,6 @@ func (r *resolver) signerFor(purpose Purpose) (string, error) {
 				Mark(ierr.ErrValidation)
 		}
 		return signer, nil
-	case PurposeImport:
-		// Imports on GCS need their own bucket + signer config, which does not
-		// exist yet. Fail loudly rather than let the export signer be reused
-		// (which would presign against the wrong bucket).
-		return "", ierr.NewError("GCS is not yet supported for imports").
-			WithHint("Run this deployment with storage.provider=s3, or add a flexprice_gcs_imports config block and a companion signer service account when GCS-side imports are wired up").
-			Mark(ierr.ErrValidation)
 	default:
 		return "", unsupportedPurpose(purpose)
 	}
@@ -187,7 +197,7 @@ func (r *resolver) platformBucket(purpose Purpose) (bucket, region string, err e
 		return "", "", err
 	}
 
-	switch r.provider {
+	switch r.providerFor(purpose) {
 	case ProviderS3:
 		switch purpose {
 		case PurposeInvoice:
@@ -205,10 +215,14 @@ func (r *resolver) platformBucket(purpose Purpose) (bucket, region string, err e
 // BucketConfigFor returns bucket settings for a purpose. Invoice buckets carry a
 // full config.BucketConfig; export config is flat (no prefix/expiry fields), so
 // export synthesizes one with expiry "30m" to match defaultPresignExpiry.
+//
+// Imports are pinned to S3 (see providerFor): CSV Box only writes to S3, so
+// even a GCP-hosted deployment reads its imports through the S3 branch below,
+// using FlexpriceS3Imports credentials.
 func (r *resolver) BucketConfigFor(purpose Purpose) (config.BucketConfig, error) {
 	var bc config.BucketConfig
 
-	switch r.provider {
+	switch r.providerFor(purpose) {
 	case ProviderGCS:
 		switch purpose {
 		case PurposeInvoice:
@@ -218,11 +232,6 @@ func (r *resolver) BucketConfigFor(purpose Purpose) (config.BucketConfig, error)
 				Bucket:                r.cfg.FlexpriceGCSExports.Bucket,
 				PresignExpiryDuration: "30m",
 			}
-		case PurposeImport:
-			// See signerFor: no GCS imports config today.
-			return config.BucketConfig{}, ierr.NewError("GCS is not yet supported for imports").
-				WithHint("Run this deployment with storage.provider=s3, or add a flexprice_gcs_imports config block when GCS-side imports are wired up").
-				Mark(ierr.ErrValidation)
 		default:
 			return config.BucketConfig{}, unsupportedPurpose(purpose)
 		}
@@ -253,14 +262,14 @@ func (r *resolver) BucketConfigFor(purpose Purpose) (config.BucketConfig, error)
 			return config.BucketConfig{}, unsupportedPurpose(purpose)
 		}
 	default:
-		return config.BucketConfig{}, ierr.NewErrorf("unsupported storage provider: %s", r.provider).
+		return config.BucketConfig{}, ierr.NewErrorf("unsupported storage provider: %s", r.providerFor(purpose)).
 			WithHint("storage.provider must be 's3' or 'gcs'").
 			Mark(ierr.ErrValidation)
 	}
 
 	if bc.Bucket == "" {
-		return config.BucketConfig{}, ierr.NewErrorf("no %s bucket configured for storage provider %s", purpose, r.provider).
-			WithHint(missingBucketHint(r.provider, purpose)).
+		return config.BucketConfig{}, ierr.NewErrorf("no %s bucket configured for storage provider %s", purpose, r.providerFor(purpose)).
+			WithHint(missingBucketHint(r.providerFor(purpose), purpose)).
 			Mark(ierr.ErrValidation)
 	}
 

--- a/internal/storage/resolver_test.go
+++ b/internal/storage/resolver_test.go
@@ -267,6 +267,55 @@ func TestResolver_ForPlatform_InvoiceRespectsEnabledFlag(t *testing.T) {
 	})
 }
 
+// Imports are structurally S3-tied (CSV Box only writes to S3), so a
+// GCP-hosted deployment must still route PurposeImport through the S3
+// backend. Guards against a regression where the resolver's deployment-wide
+// provider (r.provider = GCS on GCP) leaks into the imports path.
+func TestResolver_Imports_AlwaysS3_EvenOnGCSDeployment(t *testing.T) {
+	cfg := testConfig()
+	cfg.FlexpriceS3Imports = config.FlexpriceS3ImportsConfig{
+		Enabled:            true,
+		Bucket:             "imports-bucket",
+		Region:             "ap-south-1",
+		KeyPrefix:          "csv-box-uplods",
+		AWSAccessKeyID:     "id",
+		AWSSecretAccessKey: "secret",
+	}
+	// r.provider is GCS (mimicking a GCP-hosted worker), but imports must
+	// still resolve to the S3-backed imports bucket.
+	r := newTestResolver(t, ProviderGCS, cfg)
+
+	bc, err := r.BucketConfigFor(PurposeImport)
+	require.NoError(t, err)
+	assert.Equal(t, "imports-bucket", bc.Bucket)
+	assert.Equal(t, "csv-box-uplods", bc.KeyPrefix)
+
+	// signerFor must NOT try to resolve a GCS signer for imports (there is
+	// no FlexpriceGCSImports config today), even when r.provider is GCS.
+	signer, err := r.signerFor(PurposeImport)
+	require.NoError(t, err)
+	assert.Empty(t, signer, "imports use S3 signing; no GCS signer email expected")
+
+	s, err := r.ForPlatform(context.Background(), PurposeImport)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, ProviderS3, s.Provider(), "import storage must be S3-backed regardless of deployment cloud")
+}
+
+// Explicit guard: without FlexpriceS3Imports.Enabled, resolving imports must
+// fail with the clear "not enabled" hint — otherwise the download would fail
+// later with an unclear S3 auth error.
+func TestResolver_Imports_RejectsWhenDisabled(t *testing.T) {
+	cfg := testConfig()
+	cfg.FlexpriceS3Imports = config.FlexpriceS3ImportsConfig{Enabled: false}
+	r := newTestResolver(t, ProviderGCS, cfg)
+
+	_, err := r.BucketConfigFor(PurposeImport)
+	require.Error(t, err)
+	hints := strings.Join(cockroachErrors.GetAllHints(err), " ")
+	assert.Contains(t, hints, "FLEXPRICE_FLEXPRICE_S3_IMPORTS_ENABLED")
+}
+
 func TestResolver_ForPlatform_Caches(t *testing.T) {
 	cfg := testConfig()
 	r := newTestResolver(t, ProviderS3, cfg)


### PR DESCRIPTION
Follow-up to #2710. On a GCP-hosted worker, running an import task fails with:

\`\`\`
GCS is not yet supported for imports
\`\`\`

CSV Box only writes to S3, so imports are structurally S3-tied — even on GCP compute. The resolver's deployment-wide provider (chosen at boot by \`CloudDetector\`) was forcing \`PurposeImport\` through the GCS branch, which had no bucket/signer config and errored out.

## Fix

Introduce \`providerFor(purpose Purpose) Provider\` as a per-purpose override on top of \`r.provider\`:

- \`PurposeImport\` → always \`ProviderS3\`.
- All other purposes → \`r.provider\` (deployment-wide, unchanged).

Threaded through \`ForPlatform\`, \`BucketConfigFor\`, \`platformBucket\`, and \`signerFor\` so the whole resolution chain agrees. \`NewPlatformStorage\` already knew how to build an S3 backend for imports on any host (it injects \`FlexpriceS3Imports.*\` static creds when \`purpose==Import\`), so no change needed there.

## Result

A GCP-hosted deployment can now run imports without any config change beyond what \`FLEXPRICE_FLEXPRICE_S3_IMPORTS_*\` already needed. Invoices/exports still follow the deployment cloud.

## Tests

- \`TestResolver_Imports_AlwaysS3_EvenOnGCSDeployment\` — regression guard for the exact failure: \`r.provider=GCS\` but \`BucketConfigFor(PurposeImport)\` / \`ForPlatform(PurposeImport)\` resolve to an S3-backed storage using imports config.
- \`TestResolver_Imports_RejectsWhenDisabled\` — the \`FLEXPRICE_FLEXPRICE_S3_IMPORTS_ENABLED\` guard still trips before we try to build an S3 client with an empty bucket.

Both pass; full storage + import test suites still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import storage operations now consistently use the S3 backend, including deployments configured with GCS.
* **Bug Fixes**
  * Improved import resolution errors when S3 imports are disabled, including guidance on the required configuration setting.
* **Tests**
  * Added coverage confirming S3 selection for imports and correct behavior when imports are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->