### PR TITLE
fix(e2eprobe): opt into multi-cadence via include_price_ids

### DIFF
--- a/internal/ee/e2eprobe/checks/fakeclient_test.go
+++ b/internal/ee/e2eprobe/checks/fakeclient_test.go
@@ -184,31 +184,70 @@ func (f *fakePlans) SyncPrices(_ context.Context, planID string) (*dtos.SyncPlan
 type fakePrices struct {
 	mu      sync.Mutex
 	created []types.CreatePriceRequest
+	// ids parallels created — one fabricated fake id per create call, so
+	// Query can return items with realistic IDs. Callers looking up
+	// created[i] can pair it with ids[i].
+	ids []string
 	// bucketSizes records the price-level bucket passed alongside each created
 	// price, keyed by lookup key. Empty string means the price is unbucketed.
 	bucketSizes map[string]string
 }
 
+func (f *fakePrices) nextID() string {
+	// Callers already hold f.mu.
+	return fmt.Sprintf("price_fake_%d", len(f.created)+1)
+}
+
 func (f *fakePrices) Create(_ context.Context, req types.CreatePriceRequest) (*dtos.CreatePriceResponse, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	id := f.nextID()
 	f.created = append(f.created, req)
+	f.ids = append(f.ids, id)
 	return &dtos.CreatePriceResponse{}, nil
 }
 func (f *fakePrices) CreateBucketed(_ context.Context, req types.CreatePriceRequest, bucketSize string) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	id := f.nextID()
 	f.created = append(f.created, req)
+	f.ids = append(f.ids, id)
 	if f.bucketSizes == nil {
 		f.bucketSizes = map[string]string{}
 	}
 	if req.LookupKey != nil {
 		f.bucketSizes[*req.LookupKey] = bucketSize
 	}
-	return "price_fake", nil
+	return id, nil
 }
-func (f *fakePrices) Query(_ context.Context, _ types.PriceFilter) (*dtos.QueryPriceResponse, error) {
-	return &dtos.QueryPriceResponse{}, nil
+func (f *fakePrices) Query(_ context.Context, filter types.PriceFilter) (*dtos.QueryPriceResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// Filter by PlanIds when provided (the seed's multi-cadence lookup uses
+	// this). Callers that pass no filter get every created price back.
+	var items []types.PriceResponse
+	for i, req := range f.created {
+		if len(filter.PlanIds) > 0 {
+			if req.EntityID == "" {
+				continue
+			}
+			matched := false
+			for _, pid := range filter.PlanIds {
+				if req.EntityID == pid {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		id := f.ids[i]
+		items = append(items, types.PriceResponse{ID: &id})
+	}
+	return &dtos.QueryPriceResponse{
+		ListPricesResponse: &types.ListPricesResponse{Items: items},
+	}, nil
 }
 
 // --- Features ---

--- a/internal/ee/e2eprobe/checks/seed_ensure.go
+++ b/internal/ee/e2eprobe/checks/seed_ensure.go
@@ -1183,6 +1183,38 @@ func (s *SeedEnsure) ensureMultiCadenceSubscription(
 		}
 	}
 
+	// Fetch every published plan price so we can pass their IDs via
+	// include_price_ids. Without the opt-in, the plan-attach filter now
+	// defaults to strict-equal cadence (post-PR #2713) and a QUARTERLY sub
+	// against a MONTHLY-only plan returns "no prices found for entity".
+	published := types.StatusPublished
+	pricesResp, err := s.client.Prices().Query(ctx, types.PriceFilter{
+		PlanIds: []string{planID},
+		Status:  &published,
+	})
+	if err != nil {
+		return e2eprobe.Errorf(map[string]string{"step": "multi_cadence_prices_query", "plan_id": planID}, "list plan prices: %w", err)
+	}
+	var includePriceIDs []string
+	if pricesResp != nil && pricesResp.ListPricesResponse != nil {
+		for _, p := range pricesResp.ListPricesResponse.Items {
+			if p.ID != nil && *p.ID != "" {
+				includePriceIDs = append(includePriceIDs, *p.ID)
+			}
+		}
+	}
+	if len(includePriceIDs) == 0 {
+		// No plan prices found → an empty include_price_ids would create a sub
+		// with zero attached prices, which fails downstream. Skip and let the
+		// next tick retry after the plan's price seeding catches up.
+		if s.logger != nil {
+			s.logger.Info(ctx, "multi-cadence seed sub: skipping create — plan has no published prices yet",
+				"plan_id", planID,
+			)
+		}
+		return nil
+	}
+
 	billingCycle := types.BillingCycleAnniversary
 	now := time.Now().UTC()
 	req := types.CreateSubscriptionRequest{
@@ -1193,6 +1225,9 @@ func (s *SeedEnsure) ensureMultiCadenceSubscription(
 		BillingPeriodCount: int64Ptr(1),
 		BillingCycle:       &billingCycle,
 		StartDate:          &now,
+		// Opt into multi-cadence: attach every monthly plan price to the
+		// quarterly sub. Invoice generation fans each out per sub-window.
+		IncludePriceIds: includePriceIDs,
 		Metadata: map[string]string{
 			"e2eprobe":        "true",
 			"e2eprobe_role":   "seed",


### PR DESCRIPTION
## Summary
Wires the e2eprobe multi-cadence seed sub to use the new \`IncludePriceIds\` field in go-sdk v2.1.29. Stops the \`e2eprobe.check.failed\` alerts.

## Why the seed needed the opt-in
The framing on PR #2713 was \"strict-equal default, opt-in for multi-cadence\" — but the seed IS a multi-cadence attach:
- Sub: QUARTERLY
- Plan's 15 prices: all MONTHLY

Post-#2713 the default is period-equal match, so the plan-price prefetch narrows to \`{QUARTERLY, ONETIME}\` and returns zero rows → \`\"The entity must have at least one price to create a subscription\"\` 400.

The seed was quietly relying on the old permissive default. It needs the opt-in same as any other multi-cadence caller.

## Fix
In \`ensureMultiCadenceSubscription\`:
1. Query the plan for every published price via \`s.client.Prices().Query\` with \`PlanIds\` filter.
2. Collect the IDs and pass them via \`CreateSubscriptionRequest.IncludePriceIds\` — the SDK v2.1.29 field that authorises multi-cadence attach.
3. If the plan has zero published prices yet (fresh env / race with plan-seeding), skip + log and let the next tick retry.

## Test fake update
\`fakePrices\` now assigns a fabricated ID on each \`Create\`/\`CreateBucketed\` and \`Query\` filters created prices by \`PlanIds\`. Without this the seed's new fetch step would find zero prices in tests too and skip the create every run.

## Test plan
- [x] \`go test -race ./internal/... -timeout 600s\` → exit 0
- [x] \`go vet ./internal/...\` → clean
- [x] \`make lint-ci\` → exit 0
- [ ] After deploy: SEED_ENSURE tick creates the multi-cadence sub without a 400; \`multi-cadence-invoice-probe\` starts asserting per-month fan-out on the resulting invoices.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subscription setup for plans with multiple billing cadences.
  - Prevented seed subscriptions from being created before published prices are available.
  - Added more reliable handling of price identifiers during subscription creation.
  - Enhanced price lookup and filtering to support selected plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->