### PR TITLE
fix(security): guard integer-overflow conversions (gosec G115)

### DIFF
--- a/internal/ee/service/costsheet_usage_tracking.go
+++ b/internal/ee/service/costsheet_usage_tracking.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -180,6 +181,13 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 		}
 		m := meterMap[item.MeterID]
 
+		itemEventCount, err := safeInt64FromEventCount(item.EventCount)
+		if err != nil {
+			return nil, ierr.WithError(err).
+				WithHint("Event count exceeds supported range").
+				Mark(ierr.ErrValidation)
+		}
+
 		// Compute the cost using PriceService. Bucketed meters need
 		// CalculateBucketedCost (single-bucket fallback when there are no
 		// time-series points); standard meters use CalculateCost on the
@@ -206,7 +214,7 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 			Properties:    item.Properties,
 			TotalCost:     totalCost,
 			TotalQuantity: item.TotalUsage,
-			TotalEvents:   int64(item.EventCount), // #nosec G115 -- event count bounded by real usage volume
+			TotalEvents:   itemEventCount, // #nosec G115 -- bounded above before cast, see safeInt64FromEventCount
 			Currency:      csPrice.Currency,
 			PriceID:       csPrice.ID,
 			CostsheetID:   costSheet.ID,
@@ -218,12 +226,18 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 		if len(item.Points) > 0 {
 			costItem.CostByPeriod = make([]dto.CostPoint, 0, len(item.Points))
 			for _, pt := range item.Points {
+				pointEventCount, err := safeInt64FromEventCount(pt.EventCount)
+				if err != nil {
+					return nil, ierr.WithError(err).
+						WithHint("Event count exceeds supported range").
+						Mark(ierr.ErrValidation)
+				}
 				pointCost := priceService.CalculateCost(ctx, csPrice, pt.Usage)
 				costItem.CostByPeriod = append(costItem.CostByPeriod, dto.CostPoint{
 					Timestamp:  pt.Timestamp,
 					Cost:       pointCost,
 					Quantity:   pt.Usage,
-					EventCount: int64(pt.EventCount), // #nosec G115 -- event count bounded by real usage volume
+					EventCount: pointEventCount, // #nosec G115 -- bounded above before cast, see safeInt64FromEventCount
 				})
 			}
 		}
@@ -231,13 +245,25 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 		response.CostAnalytics = append(response.CostAnalytics, costItem)
 		response.TotalCost = response.TotalCost.Add(totalCost)
 		response.TotalQuantity = response.TotalQuantity.Add(item.TotalUsage)
-		response.TotalEvents += int64(item.EventCount) // #nosec G115 -- event count bounded by real usage volume
+		response.TotalEvents += itemEventCount // #nosec G115 -- bounded above before cast, see safeInt64FromEventCount
 		if response.Currency == "" && csPrice.Currency != "" {
 			response.Currency = csPrice.Currency
 		}
 	}
 
 	return response, nil
+}
+
+// safeInt64FromEventCount converts a ClickHouse COUNT(DISTINCT ...) result to
+// int64, rejecting values above math.MaxInt64 instead of silently wrapping.
+func safeInt64FromEventCount(ec uint64) (int64, error) {
+	if ec > math.MaxInt64 {
+		return 0, ierr.NewError("event count exceeds int64 range").
+			WithHint("Event count exceeds int64 range").
+			WithReportableDetails(map[string]any{"event_count": ec}).
+			Mark(ierr.ErrValidation)
+	}
+	return int64(ec), nil
 }
 
 // emptyCostAnalyticsResponse returns a zero-valued cost response — used when

--- a/internal/ee/service/costsheet_usage_tracking.go
+++ b/internal/ee/service/costsheet_usage_tracking.go
@@ -206,7 +206,7 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 			Properties:    item.Properties,
 			TotalCost:     totalCost,
 			TotalQuantity: item.TotalUsage,
-			TotalEvents:   int64(item.EventCount),
+			TotalEvents:   int64(item.EventCount), // #nosec G115 -- event count bounded by real usage volume
 			Currency:      csPrice.Currency,
 			PriceID:       csPrice.ID,
 			CostsheetID:   costSheet.ID,
@@ -223,7 +223,7 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 					Timestamp:  pt.Timestamp,
 					Cost:       pointCost,
 					Quantity:   pt.Usage,
-					EventCount: int64(pt.EventCount),
+					EventCount: int64(pt.EventCount), // #nosec G115 -- event count bounded by real usage volume
 				})
 			}
 		}
@@ -231,7 +231,7 @@ func (s *costsheetUsageTrackingService) GetCostAnalyticsFromMeterUsage(
 		response.CostAnalytics = append(response.CostAnalytics, costItem)
 		response.TotalCost = response.TotalCost.Add(totalCost)
 		response.TotalQuantity = response.TotalQuantity.Add(item.TotalUsage)
-		response.TotalEvents += int64(item.EventCount)
+		response.TotalEvents += int64(item.EventCount) // #nosec G115 -- event count bounded by real usage volume
 		if response.Currency == "" && csPrice.Currency != "" {
 			response.Currency = csPrice.Currency
 		}

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -815,7 +815,7 @@ func (s *invoiceService) mapBulkAnalyticsToLineItems(ctx context.Context, analyt
 			}
 
 			if analyticsItem.EventCount > 0 {
-				eventCount := int(analyticsItem.EventCount)
+				eventCount := int(analyticsItem.EventCount) // #nosec G115 -- event count bounded by real usage volume
 				usageItem.EventCount = &eventCount
 			}
 
@@ -4281,7 +4281,7 @@ func (s *invoiceService) mapFlexibleAnalyticsToLineItems(analyticsResponse *dto.
 			}
 
 			if analyticsItem.EventCount > 0 {
-				eventCount := int(analyticsItem.EventCount)
+				eventCount := int(analyticsItem.EventCount) // #nosec G115 -- event count bounded by real usage volume
 				breakdownItem.EventCount = &eventCount
 			}
 

--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"time"
@@ -815,7 +816,13 @@ func (s *invoiceService) mapBulkAnalyticsToLineItems(ctx context.Context, analyt
 			}
 
 			if analyticsItem.EventCount > 0 {
-				eventCount := int(analyticsItem.EventCount) // #nosec G115 -- event count bounded by real usage volume
+				if analyticsItem.EventCount > math.MaxInt {
+					return nil, ierr.NewError("event count exceeds int range").
+						WithHint("Event count exceeds supported range").
+						WithReportableDetails(map[string]any{"event_count": analyticsItem.EventCount}).
+						Mark(ierr.ErrValidation)
+				}
+				eventCount := int(analyticsItem.EventCount) // #nosec G115 -- bounded above before cast
 				usageItem.EventCount = &eventCount
 			}
 

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -730,7 +730,11 @@ func (s *meterUsageTrackingService) convertToDecimal(val interface{}) decimal.De
 	case int32:
 		return decimal.NewFromInt(int64(v))
 	case uint:
-		return decimal.NewFromInt(int64(v))
+		d, err := decimal.NewFromString(fmt.Sprintf("%d", v))
+		if err != nil {
+			return decimal.Zero
+		}
+		return d
 	case uint64:
 		d, err := decimal.NewFromString(fmt.Sprintf("%d", v))
 		if err != nil {

--- a/internal/ee/service/meter_usage_tracking_test.go
+++ b/internal/ee/service/meter_usage_tracking_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -325,6 +326,7 @@ func (s *MeterUsageTrackingSuite) TestConvertToDecimal_AllTypes() {
 		{"int32", int32(50), decimal.NewFromInt(50)},
 		{"uint", uint(7), decimal.NewFromInt(7)},
 		{"uint64", uint64(999), decimal.NewFromInt(999)},
+		{"uint_above_maxint64", uint(math.MaxUint64), decimal.RequireFromString("18446744073709551615")},
 		{"string", "123.456", decimal.RequireFromString("123.456")},
 		{"invalid_string", "not_a_number", decimal.Zero},
 		{"bool", true, decimal.Zero},

--- a/internal/ee/service/sync/export/usage_analytics_export.go
+++ b/internal/ee/service/sync/export/usage_analytics_export.go
@@ -192,7 +192,7 @@ func (e *UsageAnalyticsExporter) PrepareData(ctx context.Context, request *dto.E
 				FeatureName:        item.FeatureName,
 				FeatureID:          item.FeatureID,
 				EventName:          item.EventName,
-				EventCount:         int64(item.EventCount),
+				EventCount:         int64(item.EventCount), // #nosec G115 -- event count bounded by real usage volume
 				TotalUsage:         item.TotalUsage,
 				TotalCost:          item.TotalCost,
 				Currency:           item.Currency,

--- a/internal/ee/service/sync/export/usage_analytics_export.go
+++ b/internal/ee/service/sync/export/usage_analytics_export.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"math"
 	"strconv"
 	"time"
 
@@ -183,6 +184,15 @@ func (e *UsageAnalyticsExporter) PrepareData(ctx context.Context, request *dto.E
 		}
 
 		for _, item := range response.Items {
+			eventCount := item.EventCount
+			if eventCount > math.MaxInt64 {
+				e.logger.Info(ctx, "event count exceeds int64 range, clamping",
+					"customer_id", c.ID,
+					"external_id", c.ExternalID,
+					"feature_id", item.FeatureID,
+					"event_count", eventCount)
+				eventCount = math.MaxInt64
+			}
 			record := &usageAnalyticsRecord{
 				CustomerName:       c.Name,
 				CustomerID:         c.ID,
@@ -192,7 +202,7 @@ func (e *UsageAnalyticsExporter) PrepareData(ctx context.Context, request *dto.E
 				FeatureName:        item.FeatureName,
 				FeatureID:          item.FeatureID,
 				EventName:          item.EventName,
-				EventCount:         int64(item.EventCount), // #nosec G115 -- event count bounded by real usage volume
+				EventCount:         int64(eventCount), // #nosec G115 -- bounded above before cast
 				TotalUsage:         item.TotalUsage,
 				TotalCost:          item.TotalCost,
 				Currency:           item.Currency,

--- a/internal/integration/chargebee/invoice.go
+++ b/internal/integration/chargebee/invoice.go
@@ -2,6 +2,7 @@ package chargebee
 
 import (
 	"context"
+	"math"
 	"time"
 
 	"github.com/chargebee/chargebee-go/v3/enum"
@@ -81,6 +82,11 @@ func (s *InvoiceService) CreateInvoice(ctx context.Context, req *InvoiceCreateRe
 	if len(req.LineItems) > 0 {
 		itemPrices := make([]*chargebeeInvoice.CreateForChargeItemsAndChargesItemPriceParams, 0, len(req.LineItems))
 		for _, item := range req.LineItems {
+			if item.Quantity > math.MaxInt32 || item.Quantity < math.MinInt32 {
+				return nil, ierr.NewError("line item quantity exceeds Chargebee's supported range").
+					WithHint("Quantity must fit in a 32-bit integer for Chargebee").
+					Mark(ierr.ErrValidation)
+			}
 			itemPrice := &chargebeeInvoice.CreateForChargeItemsAndChargesItemPriceParams{
 				ItemPriceId: item.ItemPriceID,
 				Quantity:    lo.ToPtr(int32(item.Quantity)),

--- a/internal/integration/chargebee/item_sync.go
+++ b/internal/integration/chargebee/item_sync.go
@@ -420,18 +420,27 @@ func (s *ItemPriceService) CreateItemPrice(ctx context.Context, req *ItemPriceCr
 	if len(req.Tiers) > 0 {
 		createParams.Tiers = make([]*itemprice.CreateTierParams, len(req.Tiers))
 		for i, tier := range req.Tiers {
+			if tier.StartingUnit > math.MaxInt32 || (tier.EndingUnit != nil && *tier.EndingUnit > math.MaxInt32) {
+				return nil, ierr.NewError("tier unit exceeds Chargebee's supported range").
+					WithHint("Tier boundaries must fit in a 32-bit integer for Chargebee").
+					Mark(ierr.ErrValidation)
+			}
 			createParams.Tiers[i] = &itemprice.CreateTierParams{
-				StartingUnit: lo.ToPtr(int32(tier.StartingUnit)),
+				StartingUnit: lo.ToPtr(int32(tier.StartingUnit)), // #nosec G115 -- bounds checked above
 				Price:        lo.ToPtr(int64(tier.Price)),
 			}
 			if tier.EndingUnit != nil {
-				createParams.Tiers[i].EndingUnit = lo.ToPtr(int32(*tier.EndingUnit))
+				createParams.Tiers[i].EndingUnit = lo.ToPtr(int32(*tier.EndingUnit)) // #nosec G115 -- bounds checked above
 			}
 		}
 	}
 
 	// Add period for package pricing
 	if req.Period != nil {
+		if *req.Period > math.MaxInt32 || *req.Period < math.MinInt32 {
+			return nil, ierr.NewError("period value out of range for Chargebee").
+				Mark(ierr.ErrValidation)
+		}
 		createParams.Period = lo.ToPtr(int32(*req.Period))
 	}
 	if req.PeriodUnit != "" {
@@ -586,7 +595,7 @@ func convertTiersForChargebee(flexPriceTiers []*types.PriceTier, currency string
 
 		// Set ending unit (nil for last tier)
 		if tier.UpTo != nil {
-			endingUnit := int64(*tier.UpTo)
+			endingUnit := int64(*tier.UpTo) // #nosec G115 -- pricing tier boundary, downstream guards int32 range
 			chargebeeTier.EndingUnit = &endingUnit
 			startingUnit = endingUnit + 1 // Next tier starts after current tier ends
 		} else {

--- a/internal/kafka/reconcile/reconcile.go
+++ b/internal/kafka/reconcile/reconcile.go
@@ -119,12 +119,13 @@ func Apply(a Admin, plan []Action) (Result, error) {
 	for _, act := range plan {
 		switch act.Kind {
 		case ActionCreate:
-			if err := a.CreateTopic(act.Topic.Name, int32(act.Topic.Partitions), act.Topic.ReplicationFactor, act.Topic.RetentionMs); err != nil {
+			// Partition counts come from committed topic-spec config, always small.
+			if err := a.CreateTopic(act.Topic.Name, int32(act.Topic.Partitions), act.Topic.ReplicationFactor, act.Topic.RetentionMs); err != nil { // #nosec G115 -- topic spec config, bounded
 				return res, fmt.Errorf("create topic %s: %w", act.Topic.Name, err)
 			}
 			res.Created++
 		case ActionGrow:
-			if err := a.CreatePartitions(act.Topic.Name, int32(act.Topic.Partitions)); err != nil {
+			if err := a.CreatePartitions(act.Topic.Name, int32(act.Topic.Partitions)); err != nil { // #nosec G115 -- topic spec config, bounded
 				return res, fmt.Errorf("grow partitions %s: %w", act.Topic.Name, err)
 			}
 			res.Grown++

--- a/internal/kafka/reconcile/reconcile.go
+++ b/internal/kafka/reconcile/reconcile.go
@@ -114,18 +114,20 @@ func Plan(a Admin, desired []topicspec.ResolvedTopic) ([]Action, error) {
 // Apply executes the mutating actions (create, grow). Warn-only actions
 // (skip-shrink, RF mismatch, retention mismatch) and unchanged topics are
 // counted but not acted on.
+//
+// act.Topic.Partitions is upper-bounded to math.MaxInt32 by
+// topicspec.Spec.Resolve, so the int32 casts below cannot overflow.
 func Apply(a Admin, plan []Action) (Result, error) {
 	var res Result
 	for _, act := range plan {
 		switch act.Kind {
 		case ActionCreate:
-			// Partition counts come from committed topic-spec config, always small.
-			if err := a.CreateTopic(act.Topic.Name, int32(act.Topic.Partitions), act.Topic.ReplicationFactor, act.Topic.RetentionMs); err != nil { // #nosec G115 -- topic spec config, bounded
+			if err := a.CreateTopic(act.Topic.Name, int32(act.Topic.Partitions), act.Topic.ReplicationFactor, act.Topic.RetentionMs); err != nil { // #nosec G115 -- bounded above in topicspec.Spec.Resolve
 				return res, fmt.Errorf("create topic %s: %w", act.Topic.Name, err)
 			}
 			res.Created++
 		case ActionGrow:
-			if err := a.CreatePartitions(act.Topic.Name, int32(act.Topic.Partitions)); err != nil { // #nosec G115 -- topic spec config, bounded
+			if err := a.CreatePartitions(act.Topic.Name, int32(act.Topic.Partitions)); err != nil { // #nosec G115 -- bounded above in topicspec.Spec.Resolve
 				return res, fmt.Errorf("grow partitions %s: %w", act.Topic.Name, err)
 			}
 			res.Grown++

--- a/internal/kafka/topicspec/spec.go
+++ b/internal/kafka/topicspec/spec.go
@@ -3,6 +3,7 @@ package topicspec
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 )
@@ -72,6 +73,9 @@ func (s *Spec) Resolve() ([]ResolvedTopic, error) {
 		}
 		if r.Partitions < 1 {
 			return nil, fmt.Errorf("topic %q: partitions must be >= 1 (got %d)", name, r.Partitions)
+		}
+		if r.Partitions > math.MaxInt32 {
+			return nil, fmt.Errorf("topic %q: partitions must be <= %d (got %d)", name, math.MaxInt32, r.Partitions)
 		}
 		if r.ReplicationFactor < 1 {
 			return nil, fmt.Errorf("topic %q: replicationFactor must be >= 1 (got %d)", name, r.ReplicationFactor)

--- a/internal/temporal/activities/marketplace/reporter.go
+++ b/internal/temporal/activities/marketplace/reporter.go
@@ -333,11 +333,11 @@ func (r *MarketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 	// sent in USD cents — the tenant prices their dimension per cent. Turning cents into a charge is
 	// AWS's job: it bills quantity x the dimension's rate.
 	quantity := types.ToSmallestUnit(rec.Amount, marketplaceReportingCurrency)
-	if quantity > math.MaxInt32 {
+	if quantity > math.MaxInt32 || quantity < 0 {
 		r.logger.Error(ctx, "marketplace usage report: failed to convert amount to an aws quantity", "marketplace", marketplaceConn.conn.ProviderType,
 			"tenant_id", tenantID, "environment_id", environmentID, "subscription_id", rec.SubscriptionID,
 			"usage_record_id", rec.ID, "connection_id", marketplaceConn.conn.ID, "amount", rec.Amount, "currency", rec.Currency, "quantity", quantity,
-			"error", "quantity exceeds the maximum aws accepts", "stage", "convert_quantity")
+			"error", "quantity out of the range aws accepts", "stage", "convert_quantity")
 		return types.UsageRecordSyncEntry{}, false
 	}
 
@@ -346,7 +346,7 @@ func (r *MarketplaceReporter) reportAWSRecord(ctx context.Context, rec *usagerec
 		LicenseArn:           licenseArn,
 		ProductCode:          productCode,
 		Dimension:            plan.dimension,
-		Quantity:             int32(quantity),
+		Quantity:             int32(quantity), // #nosec G115 -- bounds checked above
 		// PeriodEnd is the timestamp so a retry sends an identical record and AWS de-duplicates it.
 		Timestamp: rec.PeriodEnd,
 	})

--- a/internal/testutil/inmemory_meter_usage_store.go
+++ b/internal/testutil/inmemory_meter_usage_store.go
@@ -365,7 +365,7 @@ func (s *InMemoryMeterUsageStore) GetUsage(_ context.Context, params *events.Met
 
 	if params.WindowSize == "" {
 		result.TotalValue = aggregateScalar(matched, params.AggregationType)
-		result.EventCount = uint64(distinctIDCount(matched))
+		result.EventCount = uint64(distinctIDCount(matched)) // #nosec G115 -- test store, bounded
 		return result, nil
 	}
 
@@ -376,7 +376,7 @@ func (s *InMemoryMeterUsageStore) GetUsage(_ context.Context, params *events.Met
 		points = append(points, events.MeterUsageResult{
 			WindowStart: b.start,
 			Value:       aggregateScalar(b.records, params.AggregationType),
-			EventCount:  uint64(distinctIDCount(b.records)),
+			EventCount:  uint64(distinctIDCount(b.records)), // #nosec G115 -- test store, bounded
 		})
 	}
 	sort.Slice(points, func(i, j int) bool { return points[i].WindowStart.Before(points[j].WindowStart) })
@@ -410,7 +410,7 @@ func (s *InMemoryMeterUsageStore) GetUsageMultiMeter(_ context.Context, params *
 
 		if params.WindowSize == "" {
 			res.TotalValue = aggregateScalar(recs, params.AggregationType)
-			res.EventCount = uint64(distinctIDCount(recs))
+			res.EventCount = uint64(distinctIDCount(recs)) // #nosec G115 -- test store, bounded
 			results = append(results, res)
 			continue
 		}
@@ -421,7 +421,7 @@ func (s *InMemoryMeterUsageStore) GetUsageMultiMeter(_ context.Context, params *
 			points = append(points, events.MeterUsageResult{
 				WindowStart: b.start,
 				Value:       aggregateScalar(b.records, params.AggregationType),
-				EventCount:  uint64(distinctIDCount(b.records)),
+				EventCount:  uint64(distinctIDCount(b.records)), // #nosec G115 -- test store, bounded
 			})
 		}
 		sort.Slice(points, func(i, j int) bool { return points[i].WindowStart.Before(points[j].WindowStart) })
@@ -529,7 +529,7 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, p
 					bucket:     bucket,
 					groupKey:   k,
 					value:      aggFn(crecs),
-					eventCount: uint64(distinctIDCount(crecs)),
+					eventCount: uint64(distinctIDCount(crecs)), // #nosec G115 -- test store, bounded
 				})
 			}
 		}
@@ -544,7 +544,7 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMeters(_ context.Context, p
 			entries = append(entries, entry{
 				bucket:     bucket,
 				value:      aggFn(recs),
-				eventCount: uint64(distinctIDCount(recs)),
+				eventCount: uint64(distinctIDCount(recs)), // #nosec G115 -- test store, bounded
 			})
 		}
 		sort.Slice(entries, func(i, j int) bool { return entries[i].bucket.Before(entries[j].bucket) })
@@ -654,7 +654,7 @@ func (s *InMemoryMeterUsageStore) GetUsageForBucketedMetersDetailed(_ context.Co
 				combos[ck] = cs
 			}
 			v := aggFn(crecs)
-			ec := uint64(distinctIDCount(crecs))
+			ec := uint64(distinctIDCount(crecs)) // #nosec G115 -- test store, bounded
 			cs.cells[bucket] = &bucketCell{value: v, eventCount: ec}
 			cs.buckets = append(cs.buckets, bucket)
 			cs.total = cs.total.Add(v)
@@ -894,8 +894,8 @@ func (s *InMemoryMeterUsageStore) GetDetailedAnalytics(_ context.Context, params
 
 	results := make([]*events.MeterUsageDetailedResult, 0, len(byKey))
 	for _, g := range byKey {
-		eventCount := uint64(distinctIDCount(g.records))
-		countUnique := uint64(distinctUniqueHashCount(g.records))
+		eventCount := uint64(distinctIDCount(g.records))         // #nosec G115 -- test store, bounded
+		countUnique := uint64(distinctUniqueHashCount(g.records)) // #nosec G115 -- test store, bounded
 		res := &events.MeterUsageDetailedResult{
 			MeterID:          g.meterID,
 			Source:           g.source,
@@ -950,8 +950,8 @@ func computeDetailedPoints(records []*events.MeterUsage, ws types.WindowSize, an
 	buckets := bucketRecords(records, ws, anchor)
 	points := make([]events.MeterUsageDetailedPoint, 0, len(buckets))
 	for _, b := range buckets {
-		eventCount := uint64(distinctIDCount(b.records))
-		countUnique := uint64(distinctUniqueHashCount(b.records))
+		eventCount := uint64(distinctIDCount(b.records))         // #nosec G115 -- test store, bounded
+		countUnique := uint64(distinctUniqueHashCount(b.records)) // #nosec G115 -- test store, bounded
 		points = append(points, events.MeterUsageDetailedPoint{
 			WindowStart:      b.start,
 			TotalUsage:       primaryAggregationValue(b.records, aggTypes, eventCount, countUnique),
@@ -977,9 +977,9 @@ func primaryAggregationValue(records []*events.MeterUsage, aggTypes []types.Aggr
 	case aggSet[types.AggregationSum]:
 		return aggregateScalar(records, types.AggregationSum)
 	case aggSet[types.AggregationCount]:
-		return decimal.NewFromInt(int64(eventCount))
+		return decimal.NewFromInt(int64(eventCount)) // #nosec G115 -- test store, bounded
 	case aggSet[types.AggregationCountUnique]:
-		return decimal.NewFromInt(int64(countUnique))
+		return decimal.NewFromInt(int64(countUnique)) // #nosec G115 -- test store, bounded
 	case aggSet[types.AggregationMax]:
 		return aggregateScalar(records, types.AggregationMax)
 	case aggSet[types.AggregationAvg]:

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -590,7 +590,7 @@ func (s *Service) Flush(timeout uint) bool {
 		return true
 	}
 	if s.sentryEnabled {
-		return sentry.Flush(time.Duration(timeout) * time.Second)
+		return sentry.Flush(time.Duration(timeout) * time.Second) // #nosec G115 -- shutdown timeout constant, small
 	}
 	return true
 }

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 	"time"
@@ -590,7 +591,13 @@ func (s *Service) Flush(timeout uint) bool {
 		return true
 	}
 	if s.sentryEnabled {
-		return sentry.Flush(time.Duration(timeout) * time.Second) // #nosec G115 -- shutdown timeout constant, small
+		// Bound before the multiply so an oversized timeout cannot wrap
+		// time.Duration into a negative/invalid value.
+		const maxSeconds = uint(math.MaxInt64 / int64(time.Second))
+		if timeout > maxSeconds {
+			timeout = maxSeconds
+		}
+		return sentry.Flush(time.Duration(timeout) * time.Second) // #nosec G115 -- bounded above before multiply
 	}
 	return true
 }

--- a/internal/types/date.go
+++ b/internal/types/date.go
@@ -669,7 +669,7 @@ func isBetween(eventTimestamp time.Time, periodStart time.Time, periodEnd time.T
 }
 
 func calculatePeriodID(periodStart time.Time) uint64 {
-	return uint64(periodStart.Unix() * 1000)
+	return uint64(periodStart.Unix() * 1000) // #nosec G115 -- billing period post-epoch, never negative
 }
 
 // GetNextUsageResetAtParams holds the inputs for GetNextUsageResetAt.

--- a/internal/types/date.go
+++ b/internal/types/date.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"math"
 	"time"
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -669,7 +670,17 @@ func isBetween(eventTimestamp time.Time, periodStart time.Time, periodEnd time.T
 }
 
 func calculatePeriodID(periodStart time.Time) uint64 {
-	return uint64(periodStart.Unix() * 1000) // #nosec G115 -- billing period post-epoch, never negative
+	unixSec := periodStart.Unix()
+	// Billing periods are always post-epoch; a pre-epoch input has no
+	// meaningful period ID, so treat it as epoch rather than underflowing.
+	if unixSec < 0 {
+		return 0
+	}
+	// Guard the *1000 multiply against overflowing int64 before the uint64 cast.
+	if unixSec > math.MaxInt64/1000 {
+		return math.MaxUint64
+	}
+	return uint64(unixSec * 1000) // #nosec G115 -- bounded above before cast
 }
 
 // GetNextUsageResetAtParams holds the inputs for GetNextUsageResetAt.


### PR DESCRIPTION
From the SAST baseline triage — gosec **G115** (integer overflow on narrowing numeric conversions), 30 sites.

## Real guards added (prod paths)
Where a large or negative value could silently wrap on a narrowing cast:

| Site | Guard |
|---|---|
| `chargebee/invoice.go:86` | validate `item.Quantity` fits int32 before cast; return validation error otherwise |
| `chargebee/item_sync.go` | bound tier `StartingUnit` / `EndingUnit` / `Period` before their int32 casts |
| `temporal/.../marketplace/reporter.go` | reject **negative** quantity too (was only `> MaxInt32`) before the AWS Marketplace int32 cast |
| `ee/service/meter_usage_tracking.go:733` | convert `uint` via the string-based `decimal` path (as `uint64` already did) — avoids silent wraparound on large user-supplied event-property values |

## Verified-safe (annotated `#nosec G115 + reason`)
- ClickHouse `EventCount` uint64→int64/int — bounded by real event volume (would take quintillions to overflow int64)
- topic-spec partition counts (small, config-sourced)
- post-epoch timestamps (non-negative)
- 13 sites in the in-memory **test store** (`internal/testutil`) — bounded by slice length

## Verification
- `go build ./internal/...` — clean
- `gosec -include=G115 ./internal/...` — **0**
- tests pass: chargebee, marketplace, ee/service

## One to double-check
`chargebee/item_sync.go` tier `UpTo` uint64→int64 narrowing: suppressed rather than threading an error return through `convertTiersForChargebee` (downstream `CreateItemPrice` bounds-checks before the final int32 cast; a tier boundary exceeding int64 max is not a realistic scenario). Flagging in case you want the guard pushed further upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for invoice quantities, pricing tiers, package periods, marketplace quantities, and topic partition counts.
  - Invalid, negative, or out-of-range values are now rejected with clearer validation errors instead of being converted incorrectly.
  - Improved handling of unsigned meter usage values and date calculations, including extreme timestamps.

- **Reliability**
  - Strengthened numeric conversion safeguards across usage tracking, analytics, invoicing, exports, reconciliation, and tracing workflows.
  - Prevented overflow-related issues while preserving behavior for valid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->