### PR TITLE
ci(deploy): restore GHCR :develop image build on develop push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,9 @@ name: Build, Push & Deploy to AWS ECS
 
 on:
   push:
-    branches: [main]
+    # develop builds + publishes the GHCR :develop image only; no ECS deploy
+    # (staging ECS is deprovisioned). main runs the full production pipeline.
+    branches: [develop, main]
     tags: ['v*']
   # Manual trigger: lets you validate config or force-deploy without a push
   workflow_dispatch:
@@ -91,6 +93,7 @@ jobs:
           echo "tag=${ECR_REGISTRY}/${ECR_REPOSITORY}:${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
           IS_MAIN="${{ github.ref_name == 'main' }}"
+          IS_DEVELOP="${{ github.ref_name == 'develop' }}"
 
           {
             echo "ghcr_tags<<TAGS_EOF"
@@ -98,6 +101,8 @@ jobs:
             if [ "$IS_RELEASE" = "true" ]; then
               echo "${GHCR_IMAGE}:${GITHUB_REF_NAME}"
               echo "${GHCR_IMAGE}:latest"
+            elif [ "$IS_DEVELOP" = "true" ]; then
+              echo "${GHCR_IMAGE}:develop"
             # NOTE: on main we intentionally do NOT push :main here. The build job
             # publishes only the immutable :<sha> tag. The :main tag — which the GCP
             # ArgoCD image-updater watches — is promoted in the 'promote-main-ghcr'
@@ -107,7 +112,7 @@ jobs:
             echo "TAGS_EOF"
           } >> $GITHUB_OUTPUT
 
-          if [ "$IS_RELEASE" = "true" ] || [ "$IS_MAIN" = "true" ]; then
+          if [ "$IS_RELEASE" = "true" ] || [ "$IS_MAIN" = "true" ] || [ "$IS_DEVELOP" = "true" ]; then
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           else
             echo "platforms=linux/arm64" >> $GITHUB_OUTPUT
@@ -190,6 +195,9 @@ jobs:
   # ──────────────────────────────────────────────────────────────────────────
   resolve-config:
     name: Resolve deployment targets
+    # develop only builds/publishes the GHCR image (staging ECS deprovisioned).
+    # Skipping here cascades: every deploy job needs this one, so none run.
+    if: ${{ github.ref_name != 'develop' }}
     runs-on: self-hosted
     outputs:
       targets: ${{ steps.config.outputs.targets }}


### PR DESCRIPTION
## What

Restores the `ghcr.io/flexprice/flexprice:develop` image build/push that runs on pushes to `develop`.

## Why

Commit `6a3f8424` (`chore(ci): remove deprovisioned ECS staging deploy path`) dropped `develop` from `deploy.yml`'s push trigger because staging ECS was deprovisioned. That was correct for the *deploy* path — but it also silently killed the `:develop` GHCR image build, which develop consumers still rely on. Since then, pushes to develop run only Tests/CodeQL/SAST/Migration and produce no image.

## How

- **push trigger**: `[develop, main]` (was main-only)
- **build job**: republish the `:develop` GHCR tag, multi-arch (`linux/amd64,linux/arm64`) on develop — same as before the removal
- **safety guard**: `resolve-config` is gated `if: github.ref_name != 'develop'`. It's skipped on develop pushes, and since every migrate/deploy/approval job `needs` it and asserts `result == 'success'`, the whole ECS path cascades to skipped. **develop only builds + pushes the image; it never touches the now-production-only ECS targets.**

Production pipeline (main push → build → migrate → preprod canary → approval gates → GCP `:main` promotion) is unchanged.

## Verification

- YAML parses (`yaml.safe_load`)
- Cascade traced: `resolve-config` skipped → `result != 'success'` → migrate/deploy-preprod/approval-gate/promote-main-ghcr/deploy-{api,consumer,worker} all skip. Build job has no branch guard, so it runs and pushes GHCR on develop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated image builds and publishing for the `develop` branch.
  - Added multi-platform image build support.
  - Added dedicated `develop` image tagging.

- **Deployment**
  - Development builds no longer trigger ECS deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->