### PR TITLE
ci: bump SDK workflow Go to 1.25.12 to match go.mod

### DIFF
--- a/.github/workflows/generate-sdks.yml
+++ b/.github/workflows/generate-sdks.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.24.0"
+          go-version: "1.25.12"
 
       # make swagger needs Node (fix_swagger_internal_types.mjs) and Python 3 (fix_swagger_refs.sh)
       # before OpenAPI generation — not only for Speakeasy steps below.

--- a/.github/workflows/generate-wl-sdks.yml
+++ b/.github/workflows/generate-wl-sdks.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.24.0"
+          go-version: "1.25.12"
 
       - name: Set up Node.js
         uses: actions/setup-node@v7


### PR DESCRIPTION
## Problem
SDK generation workflows fail at `make swagger`:
```
go: go.mod requires go >= 1.25.12 (running go 1.24.0; GOTOOLCHAIN=local)
```
[Failed run](https://github.com/flexprice/flexprice/actions/runs/33496140388/job/99818709136)

## Cause
`go.mod` requires `go 1.25.12`, but `actions/setup-go` was pinned to `1.24.0` in both SDK workflows. With `GOTOOLCHAIN=local`, Go can't auto-upgrade the toolchain, so it errors.

## Fix
Bump `go-version` to `1.25.12` in `generate-sdks.yml` and `generate-wl-sdks.yml` to match go.mod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain used for SDK generation workflows.
  * Improved consistency and reliability of generated SDK builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->