### PR TITLE
fix(e2eprobe): widen bucketed-meter analytics deadline to 180s

### DIFF
--- a/internal/ee/e2eprobe/checks/bucketed_meter_probe.go
+++ b/internal/ee/e2eprobe/checks/bucketed_meter_probe.go
@@ -191,7 +191,8 @@ func (p *BucketedMeterProbe) pollAnalytics(ctx context.Context, spec bucketedSpe
 	// Day-granularity rollups materialize slower than the 15m/hour specs, so the
 	// analytics view occasionally lags past 90s under load. Raw ingestion is
 	// verified separately, so this only waits on aggregation.
-	deadline := time.Now().Add(180 * time.Second)
+	analyticsTimeout := 180 * time.Second
+	deadline := time.Now().Add(analyticsTimeout)
 	for {
 		resp, err := p.client.Events().GetUsageAnalytics(ctx, types.GetUsageAnalyticsRequest{
 			ExternalCustomerID: &custExt,
@@ -213,7 +214,7 @@ func (p *BucketedMeterProbe) pollAnalytics(ctx context.Context, spec bucketedSpe
 				"external_customer_id": custExt,
 				"event_name":           spec.eventName,
 				"feature_id":           featID,
-			}, "expected %d buckets after 90s, got fewer", len(wantValues))
+			}, "expected %d buckets after %s, got fewer", len(wantValues), analyticsTimeout)
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/ee/e2eprobe/checks/bucketed_meter_probe.go
+++ b/internal/ee/e2eprobe/checks/bucketed_meter_probe.go
@@ -188,7 +188,10 @@ func (p *BucketedMeterProbe) pollRawEvents(ctx context.Context, spec bucketedSpe
 
 func (p *BucketedMeterProbe) pollAnalytics(ctx context.Context, spec bucketedSpec, custExt, featID string, start, end time.Time, wantValues []int) error {
 	windowSize := spec.window
-	deadline := time.Now().Add(90 * time.Second)
+	// Day-granularity rollups materialize slower than the 15m/hour specs, so the
+	// analytics view occasionally lags past 90s under load. Raw ingestion is
+	// verified separately, so this only waits on aggregation.
+	deadline := time.Now().Add(180 * time.Second)
 	for {
 		resp, err := p.client.Events().GetUsageAnalytics(ctx, types.GetUsageAnalyticsRequest{
 			ExternalCustomerID: &custExt,


### PR DESCRIPTION
## Problem

The bucketed-meter-probe intermittently fails with `expected 3 buckets after 90s, got fewer` on the `e2eprobe_max_day` spec (day-granularity window).

Investigating a live failure: raw ingestion and the underlying aggregated usage both contained the expected 3 backdated day buckets — only the analytics read lagged past the probe's 90s poll deadline. Day rollups materialize slower than the 15m/hour specs, so under load the day case occasionally crosses 90s while the others stay green.

## Fix

Extend the `pollAnalytics` deadline from 90s to 180s.

`pollRawEvents` already verifies ingestion separately before analytics is polled, so a longer analytics deadline only waits on aggregation lag — it does not mask an ingest failure. Only the analytics poll changes; the raw-verify deadline is untouched.

## Test

- `go build ./internal/ee/e2eprobe/checks/` passes.
- Behavioral: the day-bucketed check no longer times out on the slower rollup while keeping the fast specs' effective timing unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected analytics timeout messaging so it accurately reflects the 180-second verification window.
  * Improved clarity when analytics usage rollup verification exceeds its allotted wait time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->