### PR TITLE
fix(customer-portal): drop the usage graph from the default Overview

### DIFF
--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -655,18 +655,13 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 			},
 			{
 				ID: "overview", Label: "Overview", Enabled: true, Order: 4,
+				// No usage_graph here. Overview summarises the account; the usage
+				// section owns the trend chart, and duplicating it also gave overview
+				// a date filter, since the portal shows one for any section holding an
+				// analytics widget.
 				Tabs: []CustomerPortalTab{
 					{ID: "9", Type: "wallet_balance", Order: 1, Enabled: true},
 					{ID: "10", Type: "subscriptions", Order: 2, Enabled: true},
-					{
-						ID: "11", Type: "usage_graph", Order: 3, Enabled: true,
-						UsageGraph: &CustomerPortalUsageGraph{
-							DatePresets:          []string{"last_7_days", "last_30_days"},
-							DefaultPreset:        "last_7_days",
-							FeatureFilterMode:    "all",
-							AllowCustomDateRange: true,
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
## Problem

The customer portal's Overview tab rendered a usage trend chart *and* a date-range filter. Both come from one line in the default portal config: the `overview` section carried a `usage_graph` tab.

The chart is the Usage section's job — Overview was showing a second copy. The date filter came along with it, because the frontend renders a section-level filter for any section holding an analytics widget ([SectionContent.tsx:153](https://github.com/flexprice/flexprice-front/blob/develop/src/components/customer-portal/SectionContent.tsx#L153): `hasAnalytics = enabledTabs.some(t => t.type === 'usage_graph' || t.type === 'metric_cards')`). Removing the tab removes both.

## Change

`GetDefaultSettings()` — the `overview` section is now `wallet_balance` + `subscriptions`, with the `usage_graph` tab and its `UsageGraph` date-preset config removed.

## Scope

Defaults are resolved at read time (`getDefaultValue` in `internal/ee/service/settings.go` returns them when no row exists), so this applies immediately to every tenant that has **not** saved its own portal config.

A tenant that *has* saved one keeps what it stored — that is what storing it means. If the intent is to strip the graph from tenants who already persisted a config, that is a data change, not this one.

The frontend's own `DEFAULT_PORTAL_CONFIG` already excluded `usage_graph` from Overview, so this brings the backend default in line with it. No frontend change is needed.

## Verification

- `go build ./internal/...` — clean
- `gofmt -l` — clean
- `go test ./internal/types/... ./internal/ee/service/...` — passing

(Two pre-existing build failures outside `internal/` — the root package having no `main`, and `api/custom/go` being a merge-target tree — are present on a clean checkout of `main` and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)