### PR TITLE
fix(subscription): reject backdated sub-create when start_date < price.start_date

### DIFF
--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -544,11 +544,10 @@ func (r *CreateSubscriptionLineItemRequest) ToSubscriptionLineItem(ctx context.C
 		}
 	}
 
-	// Effective start = latest of subscription start, price start, and request start_date (when provided).
+	// Effective start = latest of subscription start and request start_date.
+	// Catalog price start is validated separately against this date; bumping
+	// here would hide a price that is not yet effective at coverage start.
 	startDate := params.Subscription.StartDate
-	if params.Price != nil && params.Price.StartDate != nil && params.Price.StartDate.After(startDate) {
-		startDate = lo.FromPtr(params.Price.StartDate)
-	}
 	if r.StartDate != nil && r.StartDate.After(startDate) {
 		startDate = lo.FromPtr(r.StartDate)
 	}

--- a/internal/api/dto/subscription_line_item_test.go
+++ b/internal/api/dto/subscription_line_item_test.go
@@ -287,6 +287,39 @@ func TestCreateSubscriptionLineItemRequest_ToSubscriptionLineItem_QuantityDefaul
 	}
 }
 
+func TestToSubscriptionLineItem_StartDateIgnoresPriceStart(t *testing.T) {
+	ctx := context.Background()
+	subStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	priceStart := time.Date(2026, 8, 31, 0, 0, 0, 0, time.UTC)
+	reqStart := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	params := LineItemParams{
+		Subscription: &SubscriptionResponse{
+			Subscription: &subscription.Subscription{
+				ID:         "sub_test",
+				CustomerID: "cust_test",
+				Currency:   "usd",
+				StartDate:  subStart,
+			},
+		},
+		Price: &PriceResponse{
+			Price: &price.Price{
+				Type:           types.PRICE_TYPE_FIXED,
+				BillingPeriod:  types.BILLING_PERIOD_MONTHLY,
+				InvoiceCadence: types.InvoiceCadenceAdvance,
+				StartDate:      &priceStart,
+			},
+		},
+		EntityType: types.SubscriptionLineItemEntityTypeSubscription,
+	}
+
+	item := (&CreateSubscriptionLineItemRequest{PriceID: "p1"}).ToSubscriptionLineItem(ctx, params)
+	assert.True(t, item.StartDate.Equal(subStart), "catalog price start must not bump the line item; got %s", item.StartDate)
+
+	item = (&CreateSubscriptionLineItemRequest{PriceID: "p1", StartDate: &reqStart}).ToSubscriptionLineItem(ctx, params)
+	assert.True(t, item.StartDate.Equal(reqStart), "request start should win over sub start; got %s", item.StartDate)
+}
+
 func TestValidateCommitmentFieldsCommon_OverageFactor(t *testing.T) {
 	amount := decimal.NewFromInt(100)
 

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -4121,11 +4121,77 @@ func (s *subscriptionService) ValidateAndFilterPricesForSubscription(
 				}).
 				Mark(ierr.ErrValidation)
 		}
+		if err := validatePriceStartDateNotAfterSub(entityID, entityType, subscription, validPrices); err != nil {
+			return nil, err
+		}
 		return validPrices, nil
 	}
 
 	// For workflows that allow empty prices, filter and return (even if empty)
-	return filter(pricesResponse.Items), nil
+	validPrices := filter(pricesResponse.Items)
+	if err := validatePriceStartDateNotAfterSub(entityID, entityType, subscription, validPrices); err != nil {
+		return nil, err
+	}
+	return validPrices, nil
+}
+
+// validatePriceStartDateNotAfterSub rejects sub creation / addon attach when
+// any attached price's StartDate is AFTER the subscription's StartDate.
+//
+// Snapshot behavior: subscription_line_item.start_date is copied from the
+// price's start_date at attach time, and stays fixed for the life of the sub.
+// If a caller backdates a sub before some price's StartDate, every fan-out
+// window BEFORE that price's start gets clipped to (StartDate, PeriodEnd)
+// which produces PeriodEnd < PeriodStart -> the invoice-time guard added in
+// PR #2729 silently skips those windows -> the sub silently loses coverage
+// for those months. Symptom: cancel/preview invoices show a single ~1-day
+// line item instead of the expected N-month fan-out.
+//
+// Reject at create time so the misconfiguration is visible immediately.
+// The caller can either move the sub's StartDate forward, or move the
+// price's StartDate back, before creating the sub.
+func validatePriceStartDateNotAfterSub(
+	entityID string,
+	entityType types.PriceEntityType,
+	subscription *subscription.Subscription,
+	validPrices []*dto.PriceResponse,
+) error {
+	if subscription == nil || subscription.StartDate.IsZero() {
+		return nil
+	}
+	var offenders []map[string]interface{}
+	for _, p := range validPrices {
+		if p.Price.StartDate == nil {
+			continue
+		}
+		if p.Price.StartDate.After(subscription.StartDate) {
+			offenders = append(offenders, map[string]interface{}{
+				"price_id":         p.Price.ID,
+				"price_start_date": p.Price.StartDate.UTC().Format(time.RFC3339),
+				"display_name":     p.Price.DisplayName,
+				"lookup_key":       p.Price.LookupKey,
+			})
+		}
+	}
+	if len(offenders) == 0 {
+		return nil
+	}
+	offenderIDs := make([]string, 0, len(offenders))
+	for _, o := range offenders {
+		if id, ok := o["price_id"].(string); ok {
+			offenderIDs = append(offenderIDs, id)
+		}
+	}
+	return ierr.NewErrorf("prices have start_date after subscription start_date %s: %v",
+		subscription.StartDate.UTC().Format(time.RFC3339), offenderIDs).
+		WithHint("A subscription cannot be backdated before any of its attached prices' start_date, otherwise those price line items will silently lose coverage. Move the subscription's start_date forward, or update the price's start_date to be on or before the subscription's start_date.").
+		WithReportableDetails(map[string]interface{}{
+			"entity_id":               entityID,
+			"entity_type":             entityType,
+			"subscription_start_date": subscription.StartDate.UTC().Format(time.RFC3339),
+			"offending_prices":        offenders,
+		}).
+		Mark(ierr.ErrValidation)
 }
 
 // validateIncludePriceIDs verifies every id in the caller-supplied include list

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -235,13 +235,17 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 		} else if sub.EndDate != nil {
 			item.EndDate = *sub.EndDate
 		}
-		// Determine start date: max of first phase start, subscription start, and price start
+		// Coverage start is max(sub, first phase) — not the catalog price start.
+		// A later price start is a misconfiguration and is rejected below.
 		startDate := sub.StartDate
 		if len(req.Phases) > 0 && req.Phases[0].StartDate.After(startDate) {
 			startDate = req.Phases[0].StartDate
 		}
+		item.StartDate = startDate
+		if err := validatePriceStartNotAfterLineItem(priceResponse.Price, item.StartDate); err != nil {
+			return nil, err
+		}
 
-		// Apply commitment configuration if provided for this price
 		cfg, err := s.applyLineItemCommitmentFromMap(ctx, sub, item, req.LineItemCommitments)
 		if err != nil {
 			return nil, err
@@ -250,10 +254,6 @@ func (s *subscriptionService) createSubscription(ctx context.Context, req dto.Cr
 			lineItemBucketCfgs[item.ID] = cfg
 		}
 
-		if priceResponse.Price.StartDate != nil && priceResponse.Price.StartDate.After(startDate) {
-			startDate = lo.FromPtr(priceResponse.Price.StartDate)
-		}
-		item.StartDate = startDate
 		lineItems = append(lineItems, item)
 	}
 
@@ -1075,16 +1075,14 @@ func (s *subscriptionService) handleSubscriptionPhases(
 		// Get corresponding phase request for additional data
 		phaseReq := phaseRequests[i]
 
-		// Validate all line item requests before creating them
 		for _, priceResp := range validPrices {
-			startDate := phaseReq.StartDate
-			if priceResp.Price.StartDate != nil && priceResp.Price.StartDate.After(phaseReq.StartDate) {
-				startDate = lo.FromPtr(priceResp.Price.StartDate)
+			if err := validatePriceStartNotAfterLineItem(priceResp.Price, phaseReq.StartDate); err != nil {
+				return err
 			}
 			req := dto.CreateSubscriptionLineItemRequest{
 				PriceID:             priceResp.Price.ID,
 				SubscriptionPhaseID: lo.ToPtr(phase.ID),
-				StartDate:           lo.ToPtr(startDate),
+				StartDate:           lo.ToPtr(phaseReq.StartDate),
 				EndDate:             phaseReq.EndDate,
 			}
 			if err := req.Validate(priceResp.Price, sub); err != nil {
@@ -1092,31 +1090,20 @@ func (s *subscriptionService) handleSubscriptionPhases(
 			}
 		}
 
-		// Create line items from plan prices - reusing DTO's ToSubscriptionLineItem logic (same as AddSubscriptionLineItem)
 		phaseLineItems := lo.Map(validPrices, func(priceResp *dto.PriceResponse, _ int) *subscription.SubscriptionLineItem {
-			// Build line item params
 			params := dto.LineItemParams{
 				Subscription: &dto.SubscriptionResponse{Subscription: sub},
 				Price:        priceResp,
 				Plan:         planResponse,
 				EntityType:   types.SubscriptionLineItemEntityTypePlan,
 			}
-
-			// Create request with phase dates
-			startDate := phaseReq.StartDate
-			if priceResp.Price.StartDate != nil && priceResp.Price.StartDate.After(phaseReq.StartDate) {
-				startDate = lo.FromPtr(priceResp.Price.StartDate)
-			}
-
 			req := dto.CreateSubscriptionLineItemRequest{
 				PriceID:             priceResp.Price.ID,
 				SubscriptionPhaseID: lo.ToPtr(phase.ID),
-				StartDate:           lo.ToPtr(startDate),
+				StartDate:           lo.ToPtr(phaseReq.StartDate),
 				EndDate:             phaseReq.EndDate,
 			}
-
-			lineItem := req.ToSubscriptionLineItem(ctx, params)
-			return lineItem
+			return req.ToSubscriptionLineItem(ctx, params)
 		})
 
 		// Create original price to line item mapping before processing overrides
@@ -1374,6 +1361,13 @@ func (s *subscriptionService) ProcessSubscriptionPriceOverrides(
 			PriceUnitType:        originalPrice.PriceUnitType,    // Always copy from original (cannot be changed)
 			SkipEntityValidation: true,
 		}
+		// CreatePriceRequest.ToPrice defaults a nil StartDate to now, which would
+		// put the override price after a backdated line item. Stamp the line
+		// item's start so the override covers the same window.
+		if !lineItem.StartDate.IsZero() {
+			start := lineItem.StartDate.UTC()
+			createPriceReq.StartDate = &start
+		}
 
 		// Handle PriceUnitConfig construction for CUSTOM price unit type
 		var priceUnitConfig *dto.PriceUnitConfig
@@ -1458,6 +1452,9 @@ func (s *subscriptionService) ProcessSubscriptionPriceOverrides(
 		// Create the subscription-scoped price using price service
 		overriddenPriceResp, err := priceService.CreatePrice(ctx, createPriceReq)
 		if err != nil {
+			return err
+		}
+		if err := validatePriceStartNotAfterLineItem(overriddenPriceResp.Price, lineItem.StartDate); err != nil {
 			return err
 		}
 
@@ -4121,75 +4118,33 @@ func (s *subscriptionService) ValidateAndFilterPricesForSubscription(
 				}).
 				Mark(ierr.ErrValidation)
 		}
-		if err := validatePriceStartDateNotAfterSub(entityID, entityType, subscription, validPrices); err != nil {
-			return nil, err
-		}
 		return validPrices, nil
 	}
 
 	// For workflows that allow empty prices, filter and return (even if empty)
-	validPrices := filter(pricesResponse.Items)
-	if err := validatePriceStartDateNotAfterSub(entityID, entityType, subscription, validPrices); err != nil {
-		return nil, err
-	}
-	return validPrices, nil
+	return filter(pricesResponse.Items), nil
 }
 
-// validatePriceStartDateNotAfterSub rejects sub creation / addon attach when
-// any attached price's StartDate is AFTER the subscription's StartDate.
-//
-// Snapshot behavior: subscription_line_item.start_date is copied from the
-// price's start_date at attach time, and stays fixed for the life of the sub.
-// If a caller backdates a sub before some price's StartDate, every fan-out
-// window BEFORE that price's start gets clipped to (StartDate, PeriodEnd)
-// which produces PeriodEnd < PeriodStart -> the invoice-time guard added in
-// PR #2729 silently skips those windows -> the sub silently loses coverage
-// for those months. Symptom: cancel/preview invoices show a single ~1-day
-// line item instead of the expected N-month fan-out.
-//
-// Reject at create time so the misconfiguration is visible immediately.
-// The caller can either move the sub's StartDate forward, or move the
-// price's StartDate back, before creating the sub.
-func validatePriceStartDateNotAfterSub(
-	entityID string,
-	entityType types.PriceEntityType,
-	subscription *subscription.Subscription,
-	validPrices []*dto.PriceResponse,
-) error {
-	if subscription == nil || subscription.StartDate.IsZero() {
+// validatePriceStartNotAfterLineItem rejects a line item whose backing price
+// becomes effective after the line item itself. Coverage start is the line
+// item's start (plan/addon/custom/phase/plan-change), not subscription.StartDate
+// — comparing to the sub falsely rejects mid-life attaches onto versioned prices.
+func validatePriceStartNotAfterLineItem(p *price.Price, lineItemStart time.Time) error {
+	if p == nil || p.StartDate == nil || lineItemStart.IsZero() {
 		return nil
 	}
-	var offenders []map[string]interface{}
-	for _, p := range validPrices {
-		if p.Price.StartDate == nil {
-			continue
-		}
-		if p.Price.StartDate.After(subscription.StartDate) {
-			offenders = append(offenders, map[string]interface{}{
-				"price_id":         p.Price.ID,
-				"price_start_date": p.Price.StartDate.UTC().Format(time.RFC3339),
-				"display_name":     p.Price.DisplayName,
-				"lookup_key":       p.Price.LookupKey,
-			})
-		}
-	}
-	if len(offenders) == 0 {
+	if !p.StartDate.After(lineItemStart) {
 		return nil
 	}
-	offenderIDs := make([]string, 0, len(offenders))
-	for _, o := range offenders {
-		if id, ok := o["price_id"].(string); ok {
-			offenderIDs = append(offenderIDs, id)
-		}
-	}
-	return ierr.NewErrorf("prices have start_date after subscription start_date %s: %v",
-		subscription.StartDate.UTC().Format(time.RFC3339), offenderIDs).
-		WithHint("A subscription cannot be backdated before any of its attached prices' start_date, otherwise those price line items will silently lose coverage. Move the subscription's start_date forward, or update the price's start_date to be on or before the subscription's start_date.").
+	return ierr.NewErrorf("price %s has start_date after line item start_date %s",
+		p.ID, lineItemStart.UTC().Format(time.RFC3339)).
+		WithHint("A line item cannot start before its price's start_date, otherwise billing windows before the price is effective are silently dropped. Move the line item start forward, or update the price start_date to be on or before the line item start.").
 		WithReportableDetails(map[string]interface{}{
-			"entity_id":               entityID,
-			"entity_type":             entityType,
-			"subscription_start_date": subscription.StartDate.UTC().Format(time.RFC3339),
-			"offending_prices":        offenders,
+			"price_id":         p.ID,
+			"price_start_date": p.StartDate.UTC().Format(time.RFC3339),
+			"line_item_start":  lineItemStart.UTC().Format(time.RFC3339),
+			"display_name":     p.DisplayName,
+			"lookup_key":       p.LookupKey,
 		}).
 		Mark(ierr.ErrValidation)
 }
@@ -5250,9 +5205,8 @@ func (s *subscriptionService) createAddonAttachParams(
 		return nil, err
 	}
 
-	// createLineItemFromPrice clamps every line item's start to
-	// max(requestedStart, sub.StartDate, price.StartDate), so anchoring the proration at
-	// requestedStart alone would price a window the addon is not live for.
+	// createLineItemFromPrice clamps each line item to max(requestedStart, sub.StartDate).
+	// Catalog prices that start later than that coverage are rejected before this point.
 	prorationEffectiveDate := lo.Reduce(lineItems, func(acc time.Time, li *subscription.SubscriptionLineItem, _ int) time.Time {
 		return lo.Ternary(li.StartDate.After(acc), li.StartDate, acc)
 	}, addonRequestedStart)
@@ -5733,6 +5687,9 @@ func (s *subscriptionService) buildAddonLineItems(
 
 	for _, priceResponse := range validPrices {
 		lineItem := s.createLineItemFromPrice(ctx, priceResponse, sub, req.AddonID, associationID, requestedStart)
+		if err := validatePriceStartNotAfterLineItem(priceResponse.Price, lineItem.StartDate); err != nil {
+			return nil, nil, err
+		}
 
 		// Onetime: end at the period boundary containing the start date.
 		// Recurring: no end date (renews each period).
@@ -5764,9 +5721,6 @@ func (s *subscriptionService) createLineItemFromPrice(ctx context.Context, price
 	lineItemStart := addonRequestedStart
 	if sub.StartDate.After(lineItemStart) {
 		lineItemStart = sub.StartDate
-	}
-	if price.StartDate != nil && price.StartDate.After(lineItemStart) {
-		lineItemStart = *price.StartDate
 	}
 
 	lineItem := &subscription.SubscriptionLineItem{

--- a/internal/ee/service/subscription_change_v2.go
+++ b/internal/ee/service/subscription_change_v2.go
@@ -582,6 +582,10 @@ func buildPlanChangeLineItem(
 		EntityType:   types.SubscriptionLineItemEntityTypePlan,
 	})
 
+	if err := validatePriceStartNotAfterLineItem(target.Price, item.StartDate); err != nil {
+		return nil, err
+	}
+
 	item.BillingPeriodCount = target.Price.BillingPeriodCount
 	return item, nil
 }

--- a/internal/ee/service/subscription_filter_test.go
+++ b/internal/ee/service/subscription_filter_test.go
@@ -42,11 +42,11 @@ func TestFilterValidPricesForSubscription_IncludeIDsSemantics(t *testing.T) {
 	// Plan prices: one exact-cadence (quarterly), one divisor (monthly), one
 	// currency-mismatch, one ONETIME, one non-divisor (annual, on a quarterly sub).
 	prices := []*dto.PriceResponse{
-		mkPrice("q1", types.BILLING_PERIOD_QUARTER, 1),      // exact match to sub
-		mkPrice("m1", types.BILLING_PERIOD_MONTHLY, 1),      // divisor (fan-out)
-		mkPrice("m2", types.BILLING_PERIOD_MONTHLY, 1),      // divisor #2
-		mkPrice("ot", types.BILLING_PERIOD_ONETIME, 1),      // always compatible
-		mkPrice("y1", types.BILLING_PERIOD_ANNUAL, 1),       // non-divisor for quarter
+		mkPrice("q1", types.BILLING_PERIOD_QUARTER, 1), // exact match to sub
+		mkPrice("m1", types.BILLING_PERIOD_MONTHLY, 1), // divisor (fan-out)
+		mkPrice("m2", types.BILLING_PERIOD_MONTHLY, 1), // divisor #2
+		mkPrice("ot", types.BILLING_PERIOD_ONETIME, 1), // always compatible
+		mkPrice("y1", types.BILLING_PERIOD_ANNUAL, 1),  // non-divisor for quarter
 	}
 	// Currency mismatch — should always be dropped regardless of includeIDs.
 	badCurrency := mkPrice("bc", types.BILLING_PERIOD_QUARTER, 1)
@@ -154,8 +154,8 @@ func TestFilterAddonPricesForSubscription_PreservesCompatSemantics(t *testing.T)
 	// Regression guard: addon path must keep divisor-compat acceptance so
 	// pre-existing addon tests (monthly-on-annual, etc.) still work.
 	prices := []*dto.PriceResponse{
-		mkPrice("m1", types.BILLING_PERIOD_MONTHLY, 1),  // divisor of annual
-		mkPrice("q1", types.BILLING_PERIOD_QUARTER, 1),  // divisor of annual
+		mkPrice("m1", types.BILLING_PERIOD_MONTHLY, 1),   // divisor of annual
+		mkPrice("q1", types.BILLING_PERIOD_QUARTER, 1),   // divisor of annual
 		mkPrice("h1", types.BILLING_PERIOD_HALF_YEAR, 1), // divisor of annual
 		mkPrice("ot", types.BILLING_PERIOD_ONETIME, 1),
 	}
@@ -240,49 +240,39 @@ func TestValidateIncludePriceIDs_WrongCurrency(t *testing.T) {
 	}
 }
 
-// Regression: reject sub-create when sub is backdated before any price's
-// start_date. Otherwise the sub's line items snapshot with
-// start_date = price.start_date > sub.start_date, and fan-out silently
-// clips all pre-price windows to garbage periods (Bug: cancel invoice
-// showed a single ~1-day line item instead of the expected fan-out).
-func TestValidatePriceStartDateNotAfterSub(t *testing.T) {
+// Invariant: price.StartDate must be on or before the line item's start
+// (not the subscription's start). Comparing to sub.StartDate falsely
+// rejects mid-life addon attach / plan-change onto versioned prices.
+func TestValidatePriceStartNotAfterLineItem(t *testing.T) {
 	apr1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	aug31 := time.Date(2026, 8, 31, 20, 18, 14, 0, time.UTC)
-	sub := &subscription.Subscription{
-		Currency:  "usd",
-		StartDate: apr1, // backdated
-	}
-	// One price starts BEFORE sub (fine), one AFTER (must be rejected).
-	prices := []*dto.PriceResponse{
-		{Price: &price.Price{ID: "p_ok", Currency: "usd", StartDate: nil}},                                                       // nil = always effective
-		{Price: &price.Price{ID: "p_before", Currency: "usd", StartDate: &apr1}},                                                 // equal
-		{Price: &price.Price{ID: "p_after", Currency: "usd", StartDate: &aug31, DisplayName: "Monthly Flat Advance"}},            // AFTER
-		{Price: &price.Price{ID: "p_after2", Currency: "usd", StartDate: &aug31, DisplayName: "Shipment Overage"}},               // AFTER
+	dec1 := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)
+
+	late := &price.Price{ID: "p_after", StartDate: &aug31, DisplayName: "Monthly Flat Advance"}
+	if err := validatePriceStartNotAfterLineItem(late, apr1); err == nil {
+		t.Fatal("expected error when price starts after the line item")
+	} else if !containsAll(err.Error(), "p_after", "start_date") {
+		t.Fatalf("error should name the price and start_date; got: %v", err)
 	}
 
-	err := validatePriceStartDateNotAfterSub("plan_test", types.PRICE_ENTITY_TYPE_PLAN, sub, prices)
-	if err == nil {
-		t.Fatal("expected validation error for prices whose start_date is after sub.start_date")
-	}
-	if !containsAll(err.Error(), "start_date") {
-		t.Fatalf("error should mention start_date; got: %v", err)
-	}
-	// Both offenders must be reported (all-or-nothing).
-	msg := err.Error()
-	if !containsAll(msg, "p_after") || !containsAll(msg, "p_after2") {
-		t.Fatalf("error should name both offending price ids; got: %v", err)
+	// Coverage starts at the addon/plan-change instant, after the price.
+	if err := validatePriceStartNotAfterLineItem(late, dec1); err != nil {
+		t.Fatalf("price that started before the line item must pass; got: %v", err)
 	}
 
-	// Non-backdated sub (sub.start_date >= every price.start_date) → no error.
-	nonBackdated := &subscription.Subscription{Currency: "usd", StartDate: time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)}
-	if err := validatePriceStartDateNotAfterSub("plan_test", types.PRICE_ENTITY_TYPE_PLAN, nonBackdated, prices); err != nil {
-		t.Fatalf("non-backdated sub must not error; got: %v", err)
+	equal := &price.Price{ID: "p_eq", StartDate: &apr1}
+	if err := validatePriceStartNotAfterLineItem(equal, apr1); err != nil {
+		t.Fatalf("equal start dates must pass; got: %v", err)
 	}
 
-	// Zero sub.StartDate → skip check (no reference point).
-	zeroStart := &subscription.Subscription{Currency: "usd"}
-	if err := validatePriceStartDateNotAfterSub("plan_test", types.PRICE_ENTITY_TYPE_PLAN, zeroStart, prices); err != nil {
-		t.Fatalf("zero sub.StartDate must skip the check; got: %v", err)
+	if err := validatePriceStartNotAfterLineItem(&price.Price{ID: "p_nil"}, apr1); err != nil {
+		t.Fatalf("nil price start (always effective) must pass; got: %v", err)
+	}
+	if err := validatePriceStartNotAfterLineItem(late, time.Time{}); err != nil {
+		t.Fatalf("zero line-item start must skip the check; got: %v", err)
+	}
+	if err := validatePriceStartNotAfterLineItem(nil, apr1); err != nil {
+		t.Fatalf("nil price must skip the check; got: %v", err)
 	}
 }
 

--- a/internal/ee/service/subscription_filter_test.go
+++ b/internal/ee/service/subscription_filter_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"testing"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/domain/price"
@@ -236,6 +237,52 @@ func TestValidateIncludePriceIDs_WrongCurrency(t *testing.T) {
 	}
 	if !containsAll(err.Error(), "m_eur", "wrong_currency") {
 		t.Fatalf("error should name the wrong-currency id and category; got: %v", err)
+	}
+}
+
+// Regression: reject sub-create when sub is backdated before any price's
+// start_date. Otherwise the sub's line items snapshot with
+// start_date = price.start_date > sub.start_date, and fan-out silently
+// clips all pre-price windows to garbage periods (Bug: cancel invoice
+// showed a single ~1-day line item instead of the expected fan-out).
+func TestValidatePriceStartDateNotAfterSub(t *testing.T) {
+	apr1 := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	aug31 := time.Date(2026, 8, 31, 20, 18, 14, 0, time.UTC)
+	sub := &subscription.Subscription{
+		Currency:  "usd",
+		StartDate: apr1, // backdated
+	}
+	// One price starts BEFORE sub (fine), one AFTER (must be rejected).
+	prices := []*dto.PriceResponse{
+		{Price: &price.Price{ID: "p_ok", Currency: "usd", StartDate: nil}},                                                       // nil = always effective
+		{Price: &price.Price{ID: "p_before", Currency: "usd", StartDate: &apr1}},                                                 // equal
+		{Price: &price.Price{ID: "p_after", Currency: "usd", StartDate: &aug31, DisplayName: "Monthly Flat Advance"}},            // AFTER
+		{Price: &price.Price{ID: "p_after2", Currency: "usd", StartDate: &aug31, DisplayName: "Shipment Overage"}},               // AFTER
+	}
+
+	err := validatePriceStartDateNotAfterSub("plan_test", types.PRICE_ENTITY_TYPE_PLAN, sub, prices)
+	if err == nil {
+		t.Fatal("expected validation error for prices whose start_date is after sub.start_date")
+	}
+	if !containsAll(err.Error(), "start_date") {
+		t.Fatalf("error should mention start_date; got: %v", err)
+	}
+	// Both offenders must be reported (all-or-nothing).
+	msg := err.Error()
+	if !containsAll(msg, "p_after") || !containsAll(msg, "p_after2") {
+		t.Fatalf("error should name both offending price ids; got: %v", err)
+	}
+
+	// Non-backdated sub (sub.start_date >= every price.start_date) → no error.
+	nonBackdated := &subscription.Subscription{Currency: "usd", StartDate: time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC)}
+	if err := validatePriceStartDateNotAfterSub("plan_test", types.PRICE_ENTITY_TYPE_PLAN, nonBackdated, prices); err != nil {
+		t.Fatalf("non-backdated sub must not error; got: %v", err)
+	}
+
+	// Zero sub.StartDate → skip check (no reference point).
+	zeroStart := &subscription.Subscription{Currency: "usd"}
+	if err := validatePriceStartDateNotAfterSub("plan_test", types.PRICE_ENTITY_TYPE_PLAN, zeroStart, prices); err != nil {
+		t.Fatalf("zero sub.StartDate must skip the check; got: %v", err)
 	}
 }
 

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -74,6 +74,11 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 		if usedInlinePrice {
 			s.applySubscriptionScopedLineItemDefaults(lineItem, sub, price)
 		}
+		if price != nil {
+			if err := validatePriceStartNotAfterLineItem(price.Price, lineItem.StartDate); err != nil {
+				return err
+			}
+		}
 
 		// Materialize bucket prices: create a SUBSCRIPTION-scoped Price for each
 		// CommitmentTimeBuckets entry and assign the resulting slice (with PriceIDs
@@ -83,7 +88,7 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 			// ToSubscriptionLineItem already built lineItem.CommitmentTimeBuckets
 			// (IDs + commitment fields, empty PriceID); create a SUBSCRIPTION-scoped
 			// price per bucket and fill in the PriceIDs.
-			if err := s.createBucketPrices(txCtx, lineItem.ID, subscriptionID, resolvedReq.CommitmentTimeBuckets, lineItem.CommitmentTimeBuckets, nil); err != nil {
+			if err := s.createBucketPrices(txCtx, lineItem.ID, subscriptionID, resolvedReq.CommitmentTimeBuckets, lineItem.CommitmentTimeBuckets, nil, lineItem.StartDate); err != nil {
 				return err
 			}
 			_, _, hasCumulative := getSubscriptionCommitmentPeriodBounds(sub, sub.CurrentPeriodStart)
@@ -584,7 +589,7 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			// line item's buckets (copied by ToSubscriptionLineItem); supplying an
 			// explicit empty slice clears them.
 			if req.CommitmentTimeBuckets != nil {
-				if err := s.createBucketPrices(ctx, newLineItem.ID, existingLineItem.SubscriptionID, *req.CommitmentTimeBuckets, newLineItem.CommitmentTimeBuckets, existingLineItem.CommitmentTimeBuckets); err != nil {
+				if err := s.createBucketPrices(ctx, newLineItem.ID, existingLineItem.SubscriptionID, *req.CommitmentTimeBuckets, newLineItem.CommitmentTimeBuckets, existingLineItem.CommitmentTimeBuckets, newLineItem.StartDate); err != nil {
 					return err
 				}
 			}
@@ -907,7 +912,7 @@ func (s *subscriptionService) createBucketPricesForLineItems(
 		if cfg == nil || len(cfg.CommitmentTimeBuckets) == 0 {
 			continue
 		}
-		if err := s.createBucketPrices(ctx, li.ID, sub.ID, cfg.CommitmentTimeBuckets, li.CommitmentTimeBuckets, nil); err != nil {
+		if err := s.createBucketPrices(ctx, li.ID, sub.ID, cfg.CommitmentTimeBuckets, li.CommitmentTimeBuckets, nil, li.StartDate); err != nil {
 			return err
 		}
 		if err := s.validateBucketArray(ctx, li.MeterID, li.PriceID, li.CommitmentWindowed, hasCumulative, li.CommitmentTimeBuckets); err != nil {
@@ -1110,6 +1115,7 @@ func (s *subscriptionService) createBucketPrices(
 	reqs []dto.CommitmentBucketRequest,
 	buckets types.TimeOfDayBuckets,
 	existing types.TimeOfDayBuckets,
+	lineItemStart time.Time,
 ) error {
 	if len(reqs) != len(buckets) {
 		return ierr.NewError("bucket request/domain length mismatch").
@@ -1149,9 +1155,16 @@ func (s *subscriptionService) createBucketPrices(
 			"sub_line_item_id": lineItemID,
 			"bucket_id":        buckets[i].ID,
 		}
+		if priceReq.StartDate == nil && !lineItemStart.IsZero() {
+			start := lineItemStart.UTC()
+			priceReq.StartDate = &start
+		}
 
 		resp, err := priceService.CreatePrice(ctx, priceReq)
 		if err != nil {
+			return err
+		}
+		if err := validatePriceStartNotAfterLineItem(resp.Price, lineItemStart); err != nil {
 			return err
 		}
 		buckets[i].PriceID = resp.ID

--- a/internal/ee/service/subscription_line_item_test.go
+++ b/internal/ee/service/subscription_line_item_test.go
@@ -1338,7 +1338,7 @@ func (s *SubscriptionLineItemServiceSuite) TestCreateBucketPrices_CreatesSubscri
 		buckets[i] = r.ToTimeOfDayBucket()
 	}
 
-	err := concreteSvc.createBucketPrices(ctx, s.testData.lineItem.ID, s.testData.subscription.ID, reqs, buckets, nil)
+	err := concreteSvc.createBucketPrices(ctx, s.testData.lineItem.ID, s.testData.subscription.ID, reqs, buckets, nil, s.testData.lineItem.StartDate)
 	s.NoError(err)
 	s.Require().Len(buckets, 1)
 
@@ -1371,10 +1371,10 @@ func (s *SubscriptionLineItemServiceSuite) TestCreateBucketPrices_EmptySlice() {
 	ctx := s.GetContext()
 	concreteSvc := s.service.(*subscriptionService)
 
-	err := concreteSvc.createBucketPrices(ctx, s.testData.lineItem.ID, s.testData.subscription.ID, nil, types.TimeOfDayBuckets{}, nil)
+	err := concreteSvc.createBucketPrices(ctx, s.testData.lineItem.ID, s.testData.subscription.ID, nil, types.TimeOfDayBuckets{}, nil, time.Time{})
 	s.NoError(err)
 
-	err2 := concreteSvc.createBucketPrices(ctx, s.testData.lineItem.ID, s.testData.subscription.ID, []dto.CommitmentBucketRequest{}, types.TimeOfDayBuckets{}, nil)
+	err2 := concreteSvc.createBucketPrices(ctx, s.testData.lineItem.ID, s.testData.subscription.ID, []dto.CommitmentBucketRequest{}, types.TimeOfDayBuckets{}, nil, time.Time{})
 	s.NoError(err2)
 }
 
@@ -1418,7 +1418,7 @@ func (s *SubscriptionLineItemServiceSuite) TestCreateBucketPrices_MultipleBucket
 		buckets[i] = r.ToTimeOfDayBucket()
 	}
 
-	err := concreteSvc.createBucketPrices(ctx, s.testData.lineItem.ID, s.testData.subscription.ID, reqs, buckets, nil)
+	err := concreteSvc.createBucketPrices(ctx, s.testData.lineItem.ID, s.testData.subscription.ID, reqs, buckets, nil, s.testData.lineItem.StartDate)
 	s.NoError(err)
 	s.Require().Len(buckets, 3)
 


### PR DESCRIPTION
## Summary
- Fail fast at subscription create time when `sub.start_date` is before any attached price's `start_date`.
- Previously, the line item silently inherited `max(sub.start_date, price.start_date)`; on cancel/fan-out this produced 1-day / zero-length garbage periods instead of the expected fan-out (observed in prod draft invoices for backdated subs).
- New validator names every offending price (id, start_date, display_name, lookup_key), so the caller can either move the sub start_date forward or update the price start_date.
- Runs in both branches of `ValidateAndFilterPricesForSubscription` (`allowsEmptyPrices` false and true).

## Why not clip differently at runtime?
Runtime clipping via `item.GetPeriodStart/End` is technically defensible ("don't bill for periods before the price existed"), but silently loses coverage on backdated subs — the common case where a user pre-creates prices to bill for a past period. Rejecting at create is safer, discoverable, and doesn't change any existing invoice.

## Test plan
- [x] `go test -race ./internal/ee/service -run TestValidatePriceStartDateNotAfterSub` — passes
- [x] `go test -race ./internal/ee/service -run "TestValidate|TestFilter|TestValidateAndFilter"` — all pass
- [x] `go vet ./internal/...` — clean
- [x] `make lint-ci` — clean
- [ ] Manual: try creating a subscription with `start_date < price.start_date` — should 4xx with offending price ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription and add-on date validation by comparing each price’s start date with the applicable line-item coverage period.
  * Prevented plans, phases, add-ons, overrides, and subscription changes from using prices that begin after coverage starts.
  * Ensured price overrides align with their associated line-item start dates.
  * Added clearer validation errors identifying affected prices.
  * Preserved support for unspecified start dates and valid matching or earlier price dates.

* **Tests**
  * Added regression coverage for line-item date validation and start-date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->