### PR TITLE
fix(billing): anchor monthly-on-quarterly fan-out at sub.BillingAnchor

### DIFF
--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -480,22 +480,35 @@ func splitInvoicePeriodByLineItemCadence(
 	if expected < 1 {
 		expected = 1
 	}
-	// Emit exactly `expected` windows. Force the LAST window to end at
-	// invoicePeriodEnd so any drift between item-cadence months and the
-	// invoice period's calendar length (e.g. Q3 = 92 UTC days vs 3×30-day
-	// UTC-anchored months) is absorbed into the last window — instead of
-	// leaking as a trailing 1-day sliver line item.
+	// Anchor at sub.BillingAnchor — the same anchor NextBillingDate uses
+	// to compute the sub's own period boundaries. If we anchored at
+	// invoicePeriodStart instead, its day-of-month has already been
+	// calendar-clamped for months < 31 days (e.g. Sep 30 loses the sub's
+	// day-31 preference), and monthly steps would never climb back to 31
+	// — producing a trailing 1-day sliver window against an invoice period
+	// that DOES end on 31. Anchoring at sub.BillingAnchor makes the
+	// N×itemPeriod walk land exactly on invoicePeriodEnd by construction.
+	// Fallback to invoicePeriodStart preserves behavior when the sub has
+	// no anchor set (older test fixtures / degenerate data).
+	anchor := invoicePeriodStart
+	if !sub.BillingAnchor.IsZero() {
+		anchor = sub.BillingAnchor
+	}
 	windows := make([]periodWindow, 0, expected)
 	current := invoicePeriodStart
 	for i := 0; i < expected; i++ {
 		var next time.Time
 		if i == expected-1 {
+			// Last window ends exactly at invoicePeriodEnd. With a correct
+			// anchor this equals what NextBillingDate would return anyway;
+			// forcing it also defends against misconfigured anchors so we
+			// never emit a trailing sliver.
 			next = invoicePeriodEnd
 		} else {
 			var err error
 			next, err = types.NextBillingDate(&types.NextBillingDateParams{
 				CurrentPeriodStart: current,
-				BillingAnchor:      invoicePeriodStart,
+				BillingAnchor:      anchor,
 				Unit:               itemCount,
 				Period:             lineItem.BillingPeriod,
 				Timezone:           sub.Timezone,
@@ -503,8 +516,6 @@ func splitInvoicePeriodByLineItemCadence(
 			if err != nil {
 				return nil, err
 			}
-			// If NextBillingDate would jump past (or exactly to) invoicePeriodEnd,
-			// or fail to advance, collapse the remaining iterations into this window.
 			if !next.After(current) || !next.Before(invoicePeriodEnd) {
 				next = invoicePeriodEnd
 			}

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -476,28 +476,44 @@ func splitInvoicePeriodByLineItemCadence(
 
 	subMonths := types.EffectiveMonths(sub.BillingPeriod, subCount)
 	itemMonths := types.EffectiveMonths(lineItem.BillingPeriod, itemCount)
-	windows := make([]periodWindow, 0, subMonths/itemMonths)
+	expected := subMonths / itemMonths
+	if expected < 1 {
+		expected = 1
+	}
+	// Emit exactly `expected` windows. Force the LAST window to end at
+	// invoicePeriodEnd so any drift between item-cadence months and the
+	// invoice period's calendar length (e.g. Q3 = 92 UTC days vs 3×30-day
+	// UTC-anchored months) is absorbed into the last window — instead of
+	// leaking as a trailing 1-day sliver line item.
+	windows := make([]periodWindow, 0, expected)
 	current := invoicePeriodStart
-	for current.Before(invoicePeriodEnd) {
-		next, err := types.NextBillingDate(&types.NextBillingDateParams{
-			CurrentPeriodStart: current,
-			BillingAnchor:      invoicePeriodStart,
-			Unit:               itemCount,
-			Period:             lineItem.BillingPeriod,
-			Timezone:           sub.Timezone,
-		})
-		if err != nil {
-			return nil, err
-		}
-		// Defensive: never emit a window that overruns the invoice period; clamp to invoicePeriodEnd.
-		if next.After(invoicePeriodEnd) {
+	for i := 0; i < expected; i++ {
+		var next time.Time
+		if i == expected-1 {
 			next = invoicePeriodEnd
+		} else {
+			var err error
+			next, err = types.NextBillingDate(&types.NextBillingDateParams{
+				CurrentPeriodStart: current,
+				BillingAnchor:      invoicePeriodStart,
+				Unit:               itemCount,
+				Period:             lineItem.BillingPeriod,
+				Timezone:           sub.Timezone,
+			})
+			if err != nil {
+				return nil, err
+			}
+			// If NextBillingDate would jump past (or exactly to) invoicePeriodEnd,
+			// or fail to advance, collapse the remaining iterations into this window.
+			if !next.After(current) || !next.Before(invoicePeriodEnd) {
+				next = invoicePeriodEnd
+			}
 		}
 		windows = append(windows, periodWindow{Start: current, End: next})
-		if !next.After(current) {
-			break // safety against infinite loop on degenerate input
-		}
 		current = next
+		if !current.Before(invoicePeriodEnd) {
+			break
+		}
 	}
 	return windows, nil
 }

--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -480,14 +480,9 @@ func splitInvoicePeriodByLineItemCadence(
 	if expected < 1 {
 		expected = 1
 	}
+
 	// Anchor at sub.BillingAnchor — the same anchor NextBillingDate uses
-	// to compute the sub's own period boundaries. If we anchored at
-	// invoicePeriodStart instead, its day-of-month has already been
-	// calendar-clamped for months < 31 days (e.g. Sep 30 loses the sub's
-	// day-31 preference), and monthly steps would never climb back to 31
-	// — producing a trailing 1-day sliver window against an invoice period
-	// that DOES end on 31. Anchoring at sub.BillingAnchor makes the
-	// N×itemPeriod walk land exactly on invoicePeriodEnd by construction.
+	// to compute the sub's own period boundaries.
 	// Fallback to invoicePeriodStart preserves behavior when the sub has
 	// no anchor set (older test fixtures / degenerate data).
 	anchor := invoicePeriodStart
@@ -499,8 +494,8 @@ func splitInvoicePeriodByLineItemCadence(
 	for i := 0; i < expected; i++ {
 		var next time.Time
 		if i == expected-1 {
-			// Last window ends exactly at invoicePeriodEnd. With a correct
-			// anchor this equals what NextBillingDate would return anyway;
+			//  window ends exactly at invoicePeriodEnd. With a correct
+			// anchLastor this equals what NextBillingDate would return anyway;
 			// forcing it also defends against misconfigured anchors so we
 			// never emit a trailing sliver.
 			next = invoicePeriodEnd

--- a/internal/ee/service/billing_test.go
+++ b/internal/ee/service/billing_test.go
@@ -5074,22 +5074,25 @@ func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_MonthlyOnQ
 	s.Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), windows[2].End)
 }
 
-func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_AbsorbsDriftIntoLastWindow() {
-	// Regression: real prod invoice for a QUARTERLY sub anchored at
-	// 2026-03-31T18:30:00Z (Apr 1 IST) produced 4 addon line items for the
-	// Q3 period (Sep 30 → Dec 31 UTC = 92 days) instead of 3. Root cause:
-	// UTC-anchored MONTHLY steps land on day-30 (Oct 30, Nov 30, Dec 30),
-	// which is 1 day short of invoicePeriodEnd (Dec 31), so the loop emitted
-	// a trailing 1-day sliver [Dec 30, Dec 31].
+func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_AnchorPreservesDayOfMonth() {
+	// Regression: real prod invoice for a QUARTERLY sub with
+	// BillingAnchor = 2026-03-31T18:30:00Z (Apr 1 IST, day-of-month 31)
+	// produced 4 addon line items for Q3 (Sep 30 → Dec 31 UTC = 92 days)
+	// instead of 3. Root cause: fan-out anchored at invoicePeriodStart
+	// (Sep 30, day-30 — sub's day-31 preference already lost to Sep's
+	// calendar clamp), so monthly steps land on day-30 and never climb
+	// back to 31 — leaving a trailing 1-day sliver [Dec 30, Dec 31].
 	//
-	// Fix: emit exactly subMonths/itemMonths windows and absorb the drift
-	// into the last window (so the last window is 31 days, not two windows
-	// of 30 + 1).
+	// Fix: anchor fan-out at sub.BillingAnchor (same anchor
+	// NextBillingDate uses to compute the sub's own period boundaries).
+	// Day-31 is restored whenever the target month allows, so the walk
+	// lands exactly on invoicePeriodEnd (Dec 31) by construction.
 	q3Start := time.Date(2026, 9, 30, 18, 30, 0, 0, time.UTC)
 	q3End := time.Date(2026, 12, 31, 18, 30, 0, 0, time.UTC)
 	sub := &subscription.Subscription{
 		BillingPeriod:      types.BILLING_PERIOD_QUARTER,
 		BillingPeriodCount: 1,
+		BillingAnchor:      time.Date(2026, 3, 31, 18, 30, 0, 0, time.UTC),
 		Timezone:           "UTC",
 	}
 	item := &subscription.SubscriptionLineItem{
@@ -5099,13 +5102,45 @@ func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_AbsorbsDri
 
 	windows, err := splitInvoicePeriodByLineItemCadence(q3Start, q3End, item, sub)
 	s.Require().NoError(err)
-	s.Require().Len(windows, 3, "monthly-on-quarterly must produce exactly 3 windows even when calendar drift would otherwise create a 4th sliver")
+	s.Require().Len(windows, 3, "monthly-on-quarterly with day-31 sub anchor must land cleanly on Dec 31 in 3 windows")
+	// Oct restores 31 from the anchor
+	s.Equal(q3Start, windows[0].Start)
+	s.Equal(time.Date(2026, 10, 31, 18, 30, 0, 0, time.UTC), windows[0].End)
+	// Nov has 30 days, clamps
+	s.Equal(time.Date(2026, 10, 31, 18, 30, 0, 0, time.UTC), windows[1].Start)
+	s.Equal(time.Date(2026, 11, 30, 18, 30, 0, 0, time.UTC), windows[1].End)
+	// Dec restores 31 from the anchor — matches invoicePeriodEnd exactly
+	s.Equal(time.Date(2026, 11, 30, 18, 30, 0, 0, time.UTC), windows[2].Start)
+	s.Equal(q3End, windows[2].End, "last window must end exactly at invoicePeriodEnd")
+}
+
+func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_FallsBackToInvoiceStartWhenNoAnchor() {
+	// If sub.BillingAnchor is unset (older test fixtures / degenerate data),
+	// fan-out anchors at invoicePeriodStart to preserve prior behavior.
+	q3Start := time.Date(2026, 9, 30, 18, 30, 0, 0, time.UTC)
+	q3End := time.Date(2026, 12, 31, 18, 30, 0, 0, time.UTC)
+	sub := &subscription.Subscription{
+		BillingPeriod:      types.BILLING_PERIOD_QUARTER,
+		BillingPeriodCount: 1,
+		Timezone:           "UTC",
+		// BillingAnchor intentionally zero
+	}
+	item := &subscription.SubscriptionLineItem{
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+	}
+
+	windows, err := splitInvoicePeriodByLineItemCadence(q3Start, q3End, item, sub)
+	s.Require().NoError(err)
+	s.Require().Len(windows, 3, "still exactly 3 windows even when the fallback anchor would otherwise drift")
+	// With invoicePeriodStart anchor (day-30), monthly steps stay on day-30.
+	// The last window is force-clamped to invoicePeriodEnd so no sliver leaks.
 	s.Equal(q3Start, windows[0].Start)
 	s.Equal(time.Date(2026, 10, 30, 18, 30, 0, 0, time.UTC), windows[0].End)
 	s.Equal(time.Date(2026, 10, 30, 18, 30, 0, 0, time.UTC), windows[1].Start)
 	s.Equal(time.Date(2026, 11, 30, 18, 30, 0, 0, time.UTC), windows[1].End)
 	s.Equal(time.Date(2026, 11, 30, 18, 30, 0, 0, time.UTC), windows[2].Start)
-	s.Equal(q3End, windows[2].End, "last window must end exactly at invoicePeriodEnd, absorbing the 1-day drift")
+	s.Equal(q3End, windows[2].End, "fallback path: last window force-clamps to invoicePeriodEnd instead of emitting a sliver")
 }
 
 func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_NonDivisibleRejected() {

--- a/internal/ee/service/billing_test.go
+++ b/internal/ee/service/billing_test.go
@@ -5074,6 +5074,40 @@ func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_MonthlyOnQ
 	s.Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), windows[2].End)
 }
 
+func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_AbsorbsDriftIntoLastWindow() {
+	// Regression: real prod invoice for a QUARTERLY sub anchored at
+	// 2026-03-31T18:30:00Z (Apr 1 IST) produced 4 addon line items for the
+	// Q3 period (Sep 30 → Dec 31 UTC = 92 days) instead of 3. Root cause:
+	// UTC-anchored MONTHLY steps land on day-30 (Oct 30, Nov 30, Dec 30),
+	// which is 1 day short of invoicePeriodEnd (Dec 31), so the loop emitted
+	// a trailing 1-day sliver [Dec 30, Dec 31].
+	//
+	// Fix: emit exactly subMonths/itemMonths windows and absorb the drift
+	// into the last window (so the last window is 31 days, not two windows
+	// of 30 + 1).
+	q3Start := time.Date(2026, 9, 30, 18, 30, 0, 0, time.UTC)
+	q3End := time.Date(2026, 12, 31, 18, 30, 0, 0, time.UTC)
+	sub := &subscription.Subscription{
+		BillingPeriod:      types.BILLING_PERIOD_QUARTER,
+		BillingPeriodCount: 1,
+		Timezone:           "UTC",
+	}
+	item := &subscription.SubscriptionLineItem{
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+	}
+
+	windows, err := splitInvoicePeriodByLineItemCadence(q3Start, q3End, item, sub)
+	s.Require().NoError(err)
+	s.Require().Len(windows, 3, "monthly-on-quarterly must produce exactly 3 windows even when calendar drift would otherwise create a 4th sliver")
+	s.Equal(q3Start, windows[0].Start)
+	s.Equal(time.Date(2026, 10, 30, 18, 30, 0, 0, time.UTC), windows[0].End)
+	s.Equal(time.Date(2026, 10, 30, 18, 30, 0, 0, time.UTC), windows[1].Start)
+	s.Equal(time.Date(2026, 11, 30, 18, 30, 0, 0, time.UTC), windows[1].End)
+	s.Equal(time.Date(2026, 11, 30, 18, 30, 0, 0, time.UTC), windows[2].Start)
+	s.Equal(q3End, windows[2].End, "last window must end exactly at invoicePeriodEnd, absorbing the 1-day drift")
+}
+
 func (s *BillingServiceSuite) TestSplitInvoicePeriodByLineItemCadence_NonDivisibleRejected() {
 	// Half-yearly (6mo) on quarterly (3mo) — line item is LONGER, not a divisor.
 	// Fixed-charge code handles this via the "longer cadence" branch (line 185-211),


### PR DESCRIPTION
## Summary
Real prod invoice: QUARTERLY sub with `BillingAnchor = 2026-03-31T18:30:00Z` (day-of-month **31**), TZ=UTC. Q3 invoice period spans Sep 30 → Dec 31 UTC (**92 days**). A monthly-cadence addon fanned out into **4** line items — the last being a **1-day sliver** `[Dec 30, Dec 31]`.

## Root cause
Fan-out anchored at `invoicePeriodStart` (Sep 30 — day 30). The sub's day-31 preference was already lost to Sep's calendar clamp, so monthly steps from day-30 land on day-30 forever and never climb back to 31. `invoicePeriodEnd` for Q3 IS day-31 (Dec 31), because it's computed from the sub's own anchor which still has day-31 — so the fan-out never reaches it naturally.

`NextBillingDate` itself is correct. The bug was in what we passed as the anchor.

## Fix
Anchor fan-out at `sub.BillingAnchor` — the same anchor `NextBillingDate` uses to compute the sub's period boundaries in the first place. Day-31 is restored whenever the target month allows:

| Window | Old (anchor = Sep 30, day 30) | New (anchor = Mar 31, day 31) |
|---|---|---|
| 1 | Sep 30 → Oct 30 | Sep 30 → **Oct 31** (restored) |
| 2 | Oct 30 → Nov 30 | Oct 31 → **Nov 30** (clamped, Nov has 30) |
| 3 | Nov 30 → Dec 30 | Nov 30 → **Dec 31** (restored, matches invoicePeriodEnd) |
| 4 | **Dec 30 → Dec 31 (sliver!)** | — no 4th window |

Kept: (a) "force last window to end at invoicePeriodEnd" as defense-in-depth against misconfigured anchors, and (b) fallback to `invoicePeriodStart` when `sub.BillingAnchor` is unset (older fixtures / degenerate data).

## Behavior change to watch
Windows for existing fan-out invoices also shift by a day where the sub's anchor day > invoicePeriodStart's day. E.g. Q2 today: `Jun 30 → Jul 30 → Aug 30 → Sep 30`. After: `Jun 30 → Jul 31 → Aug 31 → Sep 30`. Total charged unchanged (3 × price); window boundaries shift. Any existing draft invoices recompute to slightly different periods on next recalc — user confirmed no affected production drafts.

## Not fixed here (separate concern)
Same customer's platformo fee (addon, `invoice_cadence=advance`) appears in Q1's preview covering Jul–Oct because `ReferencePointPreview` bundles current-arrear + next-advance in one preview. Config mismatch on the addon side; not a fan-out bug.

## Test plan
- [x] `TestSplitInvoicePeriodByLineItemCadence_AnchorPreservesDayOfMonth` — locks in prod scenario, exact Sep 30 → Oct 31 → Nov 30 → Dec 31 boundaries
- [x] `TestSplitInvoicePeriodByLineItemCadence_FallsBackToInvoiceStartWhenNoAnchor` — fallback path still emits exactly 3 windows (safety clamp catches sliver)
- [x] Existing `TestSplitInvoicePeriodByLineItemCadence_*` cases pass
- [x] Full `internal/ee/service` suite green (`go test -race -count=1`)
- [x] `go vet ./internal/...` — clean
- [x] `make lint-ci` — clean
- [ ] Recompute affected draft invoice — verify Q2 preview shows 3 platformo fee lines, and that plan windows land on day-31 (`Jul 31`, `Aug 31`) where the calendar allows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected invoice period splitting across different billing cadences.
  * Prevented extra one-day billing line items caused by calendar drift.
  * Preserved billing dates for subscriptions anchored on the 29th, 30th, or 31st of a month.
  * Ensured billing windows end precisely at the invoice period’s end date, including subscriptions without a billing anchor.

* **Tests**
  * Added regression coverage for monthly billing within quarterly periods and subscriptions without a billing anchor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->