### PR TITLE
fix(security): annotate taint findings as verified false positives

### DIFF
--- a/cmd/migrate/clickhouse.go
+++ b/cmd/migrate/clickhouse.go
@@ -132,7 +132,7 @@ func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir
 	}
 
 	for _, f := range files {
-		raw, err := os.ReadFile(f) // #nosec G304 -- migration file from dir walk
+		raw, err := os.ReadFile(f) // #nosec G304 -- migration file from configured dir glob, CLI tool not a request handler
 		if err != nil {
 			return fmt.Errorf("read %s: %w", f, err)
 		}

--- a/cmd/migrate/clickhouse.go
+++ b/cmd/migrate/clickhouse.go
@@ -132,7 +132,7 @@ func runClickHouseMigrations(ctx context.Context, cfg *config.Configuration, dir
 	}
 
 	for _, f := range files {
-		raw, err := os.ReadFile(f)
+		raw, err := os.ReadFile(f) // #nosec G304 -- migration file from dir walk
 		if err != nil {
 			return fmt.Errorf("read %s: %w", f, err)
 		}

--- a/cmd/migrate/postgres.go
+++ b/cmd/migrate/postgres.go
@@ -67,7 +67,7 @@ func runPostgresSQLFile(file string, dryRun bool, timeout int) error {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
 
-	raw, err := os.ReadFile(file)
+	raw, err := os.ReadFile(file) // #nosec G304 -- migration file from dir walk
 	if err != nil {
 		return fmt.Errorf("read %s: %w", file, err)
 	}

--- a/cmd/migrate/postgres.go
+++ b/cmd/migrate/postgres.go
@@ -67,7 +67,7 @@ func runPostgresSQLFile(file string, dryRun bool, timeout int) error {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
 
-	raw, err := os.ReadFile(file) // #nosec G304 -- migration file from dir walk
+	raw, err := os.ReadFile(file) // #nosec G304 -- operator-supplied --file flag, CLI tool not a request handler
 	if err != nil {
 		return fmt.Errorf("read %s: %w", file, err)
 	}

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -37,7 +37,7 @@ func NewRBACService(cfg *config.Configuration) (*RBACService, error) {
 	}
 
 	// Load JSON
-	data, err := os.ReadFile(configPath)
+	data, err := os.ReadFile(configPath) // #nosec G304 -- config path, not user input
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config: %w", err)
 	}

--- a/internal/typst/typst.go
+++ b/internal/typst/typst.go
@@ -102,7 +102,7 @@ func (c *compiler) Compile(opts CompileOpts) (string, error) {
 	outputFile := filepath.Join(c.outputDir, opts.OutputFile)
 	if opts.OutputFile == "" {
 		tmpFilePath := filepath.Join(c.outputDir, fmt.Sprintf("typst-%d.pdf", time.Now().UnixMilli()))
-		tmpFile, err := os.Create(tmpFilePath)
+		tmpFile, err := os.Create(tmpFilePath) // #nosec G304 -- code-generated temp path
 		if err != nil {
 			return "", ierr.WithError(err).
 				WithMessage("failed to create temporary output file").
@@ -161,7 +161,7 @@ func (c *compiler) CompileToBytes(opts CompileOpts) ([]byte, error) {
 		return nil, err
 	}
 	defer os.Remove(pdfPath)
-	return os.ReadFile(pdfPath)
+	return os.ReadFile(pdfPath) // #nosec G304 -- compiler output path, code-controlled
 }
 
 // CompileTemplate compiles a Typst template with the provided data
@@ -264,7 +264,7 @@ func CopyDir(src, dst string) error {
 
 // CopyFile copies a file from src to dst
 func CopyFile(src, dst string) error {
-	sourceFile, err := os.Open(src)
+	sourceFile, err := os.Open(src) // #nosec G304 -- internal asset copy, not user input
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,7 @@ func CopyFile(src, dst string) error {
 		return fmt.Errorf("failed to create destination directory: %w", err)
 	}
 
-	destFile, err := os.Create(dst)
+	destFile, err := os.Create(dst) // #nosec G304 -- internal asset copy, not user input
 	if err != nil {
 		return err
 	}

--- a/scripts/internal/credit_usage_report.go
+++ b/scripts/internal/credit_usage_report.go
@@ -156,7 +156,7 @@ func GenerateCreditUsageReport() error {
 
 // generateCSVReport generates a CSV file from the report data
 func generateCSVReport(data []CreditUsageReportData, filename string) error {
-	file, err := os.Create(filename)
+	file, err := os.Create(filename) // #nosec G703,G304 -- CLI file path, dev tooling
 	if err != nil {
 		return fmt.Errorf("failed to create CSV file: %w", err)
 	}

--- a/scripts/internal/csv_feature_processor.go
+++ b/scripts/internal/csv_feature_processor.go
@@ -181,7 +181,7 @@ func newCSVFeatureProcessor(tenantID, environmentID, userID string) (*CSVFeature
 
 // parseCSV parses the CSV file
 func (p *CSVFeatureProcessor) parseCSV(filePath string) ([]CSVFeatureRecord, error) {
-	file, err := os.Open(filePath)
+	file, err := os.Open(filePath) // #nosec G703,G304 -- CLI file path, dev tooling
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}

--- a/scripts/internal/feature_import.go
+++ b/scripts/internal/feature_import.go
@@ -131,7 +131,7 @@ func newFeatureImportScript(tenantID, environmentID, planID string) (*featureImp
 
 // parseFeatureCSV parses the feature CSV file
 func (s *featureImportScript) parseFeatureCSV(filePath string) ([]FeatureRow, error) {
-	file, err := os.Open(filePath)
+	file, err := os.Open(filePath) // #nosec G703,G304 -- CLI file path, dev import tooling
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}

--- a/scripts/internal/migrate_invoice_sequences.go
+++ b/scripts/internal/migrate_invoice_sequences.go
@@ -161,7 +161,7 @@ func MigrateInvoiceSequences() error {
 		timestamp := time.Now().Format("20060102_150405")
 		filename := filepath.Join("scripts", "internal", fmt.Sprintf("invoice_sequence_dry_run_%s.json", timestamp))
 
-		file, err := os.Create(filename)
+		file, err := os.Create(filename) // #nosec G304 -- CLI/script file path, dev tooling
 		if err != nil {
 			return fmt.Errorf("failed to create output file: %w", err)
 		}

--- a/scripts/internal/pricing_import.go
+++ b/scripts/internal/pricing_import.go
@@ -116,7 +116,7 @@ func newPricingImportScript(tenantID, environmentID string) (*pricingImportScrip
 
 // parsePricingCSV parses the pricing CSV file
 func (s *pricingImportScript) parsePricingCSV(filePath string) ([]PricingRow, error) {
-	file, err := os.Open(filePath)
+	file, err := os.Open(filePath) // #nosec G703,G304 -- CLI file path, dev import tooling
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}

--- a/scripts/internal/replay_events_csv.go
+++ b/scripts/internal/replay_events_csv.go
@@ -54,7 +54,7 @@ func ReplayEventsFromCSV() error {
 
 	dryRun := strings.EqualFold(os.Getenv("DRY_RUN"), "true")
 
-	f, err := os.Open(filePath)
+	f, err := os.Open(filePath) // #nosec G703,G304 -- CLI/env file path, dev tooling
 	if err != nil {
 		return fmt.Errorf("open csv %s: %w", filePath, err)
 	}
@@ -242,7 +242,7 @@ func postSingleEvent(client *http.Client, endpoint, apiKey string, event *dto.In
 			time.Sleep(replayInitialBackoff * time.Duration(attempt))
 		}
 
-		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body)) // #nosec G704 -- endpoint from env, replays to own API
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
 		}
@@ -250,7 +250,7 @@ func postSingleEvent(client *http.Client, endpoint, apiKey string, event *dto.In
 		req.Header.Set("Accept", "application/json")
 		req.Header.Set("x-api-key", apiKey)
 
-		resp, err := client.Do(req)
+		resp, err := client.Do(req) // #nosec G704 -- endpoint from env, replays to own API
 		if err != nil {
 			lastErr = fmt.Errorf("http: %w", err)
 			continue

--- a/scripts/internal/replay_events_csv.go
+++ b/scripts/internal/replay_events_csv.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"bytes"
+	"context"
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
@@ -242,7 +243,7 @@ func postSingleEvent(client *http.Client, endpoint, apiKey string, event *dto.In
 			time.Sleep(replayInitialBackoff * time.Duration(attempt))
 		}
 
-		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body)) // #nosec G704 -- endpoint from env, replays to own API
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, endpoint, bytes.NewReader(body)) // #nosec G704 -- endpoint from env, replays to own API
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
 		}

--- a/scripts/manual/main.go
+++ b/scripts/manual/main.go
@@ -118,7 +118,7 @@ func main() {
 // - An ordered slice of all rows (to preserve original ordering)
 // - A map of feature_name -> OldRow (for quick lookup)
 func readOldCSV(path string) ([]OldRow, map[string]OldRow) {
-	file, err := os.Open(path)
+	file, err := os.Open(path) // #nosec G304 -- CLI file path, manual ops tooling
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: Cannot open old CSV %s: %v\n", path, err)
 		os.Exit(1)
@@ -204,7 +204,7 @@ func readAndTransformNewCSV(path string) map[string]TransformedNewRow {
 
 // readNewCSVRaw reads the client's CSV file (no header, 3 columns) with corruption handling.
 func readNewCSVRaw(path string) []RawNewRow {
-	rawBytes, err := os.ReadFile(path)
+	rawBytes, err := os.ReadFile(path) // #nosec G304 -- CLI file path, manual ops tooling
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: Cannot read new CSV %s: %v\n", path, err)
 		os.Exit(1)
@@ -401,7 +401,7 @@ func normalizePriceForCompare(price string) string {
 // ============================================================================
 
 func writeOutputCSV(path string, rows []OutputRow) {
-	file, err := os.Create(path)
+	file, err := os.Create(path) // #nosec G304 -- CLI file path, manual ops tooling
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: Cannot create output CSV %s: %v\n", path, err)
 		os.Exit(1)


### PR DESCRIPTION
Batch A of the SAST triage — the HIGH-severity taint findings (gosec G304 file-inclusion, G703 path-traversal, G704 SSRF).

## Finding: none are exploitable

Every site was traced to the source of its path/URL variable. None is reachable from an HTTP request handler with untrusted input:

| Area | Why it is a false positive |
|---|---|
| `internal/rbac/rbac.go:40` | `roles.json` path from `cfg.RBAC.RolesConfigPath` (config), not request input |
| `internal/typst/typst.go` (×4) | code-generated temp/output paths; template name is a **typed enum** run through `filepath.Base`; internal asset copy |
| `cmd/migrate/*` (×2) | migration files from the migrate tool’s own directory walk |
| `scripts/internal/*`, `scripts/manual` | operator-run import/replay/ops CLIs; paths + URLs come from CLI flags / env vars (`FILE_PATH`, `API_BASE_URL`, …), never a web request. The replay SSRF target is our own API by design |

## Change

Each site gets a `// #nosec <RULE> -- <reason>` explaining why the taint cannot carry attacker input to the sink. No behaviour change; no generated files touched (learned from #2752 — `ent/*` generated files are never hand-edited).

Related: the `dangerous-exec-command` twin on `typst.go` (invoice-PDF path) was analysed the same way and dismissed as code-scanning alert #222 — invoice data reaches typst as JSON file *content*, never argv, and `exec.Command` uses no shell.

## Verification

- `go build ./internal/... ./scripts/... ./cmd/...` — clean
- `go test ./internal/typst/...` — pass
- `gosec` G304 / G703 / G704 → **0**

## Scope

One rule-class cluster. Remaining baseline items (G115 int-overflow, G404 weak-RNG, Dockerfile) are separate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Clarified approved file-access patterns for migration, RBAC, reporting, import, and replay workflows to improve security analysis.
  - Documented accepted CLI-provided and internally controlled file paths across supported tools.
- **Maintenance**
  - Added request context support to event replay operations.
  - Runtime behavior, parsing, file handling, HTTP behavior, and error handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->