### PR TITLE
fix(tls): set MinVersion TLS 1.2 on ClickHouse + integration HTTP client

### DIFF
--- a/integration-testing-suite/go/http_client.go
+++ b/integration-testing-suite/go/http_client.go
@@ -18,7 +18,7 @@ func newHTTPClient(insecure bool) *http.Client {
 	c := &http.Client{Timeout: 30 * time.Second}
 	if insecure {
 		c.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // opt-in via insecure flag
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: true}, //nolint:gosec // opt-in via insecure flag
 		}
 	}
 	return c

--- a/internal/config/clickhouse_config_test.go
+++ b/internal/config/clickhouse_config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
@@ -65,4 +66,29 @@ func TestClickHouseConfig_GetClientOptions_MaxMemoryUsage(t *testing.T) {
 	if got != wantMaxMemoryUsageBytes {
 		t.Errorf("max_memory_usage: got %d, want %d (50 GB)", got, wantMaxMemoryUsageBytes)
 	}
+}
+
+// TLS is only configured when enabled, and always pins a TLS 1.2 floor.
+func TestClickHouseConfig_GetClientOptions_TLS(t *testing.T) {
+	base := ClickHouseConfig{Address: "127.0.0.1:9440", Username: "u", Password: "p", Database: "d", MaxMemoryUsage: 50}
+
+	t.Run("TLS off leaves options.TLS nil", func(t *testing.T) {
+		c := base
+		c.TLS = false
+		if got := c.GetClientOptions().TLS; got != nil {
+			t.Errorf("TLS = %v, want nil when disabled", got)
+		}
+	})
+
+	t.Run("TLS on pins MinVersion 1.2", func(t *testing.T) {
+		c := base
+		c.TLS = true
+		opts := c.GetClientOptions()
+		if opts.TLS == nil {
+			t.Fatal("TLS = nil, want set when enabled")
+		}
+		if opts.TLS.MinVersion != tls.VersionTLS12 {
+			t.Errorf("MinVersion = %d, want TLS 1.2", opts.TLS.MinVersion)
+		}
+	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1341,7 +1341,7 @@ func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 		options.ReadTimeout = c.ReadTimeout
 	}
 	if c.TLS {
-		options.TLS = &tls.Config{InsecureSkipVerify: c.TLSSkipVerify} // #nosec G402 -- opt-in, dev-only self-signed certs
+		options.TLS = &tls.Config{MinVersion: tls.VersionTLS12, InsecureSkipVerify: c.TLSSkipVerify} // #nosec G402 -- opt-in, dev-only self-signed certs
 	}
 	options.Protocol = c.protocol()
 


### PR DESCRIPTION
Second fix from the SAST baseline triage — semgrep `missing-ssl-minversion`.

## Problem

Two `tls.Config` values were constructed without a `MinVersion`, so the Go default allows negotiating down to TLS 1.0/1.1:
- `internal/config/config.go` — ClickHouse client TLS
- `integration-testing-suite/go/http_client.go` — the insecure test HTTP client

## Fix

Add `MinVersion: tls.VersionTLS12` to both. No change to verify behaviour — each keeps its existing opt-in skip-verify flag and its `#nosec`/`//nolint:gosec` justification. This PR is purely the min-version floor.

Other internal TLS sites (redis, kafka, temporal) already set MinVersion TLS 1.2 — redis was handled in #2750.

## Verification

- `go build ./internal/config/...` — clean
- `cd integration-testing-suite/go && go build ./...` — clean

## Scope

One finding class, two sites. Remaining gosec/semgrep baseline items are separate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated HTTP and ClickHouse TLS connections to require TLS 1.2 or newer, improving connection security.
  * Preserved the existing option to skip certificate verification when explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->