### PR TITLE
fix(billing): reconcile fan-out orphans + skip invalid periods + recalc exclude

### DIFF
--- a/internal/ee/service/billing_entitlement_quantity_test.go
+++ b/internal/ee/service/billing_entitlement_quantity_test.go
@@ -517,6 +517,8 @@ func (s *EntitlementQuantityTestSuite) TestRecalculateV2_WithSubLineItemIDs_Over
 				AdjustedEntitlementQuantity: nil,                          // stale — must be set
 				Currency:                    "usd",
 				EnvironmentID:               types.GetEnvironmentID(ctx),
+				PeriodStart:                 &periodStart,
+				PeriodEnd:                   &periodEnd,
 				SubscriptionLineItemID:      lo.ToPtr(s.testData.usageSubLineItem.ID), // triggers update-in-place
 				BaseModel:                   types.GetDefaultBaseModel(ctx),
 			},
@@ -592,7 +594,9 @@ func (s *EntitlementQuantityTestSuite) TestRecalculateV2_Mixed_UpdatesMatchedIte
 		BaseModel:       types.GetDefaultBaseModel(ctx),
 		LineItems: []*invoicedomain.InvoiceLineItem{
 			{
-				// Item A — has a matching SubLineItemID → update-in-place
+				// Item A — has a matching SubLineItemID → update-in-place.
+				// Period must be set for reconcile's compound key
+				// (subLineItemID, periodStart, periodEnd) to match the fresh calculation.
 				ID:                          matchedRowID,
 				CustomerID:                  s.testData.customer.ID,
 				MeterID:                     lo.ToPtr(s.testData.meter.ID),
@@ -603,13 +607,15 @@ func (s *EntitlementQuantityTestSuite) TestRecalculateV2_Mixed_UpdatesMatchedIte
 				AdjustedEntitlementQuantity: nil, // stale
 				Currency:                    "usd",
 				EnvironmentID:               types.GetEnvironmentID(ctx),
+				PeriodStart:                 &periodStart,
+				PeriodEnd:                   &periodEnd,
 				SubscriptionLineItemID:      lo.ToPtr(s.testData.usageSubLineItem.ID),
 				BaseModel:                   types.GetDefaultBaseModel(ctx),
 			},
 			{
 				// Item B — nil SubLineItemID; since item A has one, the fallback is not triggered.
-				// This item is not in the existingBySubLineItemID index and so is neither matched
-				// nor explicitly archived by the reconciler.
+				// This item is not registered in the reconcile map (missing both SubLineItemID
+				// and periods) and so is neither matched nor explicitly archived by the reconciler.
 				ID:                     unmatchedRowID,
 				CustomerID:             s.testData.customer.ID,
 				DisplayName:            lo.ToPtr("PHANTOM - nil sub_line_item_id"),

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -305,6 +305,21 @@ func (s *billingService) CalculateMeterUsageCharges(
 				}
 			}
 
+			// Clip the invoice period against the line item's own active range.
+			psStart := item.GetPeriodStart(periodStart)
+			psEnd := item.GetPeriodEnd(periodEnd)
+			if !psEnd.After(psStart) {
+				s.Logger.Debug(ctx, "skipping meter-usage line item: item inactive during invoice window",
+					"subscription_id", sub.ID,
+					"line_item_id", item.ID,
+					"price_id", item.PriceID,
+					"invoice_period_start", periodStart,
+					"invoice_period_end", periodEnd,
+					"item_start_date", item.StartDate,
+					"item_end_date", item.EndDate,
+				)
+				continue
+			}
 			usageCharges = append(usageCharges, dto.CreateInvoiceLineItemRequest{
 				EntityID:                    lo.ToPtr(item.EntityID),
 				EntityType:                  lo.ToPtr(string(item.EntityType)),
@@ -319,8 +334,8 @@ func (s *billingService) CalculateMeterUsageCharges(
 				Amount:                      lineItemAmount,
 				Quantity:                    quantityForCalculation,
 				AdjustedEntitlementQuantity: entitlementAdjustedQty,
-				PeriodStart:                 lo.ToPtr(item.GetPeriodStart(periodStart)),
-				PeriodEnd:                   lo.ToPtr(item.GetPeriodEnd(periodEnd)),
+				PeriodStart:                 lo.ToPtr(psStart),
+				PeriodEnd:                   lo.ToPtr(psEnd),
 				SubscriptionLineItemID:      lo.ToPtr(item.ID),
 				Metadata:                    metadata,
 				CommitmentInfo:              commitmentInfo,
@@ -682,6 +697,21 @@ func (s *billingService) buildCumulativeCommitmentCharges(
 	totalCost := decimal.Zero
 
 	for _, bc := range baseCharges {
+		// Skip items that weren't active during the invoice window
+		psStart := bc.item.GetPeriodStart(periodStart)
+		psEnd := bc.item.GetPeriodEnd(periodEnd)
+		if !psEnd.After(psStart) {
+			s.Logger.Debug(context.Background(), "skipping cumulative-commitment line item: item inactive during invoice window",
+				"subscription_id", sub.ID,
+				"line_item_id", bc.item.ID,
+				"price_id", bc.item.PriceID,
+				"invoice_period_start", periodStart,
+				"invoice_period_end", periodEnd,
+				"item_start_date", bc.item.StartDate,
+				"item_end_date", bc.item.EndDate,
+			)
+			continue
+		}
 		var allocatedAmount decimal.Decimal
 		if totalCurrentBase.GreaterThan(decimal.Zero) {
 			allocatedAmount = bc.baseAmount.Div(totalCurrentBase).Mul(result.WithinCommitment)
@@ -706,8 +736,8 @@ func (s *billingService) buildCumulativeCommitmentCharges(
 			Amount:                      rounded,
 			Quantity:                    displayQty,
 			AdjustedEntitlementQuantity: bc.adjustedEntitlementQuantity,
-			PeriodStart:                 lo.ToPtr(bc.item.GetPeriodStart(periodStart)),
-			PeriodEnd:                   lo.ToPtr(bc.item.GetPeriodEnd(periodEnd)),
+			PeriodStart:                 lo.ToPtr(psStart),
+			PeriodEnd:                   lo.ToPtr(psEnd),
 			SubscriptionLineItemID:      lo.ToPtr(bc.item.ID),
 			Metadata:                    bc.metadata,
 		})

--- a/internal/ee/service/billing_test.go
+++ b/internal/ee/service/billing_test.go
@@ -3127,8 +3127,18 @@ func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_CumulativeCommitmen
 	sub.CurrentPeriodEnd = time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
 	sub.BillingAnchor = sub.CurrentPeriodEnd
 
-	apiCallsLineItem := sub.LineItems[1]                                                     // Usage line item
-	sub.LineItems = []*subscription.SubscriptionLineItem{sub.LineItems[0], apiCallsLineItem} // Fixed + API Calls (default)
+	// Realign the copied line items' StartDate to the overridden sub.StartDate.
+	// setupTestData built them with StartDate = now - 30d, which is AFTER the
+	// 2025 periods we've mocked here — that would cause the meter-usage
+	// emit path to skip the items entirely (item inactive during the invoice
+	// window). Copy each item, then repoint StartDate, so we don't mutate
+	// shared testData.
+	fixedCopy := *sub.LineItems[0]
+	fixedCopy.StartDate = sub.StartDate
+	usageCopy := *sub.LineItems[1]
+	usageCopy.StartDate = sub.StartDate
+	sub.LineItems = []*subscription.SubscriptionLineItem{&fixedCopy, &usageCopy} // Fixed + API Calls (default)
+	apiCallsLineItem := &usageCopy
 
 	// Second usage line item for multi-line-item test
 	featureBLineItem := &subscription.SubscriptionLineItem{

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -3383,12 +3383,42 @@ func (s *invoiceService) reconcileLineItems(
 		return newItems, nil
 	}
 
-	// Update-in-place path
-	existingBySubLineItemID := make(map[string]*invoice.InvoiceLineItem, len(existing))
-	for _, item := range existing {
-		if item.SubscriptionLineItemID != nil {
-			existingBySubLineItemID[lo.FromPtr(item.SubscriptionLineItemID)] = item
+	// Update-in-place path.
+	//
+	// Multi-cadence fan-out (added by PR #2699) means one subscription line item
+	// can produce N invoice line items in a single compute — one per sub-window
+	// (e.g., a monthly price on a quarterly sub emits 3 monthly invoice lines,
+	// each with a distinct [PeriodStart, PeriodEnd)). Keying reconcile by
+	// SubscriptionLineItemID alone would collapse those N into 1 map entry
+	// (last-write-wins), so re-runs would silently orphan the N-1 that never
+	// got a chance to match — every recompute would then append fresh copies,
+	// producing duplicate persisted lines. Key by (sub-line-item, window) to
+	// give each fanned-out line item its own reconcile identity.
+	type reconcileKey struct {
+		SubLineItemID string
+		PeriodStart   time.Time
+		PeriodEnd     time.Time
+	}
+	keyOf := func(subLineItemID *string, periodStart, periodEnd *time.Time) (reconcileKey, bool) {
+		if subLineItemID == nil || periodStart == nil || periodEnd == nil {
+			return reconcileKey{}, false
 		}
+		return reconcileKey{
+			SubLineItemID: *subLineItemID,
+			PeriodStart:   *periodStart,
+			PeriodEnd:     *periodEnd,
+		}, true
+	}
+
+	// Items missing PeriodStart/PeriodEnd (legacy pre-migration or hand-crafted) are silently ignored here
+	// same contract as the pre-fan-out reconciler, which ignored items missing SubscriptionLineItemID. They stay in the DB untouched.
+	existingByKey := make(map[reconcileKey]*invoice.InvoiceLineItem, len(existing))
+	for _, item := range existing {
+		k, ok := keyOf(item.SubscriptionLineItemID, item.PeriodStart, item.PeriodEnd)
+		if !ok {
+			continue
+		}
+		existingByKey[k] = item
 	}
 
 	var toInsert []*invoice.InvoiceLineItem
@@ -3400,7 +3430,12 @@ func (s *invoiceService) reconcileLineItems(
 			toInsert = append(toInsert, newItem)
 			continue
 		}
-		if old, ok := existingBySubLineItemID[lo.FromPtr(newItem.SubscriptionLineItemID)]; ok {
+		k, ok := keyOf(newItem.SubscriptionLineItemID, newItem.PeriodStart, newItem.PeriodEnd)
+		if !ok {
+			toInsert = append(toInsert, newItem)
+			continue
+		}
+		if old, exists := existingByKey[k]; exists {
 			// Replace the entire computed payload, then restore immutable identity/audit fields.
 			// This ensures every field produced by ToInvoiceLineItem is refreshed (PriceID,
 			// MeterID, PriceType, PeriodStart/End, display names, etc.) without requiring
@@ -3415,15 +3450,16 @@ func (s *invoiceService) reconcileLineItems(
 			newItem.LineItemDiscount = decimal.Zero
 			newItem.InvoiceLevelDiscount = decimal.Zero
 			toUpdate = append(toUpdate, newItem)
-			delete(existingBySubLineItemID, lo.FromPtr(newItem.SubscriptionLineItemID))
+			delete(existingByKey, k)
 		} else {
 			toInsert = append(toInsert, newItem)
 		}
 	}
 
-	// Archive old items that no longer appear in the new calculation
+	// Archive old items that no longer appear in the new calculation.
+	// An existing invoice line item whose (sub-line-item, start, end) is not re-emitted by the fresh calculation gets archived.
 	var toArchiveIDs []string
-	for _, item := range existingBySubLineItemID {
+	for _, item := range existingByKey {
 		toArchiveIDs = append(toArchiveIDs, item.ID)
 	}
 	if len(toArchiveIDs) > 0 {
@@ -3511,6 +3547,12 @@ func (s *invoiceService) RecalculateInvoiceV2(ctx context.Context, id string, fi
 			PeriodStart:    *inv.PeriodStart,
 			PeriodEnd:      *inv.PeriodEnd,
 			ReferencePoint: referencePoint,
+			// Exclude THIS invoice from FilterLineItemsToBeInvoiced's already-invoiced check
+			// otherwise the draft's own line items (which sit in [periodStart, periodEnd)) get filtered out of
+			// the fresh compute and the recalc returns $0. Was silently masked pre-fan-out because tests exercised draft rows with
+			// nil PeriodStart/PeriodEnd, which the filter couldn't match on; once reconcile started requiring PeriodStart/PeriodEnd to
+			// key its update-in-place map, the missing exclusion surfaced.
+			ExcludeInvoiceID: inv.ID,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Summary

Three related fixes for the duplicated + out-of-period line items observed on real invoice \`inv_01M1ETYEXHA5943KQDJGZZN3CJ\` (10+ zero-quantity line items accumulated across three recomputes, plus line items whose period spanned \`Sep 1 → May 1\` — end before start — on a backdated invoice).

## Bug 1 — fan-out orphans in \`reconcileLineItems\` (invoice.go)
Key the update-in-place map by \`(SubscriptionLineItemID, PeriodStart, PeriodEnd)\` instead of \`SubscriptionLineItemID\` alone.

Multi-cadence fan-out (PR #2699) emits N invoice lines per sub-line-item — one per sub-window. Keying by \`SubscriptionLineItemID\` alone collapsed N to 1 map entry (last-write-wins), so recomputes matched only the first and inserted the rest as brand-new. The N-1 previous rows never got archived. Every recompute added another (N-1) orphans. Real-world observed rate: recomputed 3 times → 10+ duplicate zero-quantity lines.

Existing items missing \`PeriodStart/PeriodEnd\` are silently ignored by the map — preserves the pre-fan-out contract that \`TestRecalculateV2_Mixed_UpdatesMatchedItemPreservesID\`'s Item B verifies (unregistered items are neither matched nor archived).

## Bug 2 — invalid-period USAGE emit (billing_meter_usage.go)
Guard both emit sites: skip when the item was not active during the invoice window.

Previously \`item.GetPeriodStart(periodStart)\` returned \`max(item.StartDate, periodStart)\` and \`item.GetPeriodEnd(periodEnd)\` returned \`min(item.EndDate, periodEnd)\`. Backdated invoice (line item created AFTER the invoice period) → start > end → nonsense line item emitted with \`period_end < period_start\`. Now skips with a debug log.

## Bug 3 — RecalculateV2 filters out its own draft (invoice.go:3552)
Pass \`ExcludeInvoiceID: inv.ID\` to \`PrepareSubscriptionInvoiceRequest\`. Without it, \`FilterLineItemsToBeInvoiced\` sees the draft's own line items as \"already invoiced\" and drops them from the fresh compute → recalc returns \$0.

Silently masked pre-fan-out because test drafts had line items with nil \`PeriodStart/PeriodEnd\` (the filter couldn't match). Once reconcile's compound key required those fields, both the test setup and the RecalculateV2 caller needed alignment; this is the caller side.

## Test updates
- \`TestCalculateMeterUsageCharges_CumulativeCommitment\`: realign copied line-items' \`StartDate\` to the overridden \`sub.StartDate\`. Previous setup left \`item.StartDate\` at \`(now - 30d)\` — AFTER the mocked 2025 periods — which was invalid data the pre-guard code silently priced anyway.
- \`TestRecalculateV2_WithSubLineItemIDs_OverwritesFullPayload\` + \`TestRecalculateV2_Mixed_UpdatesMatchedItemPreservesID\`: add \`PeriodStart/PeriodEnd\` to Item A so reconcile's compound-key update-in-place path actually matches. Real DB rows always carry these; explicit here to exercise the full path end-to-end.

## Test plan
- [x] \`go test -race ./internal/... -timeout 600s\` → exit 0
- [x] \`go vet ./internal/...\` → clean
- [x] \`make lint-ci\` → exit 0
- [ ] User will verify by recomputing testing draft invoices

## Cleanup
No affected drafts on production; skipping any data cleanup script.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>