### PR TITLE
fix(e2eprobe): skip multi-cadence seed sub until go-sdk carries IncludePriceIDs

### DIFF
--- a/docs/swagger/swagger-3-0.json
+++ b/docs/swagger/swagger-3-0.json
@@ -10609,6 +10609,64 @@
             "ApiKeyAuth": []
           }
         ]
+      },
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Import a CSV of usage events",
+        "description": "Use to submit a CSV of usage events for async ingestion. The CSV must already have been uploaded to the Flexprice-managed imports bucket (currently via CSV Box) \u2014 pass the upload_id and the backend fetches the file from S3 and streams rows into ClickHouse. Returns the task ID and Temporal workflow IDs for polling.",
+        "operationId": "createTask",
+        "requestBody": {
+          "description": "Import request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTaskRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/models.TemporalWorkflowResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "x-scope": "write",
+        "x-codegen-request-body-name": "task"
       }
     },
     "/tasks/result": {
@@ -12718,6 +12776,68 @@
             "name": "id",
             "in": "path",
             "description": "Service Account ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content",
+            "content": {}
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/errors.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/users/{id}/remove": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Remove user from tenant",
+        "description": "Remove a human user (type=user) from the current tenant. Not supported for service accounts; use DELETE /users/{id} for those.",
+        "operationId": "removeUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "User ID",
             "required": true,
             "schema": {
               "type": "string"
@@ -17795,6 +17915,9 @@
               "$ref": "#/components/schemas/TaxRateOverride"
             }
           },
+          "tax_treatment": {
+            "$ref": "#/components/schemas/types.TaxTreatment"
+          },
           "timezone": {
             "type": "string",
             "description": "timezone is the customer's IANA timezone name (e.g. \"Asia/Kolkata\", \"America/New_York\")\nDefaults to \"UTC\" if not provided"
@@ -18183,13 +18306,6 @@
             "description": "period_start is the start date of the billing period",
             "format": "date-time"
           },
-          "prepared_tax_rates": {
-            "type": "array",
-            "description": "prepared_tax_rates contains the tax rates pre-resolved by the caller (e.g., billing service)",
-            "items": {
-              "$ref": "#/components/schemas/TaxRateResponse"
-            }
-          },
           "subscription_id": {
             "type": "string",
             "description": "subscription_id is the optional unique identifier of the subscription associated with this invoice"
@@ -18356,6 +18472,9 @@
           },
           "billing_period_count": {
             "type": "integer"
+          },
+          "bucket_size": {
+            "$ref": "#/components/schemas/types.WindowSize"
           },
           "currency": {
             "type": "string"
@@ -18635,6 +18754,7 @@
         "required": [
           "billing_period",
           "currency",
+          "include_price_ids",
           "plan_id"
         ],
         "type": "object",
@@ -18707,6 +18827,13 @@
           },
           "gateway_payment_method_id": {
             "type": "string"
+          },
+          "include_price_ids": {
+            "type": "array",
+            "description": "IncludePriceIDs selects which plan prices to attach. Nil/omitted attaches matching-cadence\nprices plus ONETIME; [] attaches none (LineItems extras still apply); a non-empty list\nattaches only those IDs. Each listed ID must belong to the plan, match the subscription\ncurrency, and have a cadence that equals or strictly divides the subscription cadence.\nPointer-slice distinguishes nil from [].",
+            "items": {
+              "type": "string"
+            }
           },
           "inheritance": {
             "$ref": "#/components/schemas/SubscriptionInheritanceConfig"
@@ -18807,6 +18934,40 @@
           }
         }
       },
+      "CreateTaskRequest": {
+        "required": [
+          "entity_type",
+          "file_provider",
+          "file_type",
+          "task_type",
+          "upload_id"
+        ],
+        "type": "object",
+        "properties": {
+          "entity_type": {
+            "$ref": "#/components/schemas/types.EntityType"
+          },
+          "file_name": {
+            "type": "string"
+          },
+          "file_provider": {
+            "type": "string"
+          },
+          "file_type": {
+            "$ref": "#/components/schemas/types.FileType"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "task_type": {
+            "$ref": "#/components/schemas/types.TaskType"
+          },
+          "upload_id": {
+            "type": "string"
+          }
+        }
+      },
       "CreateTaxAssociationRequest": {
         "required": [
           "tax_rate_code"
@@ -18847,6 +19008,9 @@
             "description": "StartDate sets when this association becomes active. Defaults to now if omitted.",
             "format": "date-time"
           },
+          "tax_behavior": {
+            "$ref": "#/components/schemas/types.TaxBehavior"
+          },
           "tax_rate_code": {
             "type": "string"
           }
@@ -18867,10 +19031,6 @@
             "type": "string",
             "description": "description is an optional text description providing details about the tax rate"
           },
-          "fixed_value": {
-            "type": "string",
-            "description": "fixed_value is the fixed monetary amount when tax_rate_type is \"fixed\""
-          },
           "metadata": {
             "type": "object",
             "additionalProperties": {
@@ -18884,7 +19044,7 @@
           },
           "percentage_value": {
             "type": "string",
-            "description": "percentage_value is the percentage value (0-100) when tax_rate_type is \"percentage\""
+            "description": "percentage_value is the percentage value (0-100)"
           },
           "scope": {
             "$ref": "#/components/schemas/types.TaxRateScope"
@@ -19485,6 +19645,9 @@
           },
           "status": {
             "$ref": "#/components/schemas/types.Status"
+          },
+          "tax_treatment": {
+            "$ref": "#/components/schemas/types.TaxTreatment"
           },
           "tenant_id": {
             "type": "string"
@@ -21336,6 +21499,12 @@
             "type": "string",
             "description": "subtotal is the sum of all line items before any taxes, discounts, or additional fees"
           },
+          "tax_exemption_reason_code": {
+            "$ref": "#/components/schemas/types.TaxExemptionReasonCode"
+          },
+          "tax_summary": {
+            "$ref": "#/components/schemas/TaxSummary"
+          },
           "taxes": {
             "type": "array",
             "description": "tax_applied_records contains the tax applied records associated with this invoice",
@@ -21767,6 +21936,9 @@
           "billing_model": {
             "$ref": "#/components/schemas/types.BillingModel"
           },
+          "bucket_size": {
+            "$ref": "#/components/schemas/types.WindowSize"
+          },
           "price_id": {
             "type": "string",
             "description": "PriceID references the plan price to override"
@@ -22111,6 +22283,9 @@
           "billing_period_count": {
             "type": "integer",
             "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12"
+          },
+          "bucket_size": {
+            "$ref": "#/components/schemas/types.WindowSize"
           },
           "conversion_rate": {
             "type": "string",
@@ -23481,6 +23656,9 @@
           "billing_period_count": {
             "type": "integer"
           },
+          "bucket_size": {
+            "$ref": "#/components/schemas/types.WindowSize"
+          },
           "description": {
             "type": "string"
           },
@@ -24304,6 +24482,9 @@
           "tax_association_id": {
             "type": "string"
           },
+          "tax_behavior": {
+            "$ref": "#/components/schemas/types.TaxBehavior"
+          },
           "tax_rate": {
             "$ref": "#/components/schemas/TaxRateResponse"
           },
@@ -24382,6 +24563,9 @@
           "status": {
             "$ref": "#/components/schemas/types.Status"
           },
+          "tax_behavior": {
+            "$ref": "#/components/schemas/types.TaxBehavior"
+          },
           "tax_rate": {
             "$ref": "#/components/schemas/TaxRateResponse"
           },
@@ -24415,6 +24599,20 @@
           },
           "priority": {
             "type": "integer"
+          },
+          "tax_behavior": {
+            "$ref": "#/components/schemas/types.TaxBehavior"
+          }
+        }
+      },
+      "TaxExemptionSummary": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "reason_code": {
+            "$ref": "#/components/schemas/types.TaxExemptionReasonCode"
           }
         }
       },
@@ -24441,6 +24639,9 @@
           "priority": {
             "type": "integer"
           },
+          "tax_behavior": {
+            "$ref": "#/components/schemas/types.TaxBehavior"
+          },
           "tax_rate_code": {
             "type": "string"
           }
@@ -24463,9 +24664,6 @@
             "type": "string"
           },
           "environment_id": {
-            "type": "string"
-          },
-          "fixed_value": {
             "type": "string"
           },
           "id": {
@@ -24503,6 +24701,23 @@
             "format": "date-time"
           },
           "updated_by": {
+            "type": "string"
+          }
+        }
+      },
+      "TaxSummary": {
+        "type": "object",
+        "properties": {
+          "exclusive_tax": {
+            "type": "string"
+          },
+          "exemption": {
+            "$ref": "#/components/schemas/TaxExemptionSummary"
+          },
+          "inclusive_tax": {
+            "type": "string"
+          },
+          "total_tax": {
             "type": "string"
           }
         }
@@ -24833,6 +25048,9 @@
             "type": "string",
             "description": "name is the updated name or company name for the customer"
           },
+          "tax_treatment": {
+            "$ref": "#/components/schemas/types.TaxTreatment"
+          },
           "timezone": {
             "type": "string",
             "description": "timezone is the updated IANA timezone name for the customer (e.g. \"Asia/Kolkata\", \"America/New_York\")"
@@ -25026,6 +25244,9 @@
           "billing_model": {
             "$ref": "#/components/schemas/types.BillingModel"
           },
+          "bucket_size": {
+            "$ref": "#/components/schemas/types.WindowSize"
+          },
           "description": {
             "type": "string"
           },
@@ -25150,6 +25371,9 @@
           },
           "billing_model": {
             "$ref": "#/components/schemas/types.BillingModel"
+          },
+          "bucket_size": {
+            "$ref": "#/components/schemas/types.WindowSize"
           },
           "commitment_amount": {
             "type": "number",
@@ -26281,6 +26505,9 @@
           "status": {
             "$ref": "#/components/schemas/types.Status"
           },
+          "tax_treatment": {
+            "$ref": "#/components/schemas/types.TaxTreatment"
+          },
           "tenant_id": {
             "type": "string"
           },
@@ -26650,7 +26877,7 @@
           },
           "group_by": {
             "type": "string",
-            "description": "GroupBy is the property name in event.properties to group by before aggregating.\nCurrently only supported for MAX aggregation with bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total."
+            "description": "GroupBy is the property name in event.properties to group by before aggregating.\nRequires MAX aggregation. Windowing comes from the price, so this no longer\nimplies a meter-level bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total."
           },
           "multiplier": {
             "type": "string",
@@ -26791,6 +27018,9 @@
           "billing_period_count": {
             "type": "integer",
             "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12"
+          },
+          "bucket_size": {
+            "$ref": "#/components/schemas/types.WindowSize"
           },
           "conversion_rate": {
             "type": "string",
@@ -29104,6 +29334,10 @@
           },
           "service_period_custom_fields": {
             "$ref": "#/components/schemas/types.ServicePeriodCustomFields"
+          },
+          "submit_for_approval": {
+            "type": "boolean",
+            "description": "SubmitForApproval submits the synced invoice into the merchant's Zoho Books approval\nflow before recording payment. Zoho rejects payments on draft invoices, and merchants\nconfigure a Zoho auto-approval rule for FlexPrice-sent invoices, so we submit, wait for\nthat rule to fire, then pay."
           }
         },
         "x-speakeasy-name-override": "InvoiceSyncSettings"
@@ -29850,6 +30084,9 @@
             "type": "string",
             "description": "Optional prefix for S3 keys (e.g., \"flexprice-exports/\")"
           },
+          "provider": {
+            "$ref": "#/components/schemas/types.SecretProvider"
+          },
           "region": {
             "type": "string",
             "description": "AWS region (e.g., \"us-west-2\")"
@@ -29936,6 +30173,7 @@
           "flexprice",
           "stripe",
           "s3",
+          "gcs",
           "hubspot",
           "razorpay",
           "chargebee",
@@ -29951,12 +30189,14 @@
           "azure_marketplace"
         ],
         "x-enum-comments": {
+          "SecretProviderGCS": "supports multiple connections per environment, service-account JSON creds",
           "SecretProviderS3": "supports multiple connections per environment"
         },
         "x-enum-varnames": [
           "SecretProviderFlexPrice",
           "SecretProviderStripe",
           "SecretProviderS3",
+          "SecretProviderGCS",
           "SecretProviderHubSpot",
           "SecretProviderRazorpay",
           "SecretProviderChargebee",
@@ -30451,6 +30691,30 @@
         ],
         "x-speakeasy-name-override": "TaskType"
       },
+      "types.TaxBehavior": {
+        "type": "string",
+        "enum": [
+          "inclusive",
+          "exclusive"
+        ],
+        "x-enum-varnames": [
+          "TaxBehaviorInclusive",
+          "TaxBehaviorExclusive"
+        ],
+        "x-speakeasy-name-override": "TaxBehavior"
+      },
+      "types.TaxExemptionReasonCode": {
+        "type": "string",
+        "enum": [
+          "customer_exempt",
+          "no_tax_configured"
+        ],
+        "x-enum-varnames": [
+          "TaxExemptionReasonCustomerExempt",
+          "TaxExemptionReasonNoTaxConfigured"
+        ],
+        "x-speakeasy-name-override": "TaxExemptionReasonCode"
+      },
       "types.TaxRateEntityType": {
         "type": "string",
         "enum": [
@@ -30496,14 +30760,24 @@
       "types.TaxRateType": {
         "type": "string",
         "enum": [
-          "percentage",
-          "fixed"
+          "percentage"
         ],
         "x-enum-varnames": [
-          "TaxRateTypePercentage",
-          "TaxRateTypeFixed"
+          "TaxRateTypePercentage"
         ],
         "x-speakeasy-name-override": "TaxRateType"
+      },
+      "types.TaxTreatment": {
+        "type": "string",
+        "enum": [
+          "taxable",
+          "exempt"
+        ],
+        "x-enum-varnames": [
+          "TaxTreatmentTaxable",
+          "TaxTreatmentExempt"
+        ],
+        "x-speakeasy-name-override": "TaxTreatment"
       },
       "types.TimeOfDayBucket": {
         "type": "object",
@@ -31904,6 +32178,9 @@
       "webhookDto.SubscriptionWebhookPayload": {
         "type": "object",
         "properties": {
+          "customer": {
+            "$ref": "#/components/schemas/webhookDto.Customer"
+          },
           "event_type": {
             "$ref": "#/components/schemas/types.WebhookEventName"
           },
@@ -32045,6 +32322,9 @@
         "properties": {
           "alert": {
             "$ref": "#/components/schemas/webhookDto.WalletAlertInfo"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/webhookDto.Customer"
           },
           "event_type": {
             "$ref": "#/components/schemas/types.WebhookEventName"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -8799,6 +8799,57 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Use to submit a CSV of usage events for async ingestion. The CSV must already have been uploaded to the Flexprice-managed imports bucket (currently via CSV Box) — pass the upload_id and the backend fetches the file from S3 and streams rows into ClickHouse. Returns the task ID and Temporal workflow IDs for polling.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Tasks"
+                ],
+                "summary": "Import a CSV of usage events",
+                "operationId": "createTask",
+                "parameters": [
+                    {
+                        "description": "Import request",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CreateTaskRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TemporalWorkflowResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                },
+                "x-scope": "write"
             }
         },
         "/tasks/result": {
@@ -10576,6 +10627,56 @@
                     {
                         "type": "string",
                         "description": "Service Account ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content"
+                    },
+                    "400": {
+                        "description": "Invalid request",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not found",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Server error",
+                        "schema": {
+                            "$ref": "#/definitions/errors.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{id}/remove": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Remove a human user (type=user) from the current tenant. Not supported for service accounts; use DELETE /users/{id} for those.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Remove user from tenant",
+                "operationId": "removeUser",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
                         "name": "id",
                         "in": "path",
                         "required": true
@@ -15530,6 +15631,10 @@
                         "$ref": "#/definitions/TaxRateOverride"
                     }
                 },
+                "tax_treatment": {
+                    "description": "tax_treatment is the customer's tax treatment. Defaults to \"taxable\" if not provided.",
+                    "$ref": "#/definitions/types.TaxTreatment"
+                },
                 "timezone": {
                     "description": "timezone is the customer's IANA timezone name (e.g. \"Asia/Kolkata\", \"America/New_York\")\nDefaults to \"UTC\" if not provided",
                     "type": "string"
@@ -15917,13 +16022,6 @@
                     "description": "period_start is the start date of the billing period",
                     "type": "string"
                 },
-                "prepared_tax_rates": {
-                    "description": "prepared_tax_rates contains the tax rates pre-resolved by the caller (e.g., billing service)",
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/TaxRateResponse"
-                    }
-                },
                 "subscription_id": {
                     "description": "subscription_id is the optional unique identifier of the subscription associated with this invoice",
                     "type": "string"
@@ -16091,6 +16189,10 @@
                 "billing_period_count": {
                     "type": "integer",
                     "default": 1
+                },
+                "bucket_size": {
+                    "description": "BucketSize windows the meter's aggregation for this price. The meter\naggregates within each window and the window results are summed, so the\nbillable unit becomes per-window (e.g. seats -\u003e seat-hours). Valid only on\nUSAGE prices whose meter aggregates MAX or SUM.",
+                    "$ref": "#/definitions/types.WindowSize"
                 },
                 "currency": {
                     "type": "string"
@@ -16372,6 +16474,7 @@
             "required": [
                 "billing_period",
                 "currency",
+                "include_price_ids",
                 "plan_id"
             ],
             "properties": {
@@ -16444,6 +16547,13 @@
                 },
                 "gateway_payment_method_id": {
                     "type": "string"
+                },
+                "include_price_ids": {
+                    "description": "IncludePriceIDs selects which plan prices to attach. Nil/omitted attaches matching-cadence\nprices plus ONETIME; [] attaches none (LineItems extras still apply); a non-empty list\nattaches only those IDs. Each listed ID must belong to the plan, match the subscription\ncurrency, and have a cadence that equals or strictly divides the subscription cadence.\nPointer-slice distinguishes nil from [].",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "inheritance": {
                     "description": "Inheritance groups customer-hierarchy fields; providing child IDs makes this a PARENT subscription.",
@@ -16546,6 +16656,40 @@
                 }
             }
         },
+        "CreateTaskRequest": {
+            "type": "object",
+            "required": [
+                "entity_type",
+                "file_provider",
+                "file_type",
+                "task_type",
+                "upload_id"
+            ],
+            "properties": {
+                "entity_type": {
+                    "$ref": "#/definitions/types.EntityType"
+                },
+                "file_name": {
+                    "type": "string"
+                },
+                "file_provider": {
+                    "type": "string"
+                },
+                "file_type": {
+                    "$ref": "#/definitions/types.FileType"
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": true
+                },
+                "task_type": {
+                    "$ref": "#/definitions/types.TaskType"
+                },
+                "upload_id": {
+                    "type": "string"
+                }
+            }
+        },
         "CreateTaxAssociationRequest": {
             "type": "object",
             "required": [
@@ -16584,6 +16728,10 @@
                     "description": "StartDate sets when this association becomes active. Defaults to now if omitted.",
                     "type": "string"
                 },
+                "tax_behavior": {
+                    "description": "TaxBehavior is inclusive or exclusive. Settable at any level. If left empty on a\nsubscription-level association, it resolves from the currency default at creation\ntime (internal/types.DefaultTaxBehaviorForCurrency) — tenant/customer-level templates\nonly need this set explicitly if the tenant wants one; otherwise it stays null and is\nresolved when the template is copied down to a subscription.",
+                    "$ref": "#/definitions/types.TaxBehavior"
+                },
                 "tax_rate_code": {
                     "type": "string"
                 }
@@ -16604,10 +16752,6 @@
                     "description": "description is an optional text description providing details about the tax rate",
                     "type": "string"
                 },
-                "fixed_value": {
-                    "description": "fixed_value is the fixed monetary amount when tax_rate_type is \"fixed\"",
-                    "type": "string"
-                },
                 "metadata": {
                     "description": "metadata contains additional key-value pairs for storing extra information",
                     "type": "object",
@@ -16620,7 +16764,7 @@
                     "type": "string"
                 },
                 "percentage_value": {
-                    "description": "percentage_value is the percentage value (0-100) when tax_rate_type is \"percentage\"",
+                    "description": "percentage_value is the percentage value (0-100)",
                     "type": "string"
                 },
                 "scope": {
@@ -16628,7 +16772,7 @@
                     "$ref": "#/definitions/types.TaxRateScope"
                 },
                 "tax_rate_type": {
-                    "description": "tax_rate_type determines how the tax is calculated (\"percentage\" or \"fixed\")",
+                    "description": "tax_rate_type is always \"percentage\" — fixed-amount tax rates are not supported",
                     "$ref": "#/definitions/types.TaxRateType"
                 }
             }
@@ -17221,6 +17365,10 @@
                 },
                 "status": {
                     "$ref": "#/definitions/types.Status"
+                },
+                "tax_treatment": {
+                    "description": "TaxTreatment is the customer's tax treatment — taxable (default) or exempt.",
+                    "$ref": "#/definitions/types.TaxTreatment"
                 },
                 "tenant_id": {
                     "type": "string"
@@ -19035,6 +19183,14 @@
                     "description": "subtotal is the sum of all line items before any taxes, discounts, or additional fees",
                     "type": "string"
                 },
+                "tax_exemption_reason_code": {
+                    "description": "tax_exemption_reason_code is why no tax was charged; null only when tax was actually charged.",
+                    "$ref": "#/definitions/types.TaxExemptionReasonCode"
+                },
+                "tax_summary": {
+                    "description": "tax_summary breaks total_tax down by behavior and states why no tax was charged, when\nnone was. Set by WithTaxes once Taxes and TaxExemptionReasonCode are both known.",
+                    "$ref": "#/definitions/TaxSummary"
+                },
                 "taxes": {
                     "description": "tax_applied_records contains the tax applied records associated with this invoice",
                     "type": "array",
@@ -19460,6 +19616,10 @@
                 "billing_model": {
                     "$ref": "#/definitions/types.BillingModel"
                 },
+                "bucket_size": {
+                    "description": "BucketSize overrides the windowing used to turn this meter's usage into\nbillable units for this subscription. See CreatePriceRequest.BucketSize.",
+                    "$ref": "#/definitions/types.WindowSize"
+                },
                 "price_id": {
                     "description": "PriceID references the plan price to override",
                     "type": "string"
@@ -19798,6 +19958,10 @@
                     "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
                     "type": "integer",
                     "default": 1
+                },
+                "bucket_size": {
+                    "description": "BucketSize windows the meter's aggregation for this price: the meter\naggregates within each window and the window results are summed. Empty\nmeans unbucketed. Only valid on USAGE prices whose meter aggregates MAX\nor SUM. Resolved through ResolveBucketSize, never read directly.",
+                    "$ref": "#/definitions/types.WindowSize"
                 },
                 "conversion_rate": {
                     "description": "ConversionRate is the conversion rate of the price unit to the fiat currency",
@@ -21170,6 +21334,10 @@
                 "billing_period_count": {
                     "type": "integer"
                 },
+                "bucket_size": {
+                    "description": "BucketSize windows the meter's aggregation for this price. See\nCreatePriceRequest.BucketSize.",
+                    "$ref": "#/definitions/types.WindowSize"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -21966,6 +22134,9 @@
                 "tax_association_id": {
                     "type": "string"
                 },
+                "tax_behavior": {
+                    "$ref": "#/definitions/types.TaxBehavior"
+                },
                 "tax_rate": {
                     "$ref": "#/definitions/TaxRateResponse"
                 },
@@ -22041,6 +22212,10 @@
                 "status": {
                     "$ref": "#/definitions/types.Status"
                 },
+                "tax_behavior": {
+                    "description": "TaxBehavior is inclusive or exclusive; null on tenant/customer-level rows,\nresolved when copied down to a subscription",
+                    "$ref": "#/definitions/types.TaxBehavior"
+                },
                 "tax_rate": {
                     "$ref": "#/definitions/TaxRateResponse"
                 },
@@ -22073,6 +22248,20 @@
                 },
                 "priority": {
                     "type": "integer"
+                },
+                "tax_behavior": {
+                    "$ref": "#/definitions/types.TaxBehavior"
+                }
+            }
+        },
+        "TaxExemptionSummary": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string"
+                },
+                "reason_code": {
+                    "$ref": "#/definitions/types.TaxExemptionReasonCode"
                 }
             }
         },
@@ -22099,6 +22288,9 @@
                 "priority": {
                     "type": "integer"
                 },
+                "tax_behavior": {
+                    "$ref": "#/definitions/types.TaxBehavior"
+                },
                 "tax_rate_code": {
                     "type": "string"
                 }
@@ -22120,9 +22312,6 @@
                     "type": "string"
                 },
                 "environment_id": {
-                    "type": "string"
-                },
-                "fixed_value": {
                     "type": "string"
                 },
                 "id": {
@@ -22159,6 +22348,23 @@
                     "type": "string"
                 },
                 "updated_by": {
+                    "type": "string"
+                }
+            }
+        },
+        "TaxSummary": {
+            "type": "object",
+            "properties": {
+                "exclusive_tax": {
+                    "type": "string"
+                },
+                "exemption": {
+                    "$ref": "#/definitions/TaxExemptionSummary"
+                },
+                "inclusive_tax": {
+                    "type": "string"
+                },
+                "total_tax": {
                     "type": "string"
                 }
             }
@@ -22488,6 +22694,10 @@
                     "description": "name is the updated name or company name for the customer",
                     "type": "string"
                 },
+                "tax_treatment": {
+                    "description": "tax_treatment is the updated tax treatment for the customer",
+                    "$ref": "#/definitions/types.TaxTreatment"
+                },
                 "timezone": {
                     "description": "timezone is the updated IANA timezone name for the customer (e.g. \"Asia/Kolkata\", \"America/New_York\")",
                     "type": "string"
@@ -22677,6 +22887,10 @@
                 "billing_model": {
                     "$ref": "#/definitions/types.BillingModel"
                 },
+                "bucket_size": {
+                    "description": "BucketSize windows the meter's aggregation for this price. Changing it\nchanges the billable unit, so it versions the price rather than editing\nit in place. Send \"none\" to remove bucketing from the successor.",
+                    "$ref": "#/definitions/types.WindowSize"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -22804,6 +23018,10 @@
                 "billing_model": {
                     "$ref": "#/definitions/types.BillingModel"
                 },
+                "bucket_size": {
+                    "description": "BucketSize overrides the windowing used to turn this meter's usage into\nbillable units for this line item. See CreatePriceRequest.BucketSize.",
+                    "$ref": "#/definitions/types.WindowSize"
+                },
                 "commitment_amount": {
                     "description": "Commitment fields",
                     "type": "number"
@@ -22913,7 +23131,7 @@
                     "type": "string"
                 },
                 "tax_rate_status": {
-                    "description": "tax_rate_type determines how the tax is calculated (\"percentage\" or \"fixed\")",
+                    "description": "tax_rate_status is the updated status of the tax rate",
                     "$ref": "#/definitions/types.TaxRateStatus"
                 }
             }
@@ -23924,6 +24142,10 @@
                 "status": {
                     "$ref": "#/definitions/types.Status"
                 },
+                "tax_treatment": {
+                    "description": "TaxTreatment is the customer's tax treatment — taxable (default) or exempt.",
+                    "$ref": "#/definitions/types.TaxTreatment"
+                },
                 "tenant_id": {
                     "type": "string"
                 },
@@ -24268,8 +24490,9 @@
             "type": "object",
             "properties": {
                 "bucket_size": {
-                    "description": "BucketSize is used only for MAX aggregation when windowed aggregation is needed\nIt defines the size of time windows to calculate max values within",
-                    "$ref": "#/definitions/types.WindowSize"
+                    "description": "BucketSize windows the aggregation: the meter aggregates within each window\nand the window results are summed.\n\nDeprecated: configure bucket_size on the price instead. Still read and\nhonoured — meters that carry it keep billing exactly as before, and new\nmeters may still set it — but a price-level bucket_size takes precedence\nand is the only place new configuration should go. See\nprice.ResolveBucketSize.",
+                    "$ref": "#/definitions/types.WindowSize",
+                    "x-speakeasy-deprecation-message": "Deprecated: set bucket_size on the price instead. Still honoured for existing meters."
                 },
                 "expression": {
                     "description": "Expression is an optional CEL expression to compute per-event quantity from event.properties.\nWhen set, it replaces Field-based extraction. Property names are used directly (e.g., token * duration * pixel).",
@@ -24280,7 +24503,7 @@
                     "type": "string"
                 },
                 "group_by": {
-                    "description": "GroupBy is the property name in event.properties to group by before aggregating.\nCurrently only supported for MAX aggregation with bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total.",
+                    "description": "GroupBy is the property name in event.properties to group by before aggregating.\nRequires MAX aggregation. Windowing comes from the price, so this no longer\nimplies a meter-level bucket_size.\nWhen set, aggregation is applied per unique value of this property within each bucket,\nthen the per-group results are summed to produce the bucket total.",
                     "type": "string"
                 },
                 "multiplier": {
@@ -24424,6 +24647,10 @@
                     "description": "BillingPeriodCount is the count of the billing period ex 1, 3, 6, 12",
                     "type": "integer",
                     "default": 1
+                },
+                "bucket_size": {
+                    "description": "BucketSize windows the meter's aggregation for this price: the meter\naggregates within each window and the window results are summed. Empty\nmeans unbucketed. Only valid on USAGE prices whose meter aggregates MAX\nor SUM. Resolved through ResolveBucketSize, never read directly.",
+                    "$ref": "#/definitions/types.WindowSize"
                 },
                 "conversion_rate": {
                     "description": "ConversionRate is the conversion rate of the price unit to the fiat currency",
@@ -26628,6 +26855,10 @@
                 "service_period_custom_fields": {
                     "description": "ServicePeriodCustomFields names the Zoho custom fields that receive the\ninvoice's service start and end dates.",
                     "$ref": "#/definitions/types.ServicePeriodCustomFields"
+                },
+                "submit_for_approval": {
+                    "description": "SubmitForApproval submits the synced invoice into the merchant's Zoho Books approval\nflow before recording payment. Zoho rejects payments on draft invoices, and merchants\nconfigure a Zoho auto-approval rule for FlexPrice-sent invoices, so we submit, wait for\nthat rule to fire, then pay.",
+                    "type": "boolean"
                 }
             }
         },
@@ -27335,6 +27566,10 @@
                     "description": "Optional prefix for S3 keys (e.g., \"flexprice-exports/\")",
                     "type": "string"
                 },
+                "provider": {
+                    "description": "Empty means S3 for back-compat.",
+                    "$ref": "#/definitions/types.SecretProvider"
+                },
                 "region": {
                     "description": "AWS region (e.g., \"us-west-2\")",
                     "type": "string"
@@ -27416,6 +27651,7 @@
                 "flexprice",
                 "stripe",
                 "s3",
+                "gcs",
                 "hubspot",
                 "razorpay",
                 "chargebee",
@@ -27431,12 +27667,14 @@
                 "azure_marketplace"
             ],
             "x-enum-comments": {
+                "SecretProviderGCS": "supports multiple connections per environment, service-account JSON creds",
                 "SecretProviderS3": "supports multiple connections per environment"
             },
             "x-enum-varnames": [
                 "SecretProviderFlexPrice",
                 "SecretProviderStripe",
                 "SecretProviderS3",
+                "SecretProviderGCS",
                 "SecretProviderHubSpot",
                 "SecretProviderRazorpay",
                 "SecretProviderChargebee",
@@ -27914,6 +28152,28 @@
                 "TaskTypeExport"
             ]
         },
+        "types.TaxBehavior": {
+            "type": "string",
+            "enum": [
+                "inclusive",
+                "exclusive"
+            ],
+            "x-enum-varnames": [
+                "TaxBehaviorInclusive",
+                "TaxBehaviorExclusive"
+            ]
+        },
+        "types.TaxExemptionReasonCode": {
+            "type": "string",
+            "enum": [
+                "customer_exempt",
+                "no_tax_configured"
+            ],
+            "x-enum-varnames": [
+                "TaxExemptionReasonCustomerExempt",
+                "TaxExemptionReasonNoTaxConfigured"
+            ]
+        },
         "types.TaxRateEntityType": {
             "type": "string",
             "enum": [
@@ -27956,12 +28216,21 @@
         "types.TaxRateType": {
             "type": "string",
             "enum": [
-                "percentage",
-                "fixed"
+                "percentage"
             ],
             "x-enum-varnames": [
-                "TaxRateTypePercentage",
-                "TaxRateTypeFixed"
+                "TaxRateTypePercentage"
+            ]
+        },
+        "types.TaxTreatment": {
+            "type": "string",
+            "enum": [
+                "taxable",
+                "exempt"
+            ],
+            "x-enum-varnames": [
+                "TaxTreatmentTaxable",
+                "TaxTreatmentExempt"
             ]
         },
         "types.TimeOfDayBucket": {
@@ -29306,6 +29575,9 @@
         "webhookDto.SubscriptionWebhookPayload": {
             "type": "object",
             "properties": {
+                "customer": {
+                    "$ref": "#/definitions/webhookDto.Customer"
+                },
                 "event_type": {
                     "$ref": "#/definitions/types.WebhookEventName"
                 },
@@ -29446,6 +29718,9 @@
             "properties": {
                 "alert": {
                     "$ref": "#/definitions/webhookDto.WalletAlertInfo"
+                },
+                "customer": {
+                    "$ref": "#/definitions/webhookDto.Customer"
                 },
                 "event_type": {
                     "$ref": "#/definitions/types.WebhookEventName"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1957,6 +1957,11 @@ definitions:
         items:
           $ref: '#/definitions/TaxRateOverride'
         type: array
+      tax_treatment:
+        allOf:
+        - $ref: '#/definitions/types.TaxTreatment'
+        description: tax_treatment is the customer's tax treatment. Defaults to "taxable"
+          if not provided.
       timezone:
         description: |-
           timezone is the customer's IANA timezone name (e.g. "Asia/Kolkata", "America/New_York")
@@ -2283,12 +2288,6 @@ definitions:
       period_start:
         description: period_start is the start date of the billing period
         type: string
-      prepared_tax_rates:
-        description: prepared_tax_rates contains the tax rates pre-resolved by the
-          caller (e.g., billing service)
-        items:
-          $ref: '#/definitions/TaxRateResponse'
-        type: array
       subscription_id:
         description: subscription_id is the optional unique identifier of the subscription
           associated with this invoice
@@ -2409,6 +2408,14 @@ definitions:
       billing_period_count:
         default: 1
         type: integer
+      bucket_size:
+        allOf:
+        - $ref: '#/definitions/types.WindowSize'
+        description: |-
+          BucketSize windows the meter's aggregation for this price. The meter
+          aggregates within each window and the window results are summed, so the
+          billable unit becomes per-window (e.g. seats -> seat-hours). Valid only on
+          USAGE prices whose meter aggregates MAX or SUM.
       currency:
         type: string
       description:
@@ -2691,6 +2698,16 @@ definitions:
         type: string
       gateway_payment_method_id:
         type: string
+      include_price_ids:
+        description: |-
+          IncludePriceIDs selects which plan prices to attach. Nil/omitted attaches matching-cadence
+          prices plus ONETIME; [] attaches none (LineItems extras still apply); a non-empty list
+          attaches only those IDs. Each listed ID must belong to the plan, match the subscription
+          currency, and have a cadence that equals or strictly divides the subscription cadence.
+          Pointer-slice distinguishes nil from [].
+        items:
+          type: string
+        type: array
       inheritance:
         allOf:
         - $ref: '#/definitions/SubscriptionInheritanceConfig'
@@ -2773,7 +2790,32 @@ definitions:
     required:
     - billing_period
     - currency
+    - include_price_ids
     - plan_id
+    type: object
+  CreateTaskRequest:
+    properties:
+      entity_type:
+        $ref: '#/definitions/types.EntityType'
+      file_name:
+        type: string
+      file_provider:
+        type: string
+      file_type:
+        $ref: '#/definitions/types.FileType'
+      metadata:
+        additionalProperties: true
+        type: object
+      task_type:
+        $ref: '#/definitions/types.TaskType'
+      upload_id:
+        type: string
+    required:
+    - entity_type
+    - file_provider
+    - file_type
+    - task_type
+    - upload_id
     type: object
   CreateTaxAssociationRequest:
     properties:
@@ -2801,6 +2843,15 @@ definitions:
         description: StartDate sets when this association becomes active. Defaults
           to now if omitted.
         type: string
+      tax_behavior:
+        allOf:
+        - $ref: '#/definitions/types.TaxBehavior'
+        description: |-
+          TaxBehavior is inclusive or exclusive. Settable at any level. If left empty on a
+          subscription-level association, it resolves from the currency default at creation
+          time (internal/types.DefaultTaxBehaviorForCurrency) — tenant/customer-level templates
+          only need this set explicitly if the tenant wants one; otherwise it stays null and is
+          resolved when the template is copied down to a subscription.
       tax_rate_code:
         type: string
     required:
@@ -2816,10 +2867,6 @@ definitions:
         description: description is an optional text description providing details
           about the tax rate
         type: string
-      fixed_value:
-        description: fixed_value is the fixed monetary amount when tax_rate_type is
-          "fixed"
-        type: string
       metadata:
         additionalProperties:
           type: string
@@ -2830,8 +2877,7 @@ definitions:
         description: name is the human-readable name for the tax rate (required)
         type: string
       percentage_value:
-        description: percentage_value is the percentage value (0-100) when tax_rate_type
-          is "percentage"
+        description: percentage_value is the percentage value (0-100)
         type: string
       scope:
         allOf:
@@ -2840,8 +2886,8 @@ definitions:
       tax_rate_type:
         allOf:
         - $ref: '#/definitions/types.TaxRateType'
-        description: tax_rate_type determines how the tax is calculated ("percentage"
-          or "fixed")
+        description: tax_rate_type is always "percentage" — fixed-amount tax rates
+          are not supported
     required:
     - code
     - name
@@ -3323,6 +3369,11 @@ definitions:
         type: string
       status:
         $ref: '#/definitions/types.Status'
+      tax_treatment:
+        allOf:
+        - $ref: '#/definitions/types.TaxTreatment'
+        description: TaxTreatment is the customer's tax treatment — taxable (default)
+          or exempt.
       tenant_id:
         type: string
       timezone:
@@ -4715,6 +4766,17 @@ definitions:
         description: subtotal is the sum of all line items before any taxes, discounts,
           or additional fees
         type: string
+      tax_exemption_reason_code:
+        allOf:
+        - $ref: '#/definitions/types.TaxExemptionReasonCode'
+        description: tax_exemption_reason_code is why no tax was charged; null only
+          when tax was actually charged.
+      tax_summary:
+        allOf:
+        - $ref: '#/definitions/TaxSummary'
+        description: |-
+          tax_summary breaks total_tax down by behavior and states why no tax was charged, when
+          none was. Set by WithTaxes once Taxes and TaxExemptionReasonCode are both known.
       taxes:
         description: tax_applied_records contains the tax applied records associated
           with this invoice
@@ -5014,6 +5076,12 @@ definitions:
         type: string
       billing_model:
         $ref: '#/definitions/types.BillingModel'
+      bucket_size:
+        allOf:
+        - $ref: '#/definitions/types.WindowSize'
+        description: |-
+          BucketSize overrides the windowing used to turn this meter's usage into
+          billable units for this subscription. See CreatePriceRequest.BucketSize.
       price_id:
         description: PriceID references the plan price to override
         type: string
@@ -5257,6 +5325,14 @@ definitions:
         description: BillingPeriodCount is the count of the billing period ex 1, 3,
           6, 12
         type: integer
+      bucket_size:
+        allOf:
+        - $ref: '#/definitions/types.WindowSize'
+        description: |-
+          BucketSize windows the meter's aggregation for this price: the meter
+          aggregates within each window and the window results are summed. Empty
+          means unbucketed. Only valid on USAGE prices whose meter aggregates MAX
+          or SUM. Resolved through ResolveBucketSize, never read directly.
       conversion_rate:
         description: ConversionRate is the conversion rate of the price unit to the
           fiat currency
@@ -6310,6 +6386,12 @@ definitions:
         $ref: '#/definitions/types.BillingPeriod'
       billing_period_count:
         type: integer
+      bucket_size:
+        allOf:
+        - $ref: '#/definitions/types.WindowSize'
+        description: |-
+          BucketSize windows the meter's aggregation for this price. See
+          CreatePriceRequest.BucketSize.
       description:
         type: string
       display_name:
@@ -6970,6 +7052,8 @@ definitions:
         type: string
       tax_association_id:
         type: string
+      tax_behavior:
+        $ref: '#/definitions/types.TaxBehavior'
       tax_rate:
         $ref: '#/definitions/TaxRateResponse'
       tax_rate_id:
@@ -7026,6 +7110,12 @@ definitions:
         type: string
       status:
         $ref: '#/definitions/types.Status'
+      tax_behavior:
+        allOf:
+        - $ref: '#/definitions/types.TaxBehavior'
+        description: |-
+          TaxBehavior is inclusive or exclusive; null on tenant/customer-level rows,
+          resolved when copied down to a subscription
       tax_rate:
         $ref: '#/definitions/TaxRateResponse'
       tax_rate_id:
@@ -7048,6 +7138,15 @@ definitions:
         type: object
       priority:
         type: integer
+      tax_behavior:
+        $ref: '#/definitions/types.TaxBehavior'
+    type: object
+  TaxExemptionSummary:
+    properties:
+      reason:
+        type: string
+      reason_code:
+        $ref: '#/definitions/types.TaxExemptionReasonCode'
     type: object
   TaxRateOverride:
     properties:
@@ -7062,6 +7161,8 @@ definitions:
         type: object
       priority:
         type: integer
+      tax_behavior:
+        $ref: '#/definitions/types.TaxBehavior'
       tax_rate_code:
         type: string
     required:
@@ -7079,8 +7180,6 @@ definitions:
       description:
         type: string
       environment_id:
-        type: string
-      fixed_value:
         type: string
       id:
         type: string
@@ -7105,6 +7204,17 @@ definitions:
       updated_at:
         type: string
       updated_by:
+        type: string
+    type: object
+  TaxSummary:
+    properties:
+      exclusive_tax:
+        type: string
+      exemption:
+        $ref: '#/definitions/TaxExemptionSummary'
+      inclusive_tax:
+        type: string
+      total_tax:
         type: string
     type: object
   TenantBillingDetails:
@@ -7371,6 +7481,10 @@ definitions:
       name:
         description: name is the updated name or company name for the customer
         type: string
+      tax_treatment:
+        allOf:
+        - $ref: '#/definitions/types.TaxTreatment'
+        description: tax_treatment is the updated tax treatment for the customer
       timezone:
         description: timezone is the updated IANA timezone name for the customer (e.g.
           "Asia/Kolkata", "America/New_York")
@@ -7508,6 +7622,13 @@ definitions:
         type: string
       billing_model:
         $ref: '#/definitions/types.BillingModel'
+      bucket_size:
+        allOf:
+        - $ref: '#/definitions/types.WindowSize'
+        description: |-
+          BucketSize windows the meter's aggregation for this price. Changing it
+          changes the billable unit, so it versions the price rather than editing
+          it in place. Send "none" to remove bucketing from the successor.
       description:
         type: string
       display_name:
@@ -7605,6 +7726,12 @@ definitions:
         type: string
       billing_model:
         $ref: '#/definitions/types.BillingModel'
+      bucket_size:
+        allOf:
+        - $ref: '#/definitions/types.WindowSize'
+        description: |-
+          BucketSize overrides the windowing used to turn this meter's usage into
+          billable units for this line item. See CreatePriceRequest.BucketSize.
       commitment_amount:
         description: Commitment fields
         type: number
@@ -7691,8 +7818,7 @@ definitions:
       tax_rate_status:
         allOf:
         - $ref: '#/definitions/types.TaxRateStatus'
-        description: tax_rate_type determines how the tax is calculated ("percentage"
-          or "fixed")
+        description: tax_rate_status is the updated status of the tax rate
     type: object
   UpdateTenantRequest:
     properties:
@@ -8436,6 +8562,11 @@ definitions:
         type: string
       status:
         $ref: '#/definitions/types.Status'
+      tax_treatment:
+        allOf:
+        - $ref: '#/definitions/types.TaxTreatment'
+        description: TaxTreatment is the customer's tax treatment — taxable (default)
+          or exempt.
       tenant_id:
         type: string
       timezone:
@@ -8682,8 +8813,16 @@ definitions:
         allOf:
         - $ref: '#/definitions/types.WindowSize'
         description: |-
-          BucketSize is used only for MAX aggregation when windowed aggregation is needed
-          It defines the size of time windows to calculate max values within
+          BucketSize windows the aggregation: the meter aggregates within each window
+          and the window results are summed.
+
+          Deprecated: configure bucket_size on the price instead. Still read and
+          honoured — meters that carry it keep billing exactly as before, and new
+          meters may still set it — but a price-level bucket_size takes precedence
+          and is the only place new configuration should go. See
+          price.ResolveBucketSize.
+        x-speakeasy-deprecation-message: 'Deprecated: set bucket_size on the price
+          instead. Still honoured for existing meters.'
       expression:
         description: |-
           Expression is an optional CEL expression to compute per-event quantity from event.properties.
@@ -8698,7 +8837,8 @@ definitions:
       group_by:
         description: |-
           GroupBy is the property name in event.properties to group by before aggregating.
-          Currently only supported for MAX aggregation with bucket_size.
+          Requires MAX aggregation. Windowing comes from the price, so this no longer
+          implies a meter-level bucket_size.
           When set, aggregation is applied per unique value of this property within each bucket,
           then the per-group results are summed to produce the bucket total.
         type: string
@@ -8823,6 +8963,14 @@ definitions:
         description: BillingPeriodCount is the count of the billing period ex 1, 3,
           6, 12
         type: integer
+      bucket_size:
+        allOf:
+        - $ref: '#/definitions/types.WindowSize'
+        description: |-
+          BucketSize windows the meter's aggregation for this price: the meter
+          aggregates within each window and the window results are summed. Empty
+          means unbucketed. Only valid on USAGE prices whose meter aggregates MAX
+          or SUM. Resolved through ResolveBucketSize, never read directly.
       conversion_rate:
         description: ConversionRate is the conversion rate of the price unit to the
           fiat currency
@@ -10495,6 +10643,13 @@ definitions:
         description: |-
           ServicePeriodCustomFields names the Zoho custom fields that receive the
           invoice's service start and end dates.
+      submit_for_approval:
+        description: |-
+          SubmitForApproval submits the synced invoice into the merchant's Zoho Books approval
+          flow before recording payment. Zoho rejects payments on draft invoices, and merchants
+          configure a Zoho auto-approval rule for FlexPrice-sent invoices, so we submit, wait for
+          that rule to fire, then pay.
+        type: boolean
     type: object
   types.InvoiceType:
     enum:
@@ -11017,6 +11172,10 @@ definitions:
       key_prefix:
         description: Optional prefix for S3 keys (e.g., "flexprice-exports/")
         type: string
+      provider:
+        allOf:
+        - $ref: '#/definitions/types.SecretProvider'
+        description: Empty means S3 for back-compat.
       region:
         description: AWS region (e.g., "us-west-2")
         type: string
@@ -11081,6 +11240,7 @@ definitions:
     - flexprice
     - stripe
     - s3
+    - gcs
     - hubspot
     - razorpay
     - chargebee
@@ -11096,11 +11256,14 @@ definitions:
     - azure_marketplace
     type: string
     x-enum-comments:
+      SecretProviderGCS: supports multiple connections per environment, service-account
+        JSON creds
       SecretProviderS3: supports multiple connections per environment
     x-enum-varnames:
     - SecretProviderFlexPrice
     - SecretProviderStripe
     - SecretProviderS3
+    - SecretProviderGCS
     - SecretProviderHubSpot
     - SecretProviderRazorpay
     - SecretProviderChargebee
@@ -11474,6 +11637,22 @@ definitions:
     x-enum-varnames:
     - TaskTypeImport
     - TaskTypeExport
+  types.TaxBehavior:
+    enum:
+    - inclusive
+    - exclusive
+    type: string
+    x-enum-varnames:
+    - TaxBehaviorInclusive
+    - TaxBehaviorExclusive
+  types.TaxExemptionReasonCode:
+    enum:
+    - customer_exempt
+    - no_tax_configured
+    type: string
+    x-enum-varnames:
+    - TaxExemptionReasonCustomerExempt
+    - TaxExemptionReasonNoTaxConfigured
   types.TaxRateEntityType:
     enum:
     - customer
@@ -11507,11 +11686,17 @@ definitions:
   types.TaxRateType:
     enum:
     - percentage
-    - fixed
     type: string
     x-enum-varnames:
     - TaxRateTypePercentage
-    - TaxRateTypeFixed
+  types.TaxTreatment:
+    enum:
+    - taxable
+    - exempt
+    type: string
+    x-enum-varnames:
+    - TaxTreatmentTaxable
+    - TaxTreatmentExempt
   types.TimeOfDayBucket:
     properties:
       commitment_type:
@@ -12486,6 +12671,8 @@ definitions:
     type: object
   webhookDto.SubscriptionWebhookPayload:
     properties:
+      customer:
+        $ref: '#/definitions/webhookDto.Customer'
       event_type:
         $ref: '#/definitions/types.WebhookEventName'
       subscription:
@@ -12578,6 +12765,8 @@ definitions:
     properties:
       alert:
         $ref: '#/definitions/webhookDto.WalletAlertInfo'
+      customer:
+        $ref: '#/definitions/webhookDto.Customer'
       event_type:
         $ref: '#/definitions/types.WebhookEventName'
       wallet:
@@ -18425,6 +18614,43 @@ paths:
       summary: List tasks
       tags:
       - Tasks
+    post:
+      consumes:
+      - application/json
+      description: Use to submit a CSV of usage events for async ingestion. The CSV
+        must already have been uploaded to the Flexprice-managed imports bucket (currently
+        via CSV Box) — pass the upload_id and the backend fetches the file from S3
+        and streams rows into ClickHouse. Returns the task ID and Temporal workflow
+        IDs for polling.
+      operationId: createTask
+      parameters:
+      - description: Import request
+        in: body
+        name: task
+        required: true
+        schema:
+          $ref: '#/definitions/CreateTaskRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TemporalWorkflowResult'
+        "400":
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Server error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Import a CSV of usage events
+      tags:
+      - Tasks
+      x-scope: write
   /tasks/{id}:
     get:
       consumes:
@@ -19524,6 +19750,39 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Update service account
+      tags:
+      - Users
+  /users/{id}/remove:
+    post:
+      description: Remove a human user (type=user) from the current tenant. Not supported
+        for service accounts; use DELETE /users/{id} for those.
+      operationId: removeUser
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No content
+        "400":
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "404":
+          description: Not found
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+        "500":
+          description: Server error
+          schema:
+            $ref: '#/definitions/errors.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      summary: Remove user from tenant
       tags:
       - Users
   /users/{id}/roles:

--- a/internal/ee/e2eprobe/checks/seed_ensure.go
+++ b/internal/ee/e2eprobe/checks/seed_ensure.go
@@ -1183,40 +1183,39 @@ func (s *SeedEnsure) ensureMultiCadenceSubscription(
 		}
 	}
 
-	billingCycle := types.BillingCycleAnniversary
-	now := time.Now().UTC()
-	req := types.CreateSubscriptionRequest{
-		ExternalCustomerID: &extID,
-		PlanID:             planID,
-		Currency:           "usd",
-		BillingPeriod:      types.BillingPeriodQuarterly,
-		BillingPeriodCount: int64Ptr(1),
-		BillingCycle:       &billingCycle,
-		StartDate:          &now,
-		Metadata: map[string]string{
-			"e2eprobe":        "true",
-			"e2eprobe_role":   "seed",
-			"e2eprobe_cohort": multiCadenceCohort,
-		},
+	// TODO(multi-cadence): after PR #2713 the plan-price attach filter now
+	// defaults to STRICT-EQUAL cadence unless the caller passes
+	// include_price_ids. The seed plan carries only MONTHLY prices, so
+	// creating a QUARTERLY sub without that opt-in returns "no prices found
+	// for entity" (validation_error 400).
+	//
+	// The correct fix is to fetch the plan's price IDs and pass them via
+	// include_price_ids in CreateSubscriptionRequest, but the field is not in
+	// the pinned go-sdk (v2.1.26 predates the field). Regenerate the SDK and
+	// bump go.mod, then replace this block with:
+	//
+	//   pricesResp, _ := s.client.Prices().Query(ctx, types.PriceFilter{
+	//     PlanIDs: []string{planID},
+	//     Statuses: []string{"published"},
+	//   })
+	//   var priceIDs []string
+	//   for _, p := range pricesResp.ListPricesResponse.Items {
+	//     if p.ID != nil { priceIDs = append(priceIDs, *p.ID) }
+	//   }
+	//   req := types.CreateSubscriptionRequest{ ..., IncludePriceIDs: &priceIDs, ... }
+	//
+	// Until then: skip the create so this seed step does not throw a 400
+	// on every SEED_ENSURE tick. The multi-cadence probe soft-skips when
+	// MultiCadenceSubID == "" (see multi_cadence_invoice_probe.go:130),
+	// so probe coverage of the multi-cadence path is temporarily disabled
+	// but no false alarms fire.
+	if s.logger != nil {
+		s.logger.Info(ctx, "multi-cadence seed sub not created: awaiting go-sdk regen with IncludePriceIDs field",
+			"external_customer_id", extID,
+			"plan_id", planID,
+			"sdk_version", "v2.1.26",
+		)
 	}
-	createResp, err := s.client.Subscriptions().Create(ctx, req)
-	if err != nil {
-		return e2eprobe.Errorf(map[string]string{"step": "multi_cadence_create", "external_customer_id": extID, "plan_id": planID}, "create quarterly sub: %w", err)
-	}
-	if createResp.SubscriptionResponse == nil || createResp.SubscriptionResponse.ID == nil {
-		return nil
-	}
-	subID := *createResp.SubscriptionResponse.ID
-
-	if createResp.SubscriptionResponse.SubscriptionStatus != nil &&
-		*createResp.SubscriptionResponse.SubscriptionStatus == types.SubscriptionStatusDraft {
-		if err := s.activateMultiCadenceSub(ctx, subID, extID, now); err != nil {
-			// Do NOT record MultiCadenceSubID — leaves the sub for retry on next
-			// tick (query-by-cohort will find it and activate again).
-			return err
-		}
-	}
-	seeds.MultiCadenceSubID = subID
 	return nil
 }
 

--- a/internal/ee/e2eprobe/checks/seed_ensure_test.go
+++ b/internal/ee/e2eprobe/checks/seed_ensure_test.go
@@ -64,7 +64,7 @@ func TestSeedEnsure(t *testing.T) {
 			wantCustomersCreated:    1,                         // 10 pre-populated; alert canary still needs creating
 			wantPlansCreated:        0,                         // plan found via Query
 			wantPricesCreated:       len(seedFeatureSpecs) + 1, // base + one usage price per feature
-			wantSubsCreated:         12,                        // 10 persistent + 1 alert canary + 1 multi-cadence quarterly
+			wantSubsCreated:         11,                        // 10 persistent + 1 alert canary (multi-cadence quarterly currently skipped: awaits SDK regen with IncludePriceIDs)
 			wantWalletsCreated:      4,                         // 3 pre-funded + 1 alert canary
 			wantPersistentCustomers: 11,                        // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,
@@ -84,7 +84,7 @@ func TestSeedEnsure(t *testing.T) {
 			wantCustomersCreated:    11, // 10 persistent + 1 alert canary
 			wantPlansCreated:        1,
 			wantPricesCreated:       len(seedFeatureSpecs) + 1, // base + one usage price per feature
-			wantSubsCreated:         12,                        // 10 persistent + 1 alert canary + 1 multi-cadence quarterly
+			wantSubsCreated:         11,                        // 10 persistent + 1 alert canary (multi-cadence quarterly currently skipped: awaits SDK regen with IncludePriceIDs)
 			wantWalletsCreated:      4,                         // 3 pre-funded + 1 alert canary
 			wantPersistentCustomers: 11,                        // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,
@@ -118,7 +118,7 @@ func TestSeedEnsure(t *testing.T) {
 			wantCustomersCreated:    1, // alert canary still needs creating
 			wantPlansCreated:        1,
 			wantPricesCreated:       len(seedFeatureSpecs) + 1,
-			wantSubsCreated:         12, // 10 persistent + 1 alert canary + 1 multi-cadence quarterly
+			wantSubsCreated:         11, // 10 persistent + 1 alert canary (multi-cadence quarterly currently skipped: awaits SDK regen with IncludePriceIDs)
 			wantWalletsCreated:      4,  // 3 pre-funded + 1 alert canary
 			wantPersistentCustomers: 11, // 10 persistent + 1 alert canary
 			wantPreFundedCustomers:  3,


### PR DESCRIPTION
## Root cause of the Slack alerts

\`e2eprobe.check.failed\` firing on every SEED_ENSURE tick across envs:

\`\`\`json
{
  \"code\": \"validation_error\",
  \"http_status_code\": 400,
  \"message\": \"The entity must have at least one price to create a subscription\",
  \"step\": \"multi_cadence_create\"
}
\`\`\`

\`ensureMultiCadenceSubscription\` (added in PR #2699) creates a **QUARTERLY** sub against the e2eprobe plan whose 15 prices are all **MONTHLY**. Before PR #2713 that worked because \`filterValidPricesForSubscription\` accepted divisor-compatible cadences by default. After PR #2713 the default is strict-equal cadence unless the caller opts in via \`include_price_ids\` — so the DB prefetch narrows to \`{QUARTERLY, ONETIME}\` and returns zero prices for this plan → 400 on every tick.

## Why we can't wire \`include_price_ids\` right now

The pinned go-sdk (v2.1.26) predates PR #2713 — the SDK's \`CreateSubscriptionRequest\` struct doesn't have the field yet. The seed calls the SDK directly, so we can't add the field until \`make regenerate-go-sdk\` runs and go.mod is bumped.

## Fix (this PR)

- Skip the multi-cadence sub create when it doesn't already exist. Log an info line naming the SDK version to make the wait explicit.
- Existing-sub reuse path is unchanged: if a multi-cadence sub was seeded before PR #2713, the query-by-cohort branch still finds it and stores \`MultiCadenceSubID\` for the probe.
- \`multi_cadence_invoice_probe\` already soft-skips when \`MultiCadenceSubID == \"\"\` (\`multi_cadence_invoice_probe.go:130\`), so probe coverage of the fan-out path is **temporarily disabled** with **no false alarms**.

TODO comment on \`seed_ensure.go\` documents the exact 3-step follow-up: regen SDK, bump go.mod, replace the skip block with the fetch-plan-prices + \`include_price_ids\` pattern.

## Test plan
- [x] \`go test -race ./internal/ee/e2eprobe/... -count=1 -timeout 300s\` → all pass
  - Updated \`TestSeedEnsure\` expectations: \`wantSubsCreated\` 12→11 across 3 rows (multi-cadence sub no longer counted in fake-client create list).
- [x] \`go vet ./internal/...\` → clean
- [x] \`make lint-ci\` → exit 0

## Impact

- **Alerts stop firing** immediately after merge + deploy.
- **Probe coverage temporarily reduced**: multi-cadence fan-out isn't exercised in prod probing until follow-up.
- **Envs that already have the seed sub** (from before PR #2713) are unaffected — the sub is reused and the probe continues to run.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API support for asynchronous CSV usage-event imports and user removal.
  * Added tax treatment, tax behavior, exemption details, and invoice tax summaries.
  * Added configurable price-level usage bucketing and subscription price selection.
  * Added Zoho approval submission and Google Cloud Storage secret-provider support.
  * Webhook payloads now include customer details.

* **Updates**
  * Tax rates now support percentage-based rates only; fixed-value rates were removed.
  * Meter-level bucketing is deprecated in favor of price-level configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->