### PR TITLE
refactor(api): private invoice modification handler behind executor interface

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -33,7 +33,7 @@ type Handlers struct {
 	Subscription             *v1.SubscriptionHandler
 	SubscriptionChange       *v1.SubscriptionChangeHandler
 	SubscriptionModification *v1.SubscriptionModificationHandler
-	InvoiceModification      *v1.InvoiceModificationHandler
+	InvoiceModification      v1.InvoiceModificationExecutor
 	SubscriptionSchedule     *v1.SubscriptionScheduleHandler
 	Wallet                   *v1.WalletHandler
 	Tenant                   *v1.TenantHandler

--- a/internal/api/v1/invoice_modification.go
+++ b/internal/api/v1/invoice_modification.go
@@ -10,18 +10,22 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// InvoiceModificationHandler handles API requests for draft invoice modifications.
-type InvoiceModificationHandler struct {
+// InvoiceModificationExecutor is the router-facing surface of the invoice
+// modification handler; the concrete type stays private per repo convention.
+type InvoiceModificationExecutor interface {
+	Execute(c *gin.Context)
+}
+
+type invoiceModificationHandler struct {
 	invoiceService service.InvoiceService
 	log            *logger.Logger
 }
 
-// NewInvoiceModificationHandler creates a new InvoiceModificationHandler.
 func NewInvoiceModificationHandler(
 	invoiceService service.InvoiceService,
 	log *logger.Logger,
-) *InvoiceModificationHandler {
-	return &InvoiceModificationHandler{
+) InvoiceModificationExecutor {
+	return &invoiceModificationHandler{
 		invoiceService: invoiceService,
 		log:            log,
 	}
@@ -42,7 +46,7 @@ func NewInvoiceModificationHandler(
 // @Failure 404 {object} ierr.ErrorResponse "Resource not found"
 // @Failure 500 {object} ierr.ErrorResponse "Server error"
 // @Router /invoices/{id}/modify/execute [post]
-func (h *InvoiceModificationHandler) Execute(c *gin.Context) {
+func (h *invoiceModificationHandler) Execute(c *gin.Context) {
 	invoiceID := c.Param("id")
 	if invoiceID == "" {
 		c.Error(ierr.NewError("invoice ID is required").


### PR DESCRIPTION
Addresses the CodeRabbit findings on the invoice modification handler from release PR #2740 (the handler merged to develop via #2668):

- **Private struct** (AGENTS.md rule 1: newly created structs stay private): `InvoiceModificationHandler` → `invoiceModificationHandler`, exposed to the router through a new `InvoiceModificationExecutor` interface returned by the constructor; `api.Handlers.InvoiceModification` now stores the interface.
- **Boilerplate comments removed** (AGENTS.md rule 3: no comments on obvious structs/constructors).

The third finding (replace `c.Error` with `c.JSON(gin.H{...})`) is intentionally **not** applied: every handler in `internal/api/v1` uses `c.Error` + the ErrorHandler middleware, which serializes typed `ierr.ErrorResponse` bodies with correct status mapping — exactly what the endpoint's swagger `@Failure` annotations document. Switching to `gin.H{"error": ...}` would break that contract.

No behavior change; `go build ./internal/... ./cmd/...`, `go vet`, and the invoice modification test suite all pass. Swagger annotations are untouched (operation unchanged), so no spec regen needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated invoice modification handling to use a more flexible internal abstraction.
  - Existing invoice modification execution behavior remains unchanged.
  - No user-facing functionality or workflows were added, removed, or modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->