### PR TITLE
chore(helm): add securityContext to in-cluster ClickHouse (standalone + altinity)

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/Chart.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: flexprice
 description: A Helm chart for FlexPrice billing and pricing platform
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: "1.0.0"
 keywords:
   - billing

--- a/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
@@ -256,6 +256,10 @@ spec:
             - name: clickhouse
               image: "{{ .Values.clickhouse.altinity.image.repository }}:{{ .Values.clickhouse.altinity.image.tag }}"
               imagePullPolicy: {{ .Values.clickhouse.altinity.image.pullPolicy }}
+              {{- with .Values.clickhouse.altinity.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               ports:
                 - containerPort: 8123
                 - containerPort: 9000

--- a/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
@@ -53,6 +53,10 @@ spec:
         - name: clickhouse
           image: "{{ .Values.clickhouse.standalone.image.repository }}:{{ .Values.clickhouse.standalone.image.tag }}"
           imagePullPolicy: {{ .Values.clickhouse.standalone.image.pullPolicy }}
+          {{- with .Values.clickhouse.standalone.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8123

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -858,6 +858,18 @@ clickhouse:
       nativePort: 9000
     nodeSelector: {}
     tolerations: []
+    # The clickhouse-server process already runs as uid 101 (data dir is 101-owned);
+    # runAsUser: 101 matches existing ownership so no fsGroup chown is triggered on
+    # the data PVC. Clears the GKE RUN_AS_NONROOT + PRIVILEGE_ESCALATION findings.
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 101
+      runAsGroup: 101
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+      seccompProfile:
+        type: RuntimeDefault
 
   # ── altinity mode ─────────────────────────────────────────────────────────────
   # ClickHouseInstallation CRD. Operator creates service: chi-<fullname>-flexprice-0-0

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -896,6 +896,18 @@ clickhouse:
       staleTimeoutMs: 1000
     nodeSelector: {}
     tolerations: []
+    # Same rationale as standalone: clickhouse-server already runs as uid 101 and
+    # the data dir is 101-owned, so runAsUser: 101 triggers no fsGroup chown on the
+    # PVC. Clears the GKE RUN_AS_NONROOT + PRIVILEGE_ESCALATION findings.
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 101
+      runAsGroup: 101
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+      seccompProfile:
+        type: RuntimeDefault
 
 # Kafka Configuration
 # Deployment options (pick one):


### PR DESCRIPTION
## What

Adds a container `securityContext` to the chart-rendered in-cluster ClickHouse, both deployment modes:
- **standalone** StatefulSet — used on `euw4`, `euw9`
- **altinity** operator CHI — used on `nane2`

## Why

Neither the standalone container nor the altinity CHI podTemplate container set a securityContext, tripping GKE Security Posture **RUN_AS_NONROOT** and **PRIVILEGE_ESCALATION**.

## Data-safe (no fsGroup chown)

Verified on live pods (euw4 standalone + nane2 altinity): clickhouse-server (PID 1) already runs as **uid 101** and `/var/lib/clickhouse` is **101-owned**. `runAsUser: 101` matches existing ownership → no fsGroup recursive chown on the data PVC → no data-migration risk.

## Change

New `clickhouse.standalone.securityContext` and `clickhouse.altinity.securityContext` values (defaults): `runAsNonRoot: true`, `runAsUser/Group: 101`, `allowPrivilegeEscalation: false`, `drop: [ALL]`, seccomp RuntimeDefault. Wired into both containers. Region values don't override → inherit defaults.

## Scope

- euw4/euw9 (standalone) + nane2 (altinity) get it.
- **us-west1 NOT affected** (mode: external — chart renders no ClickHouse there; excluded per request).
- as1 CHI (separate cluster.yaml, not chart) handled in infra PR #384. staging-mumbai CHI+Keeper applied live (out-of-band).
- Chart `1.4.1` → `1.4.4`.

## Delivery + rollout

GitOps via `flexprice-production` ArgoCD app (`flexprice@main`, manual sync). Rolling restarts the single/replica ClickHouse pods (brief unavailability per pod; operator preserves order in altinity mode).

## Verification

`helm template` in both modes renders the container with runAsUser=101, allowPrivEsc=false, drop ALL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * ClickHouse standalone and Altinity deployments now run with hardened security settings, including non-root execution, disabled privilege escalation, dropped Linux capabilities, and the RuntimeDefault seccomp profile.

* **Infrastructure**
  * Updated the FlexPrice Helm chart version to 1.4.4.
  * Security settings are applied conditionally based on the selected ClickHouse deployment mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->