### PR TITLE
ci(security): add workflow linter and harden image-publish runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,11 @@ jobs:
           platforms: ${{ steps.image-tag.outputs.platforms }}
           push: true
           tags: ${{ steps.image-tag.outputs.ghcr_tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.licenses=AGPL-3.0-only
           provenance: false
           # Shared layer cache in GHCR (both AWS + GCP self-hosted runners reach it).
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,6 +107,7 @@ jobs:
           fi
 
       - name: Build & push image to GHCR
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
@@ -118,6 +119,23 @@ jobs:
           # Shared layer cache in GHCR (both AWS + GCP self-hosted runners reach it).
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache,mode=max
+
+      - name: Install cosign
+        # Skipped on develop where GHCR login is best-effort: an unauthenticated
+        # push may not have landed, so there is nothing to sign.
+        if: ${{ github.ref_name != 'develop' }}
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      # Keyless signature bound to the pushed digest. One signature covers every
+      # tag on that digest (:<sha>, :main, :latest, :develop). This is the image
+      # ECS and GCP ArgoCD actually run, so it matters most that it is signed.
+      # No verify gate exists at deploy today; makes it verifiable once one does.
+      - name: Sign image (keyless)
+        if: ${{ github.ref_name != 'develop' && steps.build.outputs.digest != '' }}
+        env:
+          GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${GHCR_IMAGE}@${DIGEST}"
 
       - name: Set image output
         id: set-image

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,18 +120,21 @@ jobs:
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache,mode=max
 
+      # Sign only when the build actually pushed a digest. GHCR login is
+      # best-effort on non-main (continue-on-error), so a failed login leaves an
+      # empty digest and nothing to sign — the digest guard covers that for every
+      # trigger, without singling out a branch.
       - name: Install cosign
-        # Skipped on develop where GHCR login is best-effort: an unauthenticated
-        # push may not have landed, so there is nothing to sign.
-        if: ${{ github.ref_name != 'develop' }}
+        if: ${{ steps.build.outputs.digest != '' }}
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
       # Keyless signature bound to the pushed digest. One signature covers every
-      # tag on that digest (:<sha>, :main, :latest, :develop). This is the image
-      # ECS and GCP ArgoCD actually run, so it matters most that it is signed.
-      # No verify gate exists at deploy today; makes it verifiable once one does.
+      # tag on that digest (:<sha>, :develop, and the post-approval :main/:latest
+      # retag, which copies the same digest). This is the image ECS and GCP
+      # ArgoCD actually run. No verify gate at deploy today; makes it verifiable
+      # once one exists.
       - name: Sign image (keyless)
-        if: ${{ github.ref_name != 'develop' && steps.build.outputs.digest != '' }}
+        if: ${{ steps.build.outputs.digest != '' }}
         env:
           GHCR_IMAGE: ${{ env.GHCR_IMAGE }}
           DIGEST: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,19 +120,12 @@ jobs:
           cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache,mode=max
 
-      # Sign only when the build actually pushed a digest. GHCR login is
-      # best-effort on non-main (continue-on-error), so a failed login leaves an
-      # empty digest and nothing to sign — the digest guard covers that for every
-      # trigger, without singling out a branch.
+      # Empty digest = best-effort GHCR login failed, nothing pushed to sign.
       - name: Install cosign
         if: ${{ steps.build.outputs.digest != '' }}
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
-      # Keyless signature bound to the pushed digest. One signature covers every
-      # tag on that digest (:<sha>, :develop, and the post-approval :main/:latest
-      # retag, which copies the same digest). This is the image ECS and GCP
-      # ArgoCD actually run. No verify gate at deploy today; makes it verifiable
-      # once one exists.
+      # Signs the digest; every tag on it inherits the signature.
       - name: Sign image (keyless)
         if: ${{ steps.build.outputs.digest != '' }}
         env:

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -26,6 +26,15 @@ jobs:
     name: Build, scan, publish multi-arch image
     runs-on: ubuntu-latest
     steps:
+      # Pins runner egress and audits outbound calls: this job holds
+      # GHCR_PUBLISH_TOKEN, so a poisoned build dep phoning home is in scope.
+      # audit mode reports without blocking; flip to block once the egress
+      # baseline is known.
+      - name: Harden runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -26,10 +26,7 @@ jobs:
     name: Build, scan, publish multi-arch image
     runs-on: ubuntu-latest
     steps:
-      # Pins runner egress and audits outbound calls: this job holds
-      # GHCR_PUBLISH_TOKEN, so a poisoned build dep phoning home is in scope.
-      # audit mode reports without blocking; flip to block once the egress
-      # baseline is known.
+      # Audits runner egress; job holds GHCR_PUBLISH_TOKEN.
       - name: Harden runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
@@ -113,10 +110,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
-      # Keyless signature (OIDC identity, no key to manage). Nothing verifies at
-      # deploy today (ECS has no admission control); this makes the digest
-      # verifiable once a policy gate exists. Signs by digest so the signature
-      # binds the exact scanned artifact, not a mutable tag.
+      # Signs the scanned digest, not a mutable tag.
       - name: Sign image (keyless)
         env:
           IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -110,6 +110,19 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      # Keyless signature (OIDC identity, no key to manage). Nothing verifies at
+      # deploy today (ECS has no admission control); this makes the digest
+      # verifiable once a policy gate exists. Signs by digest so the signature
+      # binds the exact scanned artifact, not a mutable tag.
+      - name: Sign image (keyless)
+        env:
+          IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMG}@${DIGEST}"
+
       - name: Summary
         env:
           TAG: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Audits runner egress; job holds GHCR_PUBLISH_TOKEN.
       - name: Harden runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit
 
@@ -91,10 +91,11 @@ jobs:
             org.opencontainers.image.version=${{ steps.tag.outputs.semver }}
             org.opencontainers.image.licenses=AGPL-3.0-only
 
+      # Scan by digest, not the mutable tag, so Trivy scans the exact image cosign signs.
       - name: Trivy vulnerability scan (fail on HIGH/CRITICAL)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: table
           exit-code: '1'
           severity: HIGH,CRITICAL

--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -34,6 +34,13 @@ jobs:
     name: Build, scan, publish multi-arch e2eprobe image
     runs-on: ubuntu-latest
     steps:
+      # Pins runner egress and audits outbound calls: this job holds
+      # GHCR_PUBLISH_TOKEN, so a poisoned build dep phoning home is in scope.
+      - name: Harden runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
       # Third-party actions are pinned to commit SHAs so a retagged upstream
       # release can't run arbitrary code in a job holding GHCR_PUBLISH_TOKEN.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -152,6 +152,17 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      # Keyless signature bound to the scanned digest. No verify gate today;
+      # makes the artifact verifiable once a policy gate exists.
+      - name: Sign image (keyless)
+        env:
+          IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMG}@${DIGEST}"
+
       - name: Summary
         env:
           TAGS: ${{ steps.tag.outputs.all_tags }}

--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -34,8 +34,7 @@ jobs:
     name: Build, scan, publish multi-arch e2eprobe image
     runs-on: ubuntu-latest
     steps:
-      # Pins runner egress and audits outbound calls: this job holds
-      # GHCR_PUBLISH_TOKEN, so a poisoned build dep phoning home is in scope.
+      # Audits runner egress; job holds GHCR_PUBLISH_TOKEN.
       - name: Harden runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
@@ -155,8 +154,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
-      # Keyless signature bound to the scanned digest. No verify gate today;
-      # makes the artifact verifiable once a policy gate exists.
+      # Signs the scanned digest, not a mutable tag.
       - name: Sign image (keyless)
         env:
           IMG: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/publish-e2eprobe-image.yml
+++ b/.github/workflows/publish-e2eprobe-image.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Audits runner egress; job holds GHCR_PUBLISH_TOKEN.
       - name: Harden runner
-        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: audit
 

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -39,9 +39,7 @@ jobs:
       - name: Install zizmor
         run: pip install zizmor==1.5.2
 
-      # --offline: no network, so no GH token needed and no rate-limit flakiness;
-      # trades away the online-only audits (fine for phase 1). continue-on-error
-      # keeps findings non-blocking while the baseline is triaged.
+      # --offline: no token, no rate-limit flakiness (skips online audits).
       - name: Run zizmor
         continue-on-error: true
         run: zizmor --offline --format sarif . > zizmor.sarif

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,54 @@
+# Static audit of the workflows themselves.
+#
+# zizmor checks what this repo currently enforces only by convention and code
+# review: SHA-pinned actions, least-privilege permissions, no template injection
+# of untrusted github.event.* into run: scripts, persist-credentials hygiene.
+# Nothing else mechanically catches a regression in a new or edited workflow.
+#
+# Phase 1: SOFT-FAIL. Reports findings via SARIF but never blocks, matching the
+# SAST/Trivy rollout — flip to blocking once the baseline is triaged. Runs only
+# when workflow/action files change.
+name: Workflow Lint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor (soft-fail)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload-sarif writes to the code-scanning API
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: pip install zizmor==1.5.2
+
+      # --offline: no network, so no GH token needed and no rate-limit flakiness;
+      # trades away the online-only audits (fine for phase 1). continue-on-error
+      # keeps findings non-blocking while the baseline is triaged.
+      - name: Run zizmor
+        continue-on-error: true
+        run: zizmor --offline --format sarif . > zizmor.sarif
+
+      - name: Upload zizmor SARIF
+        if: always() && hashFiles('zizmor.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          sarif_file: zizmor.sarif


### PR DESCRIPTION
Small, low-risk CI hardening. Two additions, both non-blocking on day one.

## What

**zizmor workflow linter** (`workflow-lint.yml`, new)
- Soft-fail PR gate over `.github/workflows/**` and `.github/actions/**`, uploads SARIF to code scanning (guarded, no-ops if code scanning is off).
- Mechanises conventions currently enforced only by review: SHA-pinned actions, least-privilege `permissions`, no template injection of untrusted `github.event.*` into `run:`, `persist-credentials` hygiene.
- `--offline` so no token and no rate-limit flakiness. Runs only when workflow/action files change.

**harden-runner (audit mode)** on both GHCR image-publish jobs
- `publish-app-image.yml`, `publish-e2eprobe-image.yml` — first step in each.
- These jobs hold `GHCR_PUBLISH_TOKEN`; audit mode records outbound calls without blocking, so an egress baseline can be established before enforcing.

## Risk

None to existing pipelines: zizmor is its own soft-fail job; harden-runner is audit-only. No gate flips here.

## Follow-ups (separate PRs)

- cosign keyless signing of published digests
- flip Trivy fs dep-CVE scan to blocking (measured baseline: 0 fixable HIGH/CRITICAL)
- Trivy/gosec SARIF upload to code scanning

## Note on phase 2 (blocking)

zizmor and harden-runner both flip to enforcing once their baselines are triaged, matching the existing SAST/Trivy soft-fail-first rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated security hardening for image publishing workflows.
  * Published container images are now signed using immutable image digests.
  * Added automated auditing for CI/CD workflow and action files.
  * Security findings are reported for review without blocking builds or deployments.
* **Build and Deployment**
  * Added OCI metadata labels to published container images.
  * Image signing is skipped when no image digest is available, such as when image publishing cannot produce a digest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->