### PR TITLE
fix(deploy): send migration task output to CloudWatch

### DIFF
--- a/.github/actions/run-ecs-migration/action.yml
+++ b/.github/actions/run-ecs-migration/action.yml
@@ -223,17 +223,28 @@ runs:
         # task: on EC2 launch type the awslogs driver uses the container
         # INSTANCE's role (AmazonEC2ContainerServiceforEC2Role), which grants
         # CreateLogStream and PutLogEvents but NOT CreateLogGroup.
-        aws logs create-log-group --log-group-name "$LOG_GROUP" --region "$REGION" 2>/dev/null || true
-        aws logs put-retention-policy --log-group-name "$LOG_GROUP" \
-          --retention-in-days 30 --region "$REGION" 2>/dev/null || true
-        if ! aws logs describe-log-groups --log-group-name-prefix "$LOG_GROUP" --region "$REGION" \
-             --query "logGroups[?logGroupName=='$LOG_GROUP'].logGroupName" --output text | grep -q .; then
+        # Existence is confirmed from create-log-group's own outcome rather than a
+        # describe call: logs:DescribeLogGroups does not support resource-level
+        # permissions -- it is denied unless granted on "*" -- and a wildcard read
+        # grant is not worth adding for a check this can do directly.
+        CG_ERR="$(mktemp)"
+        if aws logs create-log-group --log-group-name "$LOG_GROUP" --region "$REGION" 2>"$CG_ERR"; then
+          echo "  created log group $LOG_GROUP"
+        elif grep -q "ResourceAlreadyExistsException" "$CG_ERR"; then
+          :
+        else
           echo "  ERROR: log group $LOG_GROUP does not exist and could not be created." >&2
           echo "         The migration task would fail to START with the awslogs driver," >&2
-          echo "         with an error that does not mention logging. Grant" >&2
-          echo "         logs:CreateLogGroup and logs:DescribeLogGroups to this role." >&2
-          exit 1
+          echo "         with an error that does not mention logging." >&2
+          sed 's/^/         /' "$CG_ERR" >&2
+          rm -f "$CG_ERR"; exit 1
         fi
+        rm -f "$CG_ERR"
+
+        # Best-effort: retention keeps this from accumulating, but a missing
+        # PutRetentionPolicy grant must not block a migration.
+        aws logs put-retention-policy --log-group-name "$LOG_GROUP" \
+          --retention-in-days 30 --region "$REGION" 2>/dev/null || true
 
         TASK=$(aws "${RUN_ARGS[@]}" --query 'tasks[0].taskArn' --output text)
         if [ -z "$TASK" ] || [ "$TASK" = "None" ]; then

--- a/.github/actions/run-ecs-migration/action.yml
+++ b/.github/actions/run-ecs-migration/action.yml
@@ -95,6 +95,12 @@ runs:
           --region "$REGION" \
           --query 'taskDefinition')
 
+        # Fixed destination for migration logs. Not derived from the service's
+        # task definition: that is json-file on India prod, so there is nothing
+        # to derive.
+        LOG_GROUP="/ecs/flexprice-migrate"
+        LOG_PREFIX="migrate"
+
         if [ "$DRY_RUN" = "true" ]; then
           echo "  [DRY RUN] Would register a -migrate task definition and run ./migrate postgres up"
           exit 0
@@ -106,7 +112,8 @@ runs:
         # a log shipper or proxy has nothing to do here and would keep the task
         # RUNNING after the migration container exits, so the task never stops.
         NEW_TASK_DEF=$(echo "$TASK_DEF" \
-          | ECR_REPO_PREFIX="$ECR_REPO_PREFIX" \
+          | LOG_GROUP="$LOG_GROUP" LOG_PREFIX="$LOG_PREFIX" REGION="$REGION" \
+            ECR_REPO_PREFIX="$ECR_REPO_PREFIX" \
             GHCR_REPO_PREFIX="$GHCR_REPO_PREFIX" \
             GHCR_CREDENTIALS_ARN="$GHCR_CREDENTIALS_ARN" \
             IMAGE="$IMAGE" python3 -c "
@@ -138,6 +145,22 @@ runs:
         # A migration task must not be restarted or health-checked as a service.
         c.pop('healthCheck', None)
         c['portMappings'] = []
+
+        # Log to CloudWatch, whatever the service uses. India prod's task
+        # definition is json-file, which keeps stdout on the EC2 instance where
+        # neither this workflow nor the ECS API can read it -- a failed migration
+        # would report an exit code and nothing else. Overriding here changes
+        # logging for THIS task only: the family is renamed below, the service's
+        # own task definition is never modified, and the app keeps json-file.
+        c['logConfiguration'] = {
+            'logDriver': 'awslogs',
+            'options': {
+                'awslogs-group': os.environ['LOG_GROUP'],
+                'awslogs-region': os.environ['REGION'],
+                'awslogs-stream-prefix': os.environ['LOG_PREFIX'],
+            },
+        }
+        c.pop('secretOptions', None)
         td['containerDefinitions'] = [c]
 
         # Separate family so migration revisions never appear in the service's
@@ -194,6 +217,24 @@ runs:
           fi
         fi
 
+        # The group MUST exist before the task starts. With the awslogs driver a
+        # missing group is a CONTAINER START failure, and the error looks nothing
+        # like a logging problem. It has to be created here rather than by the
+        # task: on EC2 launch type the awslogs driver uses the container
+        # INSTANCE's role (AmazonEC2ContainerServiceforEC2Role), which grants
+        # CreateLogStream and PutLogEvents but NOT CreateLogGroup.
+        aws logs create-log-group --log-group-name "$LOG_GROUP" --region "$REGION" 2>/dev/null || true
+        aws logs put-retention-policy --log-group-name "$LOG_GROUP" \
+          --retention-in-days 30 --region "$REGION" 2>/dev/null || true
+        if ! aws logs describe-log-groups --log-group-name-prefix "$LOG_GROUP" --region "$REGION" \
+             --query "logGroups[?logGroupName=='$LOG_GROUP'].logGroupName" --output text | grep -q .; then
+          echo "  ERROR: log group $LOG_GROUP does not exist and could not be created." >&2
+          echo "         The migration task would fail to START with the awslogs driver," >&2
+          echo "         with an error that does not mention logging. Grant" >&2
+          echo "         logs:CreateLogGroup and logs:DescribeLogGroups to this role." >&2
+          exit 1
+        fi
+
         TASK=$(aws "${RUN_ARGS[@]}" --query 'tasks[0].taskArn' --output text)
         if [ -z "$TASK" ] || [ "$TASK" = "None" ]; then
           echo "  ERROR: run-task returned no task; check cluster capacity and failures above" >&2
@@ -221,20 +262,6 @@ runs:
         # Print the migration's own output. Without this a failure shows only an
         # exit code, and the message that says which migration broke -- or that the
         # database was never adopted -- stays in CloudWatch where nobody looks.
-        LOG_CFG=$(echo "$TASK_DEF" | ECR_REPO_PREFIX="$ECR_REPO_PREFIX" GHCR_REPO_PREFIX="$GHCR_REPO_PREFIX" python3 -c "
-        import json, sys, os
-        ecr_prefix  = os.environ['ECR_REPO_PREFIX']
-        ghcr_prefix = os.environ['GHCR_REPO_PREFIX']
-        td = json.load(sys.stdin)
-        for c in td['containerDefinitions']:
-            if c.get('image','').startswith(ecr_prefix) or c.get('image','').startswith(ghcr_prefix):
-                o = (c.get('logConfiguration') or {}).get('options', {})
-                print(o.get('awslogs-group',''))
-                print(o.get('awslogs-stream-prefix',''))
-                break
-        ")
-        LOG_GROUP=$(echo "$LOG_CFG" | sed -n '1p')
-        LOG_PREFIX=$(echo "$LOG_CFG" | sed -n '2p')
 
         if [ -n "$LOG_GROUP" ] && [ -n "$LOG_PREFIX" ]; then
           echo "  ---- migration output ----"


### PR DESCRIPTION
The migrate task inherited the app service's `logConfiguration`, which is **`json-file`** on India prod. That keeps stdout on the EC2 instance, where neither this workflow nor the ECS API can read it — so a failed migration reports an exit code and nothing else. No indication of which migration broke, or that the database was simply never adopted.

Confirmed on 2026-09-02: a rehearsal task against India prod exited 0 with **no readable output at all**.

## The change

The migrate container is forced to `awslogs` at `/ecs/flexprice-migrate`.

**Scoped to this task only.** The action renames the family to `*-migrate` and never modifies the service's own task definition — it only reads it. Verified after the rehearsal: every service still runs `json-file` on its own family.

```
flexprice-api-v4                web_api:768           json-file
preprod-flexprice-api-service   web_api:767           json-file
flexprice-consumer-v1           web_consumer:679      json-file
temporal-worker                 temporal_worker:497   json-file
families: web_api, web_api-migrate
```

**The log group is created before `run-task`, and the step fails if it isn't there afterwards.** With the awslogs driver a missing group is a container **start** failure whose error mentions nothing about logging. It must be created here rather than by the task: on **EC2 launch type the awslogs driver uses the container instance's role** (`AmazonEC2ContainerServiceforEC2Role`), which grants `CreateLogStream` and `PutLogEvents` but **not** `CreateLogGroup`.

**Retention 30 days**, so this can't accumulate silently across regions and clients. Volume is ~1–2 KB per run — fractions of a cent.

**The `LOG_CFG` extraction is deleted.** It derived the group and prefix from the service's task definition — which is exactly the `json-file` config that made this unreadable. Two constants replace a Python block.

## Requires an IAM change

`GitHubActionsECRDeployPolicy` needs two more actions, scoped to the one group. `CreateLogGroup` is already granted.

```json
{ "Sid": "ReadMigrationLogs",
  "Action": ["logs:GetLogEvents", "logs:DescribeLogGroups"],
  "Resource": "arn:aws:logs:ap-south-1:851725232919:log-group:/ecs/flexprice-migrate:*" }
```

The account is at **5 of 5 policy versions**, so a version must be pruned first. Without this the step fails at the group check with a message naming the missing permissions.

## Verified

- `bash -n` passes; all four embedded Python blocks compile
- the transform against the **real** `web_api` task definition yields `awslogs`, GHCR pull credentials preserved, and all **27 secrets** and **158 environment variables** intact
- diff of the proposed policy against live v5: 8 of 8 existing statements identical, 1 added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration task logs now consistently use a dedicated CloudWatch log group and stream prefix.
  * Migration runs now create the required log group when needed and handle existing groups gracefully.
  * Added a best-effort 30-day retention policy for migration logs.
  * Improved migration container logging configuration for more reliable output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->