### PR TITLE
chore(helm): harden frontend gcsproxy + nginx container securityContext

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-frontend.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/app/deployment-frontend.yaml
@@ -41,6 +41,15 @@ spec:
           {{- if not .Values.frontend.gcs.bucket }}
           {{- fail "frontend.mode=gcsproxy requires frontend.gcs.bucket" }}
           {{- end }}
+          {{- /*
+            Clears RUN_AS_NONROOT + PRIVILEGE_ESCALATION. readOnlyRootFilesystem
+            is left off for gcsproxy (unlike nginx) — it's a third-party binary
+            with no dedicated scratch volume, and RO rootfs is not what the SCC
+            findings require.
+          */}}
+          securityContext:
+            {{- toYaml (omit .Values.securityContext "readOnlyRootFilesystem") | nindent 12 }}
+            readOnlyRootFilesystem: false
           image: {{ .Values.frontend.gcs.image | quote }}
           args:
             - "-bucket"
@@ -59,6 +68,13 @@ spec:
           resources:
             {{- toYaml .Values.frontend.gcs.resources | nindent 12 }}
         - name: nginx
+          {{- /*
+            nginx (RO rootfs from .Values.securityContext) writes only to the
+            emptyDir mounts below (/var/cache/nginx, /var/run); listens on 3000,
+            an unprivileged port, so dropping ALL caps + no-new-privs is safe.
+          */}}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ .Values.frontend.nginx.image | quote }}
           ports:
             - name: http


### PR DESCRIPTION
## What

Adds container-level `securityContext` to the two frontend containers in `frontend.mode=gcsproxy`: **gcsproxy** and **nginx**.

## Why

The gcsproxy-mode containers inherited only the pod-level `podSecurityContext`; the containers themselves had no securityContext (unlike the image-mode frontend container, which already applies `.Values.securityContext`). GKE Security Posture flags this per-container, tripping **RUN_AS_NONROOT** and **PRIVILEGE_ESCALATION** on the regional prod clusters (`prod-flexprice-gke-as1`, `-euw4`, `-euw9`).

## Change

Both containers now get the chart's existing `.Values.securityContext`:
`runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`.

- **nginx** keeps `readOnlyRootFilesystem: true` — its writes already target the `nginx-cache` / `nginx-run` emptyDir mounts, and it listens on 3000 (unprivileged).
- **gcsproxy** overrides `readOnlyRootFilesystem: false` — it has no dedicated scratch volume, and RO rootfs is not required to clear the findings. This avoids a CrashLoop risk on a third-party binary.

Chart version `1.4.1` → `1.4.2`.

## Verification

`helm template` (gcsproxy mode) renders both containers with the expected securityContext; image-mode still renders unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deployment Improvements**
  - Updated the deployment chart to improve security-context handling for frontend deployments using the GCS proxy mode.
  - The proxy container now runs with a writable root filesystem when required, while the NGINX container continues to apply the configured security settings.
- **Chores**
  - Updated the deployment chart version to 1.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->