### PR TITLE
fix(security): weak-RNG (G404) and goroutine-ctx (G118) — verified non-issues

### DIFF
--- a/api/custom/go/helpers.go
+++ b/api/custom/go/helpers.go
@@ -86,7 +86,7 @@ func generateRandomString(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
+		b[i] = charset[rand.Intn(len(charset))] // #nosec G404 -- SDK helper id, not security-sensitive
 	}
 	return string(b)
 }

--- a/internal/ee/e2eprobe/event_deck.go
+++ b/internal/ee/e2eprobe/event_deck.go
@@ -44,7 +44,7 @@ func NewEventDeck(opts EventDeckOpts) *EventDeck {
 	if len(opts.EventNames) == 0 {
 		panic("e2eprobe: EventDeck requires at least one event name")
 	}
-	return &EventDeck{opts: opts, rnd: rand.New(rand.NewSource(opts.Seed))}
+	return &EventDeck{opts: opts, rnd: rand.New(rand.NewSource(opts.Seed))} // #nosec G404 -- e2e probe test data, non-security
 }
 
 func (d *EventDeck) Next() EventDraw {

--- a/internal/ee/e2eprobe/listener.go
+++ b/internal/ee/e2eprobe/listener.go
@@ -96,7 +96,7 @@ func (h *HTTPWebhookListener) Subscribe(ctx context.Context) (<-chan ListenerEve
 	h.mu.Unlock()
 
 	go func() { _ = h.srv.Serve(ln) }()
-	go func() {
+	go func() { // #nosec G118 -- parent ctx already Done, fresh ctx needed for shutdown deadline
 		<-ctx.Done()
 		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/internal/ee/service/meter_usage_tracking.go
+++ b/internal/ee/service/meter_usage_tracking.go
@@ -121,7 +121,7 @@ func (s *meterUsageTrackingService) PublishEvent(ctx context.Context, event *eve
 		partitionKey = fmt.Sprintf("%s:%s", event.TenantID, event.ExternalCustomerID)
 	}
 
-	uniqueID := fmt.Sprintf("%s-%d-%d", event.ID, time.Now().UnixNano(), rand.Int63())
+	uniqueID := fmt.Sprintf("%s-%d-%d", event.ID, time.Now().UnixNano(), rand.Int63()) // #nosec G404 -- dedup salt, not security-sensitive
 	msg := message.NewMessage(uniqueID, payload)
 	msg.Metadata.Set("tenant_id", event.TenantID)
 	msg.Metadata.Set("environment_id", event.EnvironmentID)

--- a/internal/ee/service/onboarding.go
+++ b/internal/ee/service/onboarding.go
@@ -391,7 +391,7 @@ func (s *onboardingService) createEventRequest(eventMsg *types.OnboardingEventsM
 		// For sum/avg aggregation, we need to generate a value for the aggregation field
 		if meter.Aggregation.Field != "" {
 			// Generate a random value between 1 and 100
-			properties[meter.Aggregation.Field] = rand.Int63n(100) + 1
+			properties[meter.Aggregation.Field] = rand.Int63n(100) + 1 // #nosec G404 -- synthetic demo data, non-security
 		}
 	}
 
@@ -399,7 +399,7 @@ func (s *onboardingService) createEventRequest(eventMsg *types.OnboardingEventsM
 	for _, filter := range meter.Filters {
 		if len(filter.Values) > 0 {
 			// Select a random value from the filter values
-			properties[filter.Key] = filter.Values[rand.Intn(len(filter.Values))]
+			properties[filter.Key] = filter.Values[rand.Intn(len(filter.Values))] // #nosec G404 -- synthetic demo data, non-security
 		}
 	}
 

--- a/internal/ee/service/raw_event_consumption.go
+++ b/internal/ee/service/raw_event_consumption.go
@@ -317,7 +317,7 @@ func (s *rawEventConsumptionService) BulkIngestRawEvents(ctx context.Context, ev
 		return fmt.Errorf("failed to marshal raw event batch: %w", err)
 	}
 
-	uniqueID := fmt.Sprintf("%s-%d-%d", types.GenerateUUID(), time.Now().UnixNano(), rand.Int63())
+	uniqueID := fmt.Sprintf("%s-%d-%d", types.GenerateUUID(), time.Now().UnixNano(), rand.Int63()) // #nosec G404 -- dedup salt, not security-sensitive
 	msg := message.NewMessage(uniqueID, payload)
 	msg.Metadata.Set("tenant_id", tenantID)
 	msg.Metadata.Set("environment_id", environmentID)
@@ -353,7 +353,7 @@ func (s *rawEventConsumptionService) publishTransformedEvent(ctx context.Context
 	}
 
 	// Make UUID truly unique by adding nanosecond precision timestamp and random bytes
-	uniqueID := fmt.Sprintf("%s-%d-%d", event.ID, time.Now().UnixNano(), rand.Int63())
+	uniqueID := fmt.Sprintf("%s-%d-%d", event.ID, time.Now().UnixNano(), rand.Int63()) // #nosec G404 -- dedup salt, not security-sensitive
 
 	msg := message.NewMessage(uniqueID, payload)
 

--- a/internal/ee/service/raw_events_reprocessing.go
+++ b/internal/ee/service/raw_events_reprocessing.go
@@ -277,7 +277,7 @@ func (s *rawEventsReprocessingService) publishEvent(ctx context.Context, event *
 	}
 
 	// Make UUID truly unique by adding nanosecond precision timestamp and random bytes
-	uniqueID := fmt.Sprintf("%s-%d-%d", event.ID, time.Now().UnixNano(), rand.Int63())
+	uniqueID := fmt.Sprintf("%s-%d-%d", event.ID, time.Now().UnixNano(), rand.Int63()) // #nosec G404 -- dedup salt, not security-sensitive
 
 	msg := message.NewMessage(uniqueID, payload)
 

--- a/internal/temporal/activities/subscription/update_billing_period_activities.go
+++ b/internal/temporal/activities/subscription/update_billing_period_activities.go
@@ -269,7 +269,7 @@ func (s *BillingActivities) TriggerInvoiceWorkflowActivity(
 				EnvironmentID: input.EnvironmentID,
 				UserID:        input.UserID,
 			},
-			900+rand.Intn(300), // adding a random delay between 900 and 1200 seconds
+			900+rand.Intn(300), // #nosec G404 -- jitter, not security-sensitive
 		)
 		if err != nil {
 			s.logger.Error(ctx, "failed to trigger invoice workflow",

--- a/scripts/internal/clickhouse.go
+++ b/scripts/internal/clickhouse.go
@@ -121,7 +121,7 @@ func generateEvent(index int) dto.IngestEventRequest {
 
 	return dto.IngestEventRequest{
 		EventID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_EVENT),
-		ExternalCustomerID: customerIDs[(index+rand.Intn(10))%len(customerIDs)],
+		ExternalCustomerID: customerIDs[(index+rand.Intn(10))%len(customerIDs)], // #nosec G404 -- seed tooling, non-prod
 		EventName:          meter.Code,
 		Timestamp:          timestamp,
 		Properties:         properties,
@@ -130,7 +130,7 @@ func generateEvent(index int) dto.IngestEventRequest {
 
 // randInt64 generates a random int64 between min and max
 func randInt64(min, max int64) int64 {
-	return min + rand.Int63n(max-min+1)
+	return min + rand.Int63n(max-min+1) // #nosec G404 -- seed tooling, non-prod
 }
 
 func ingestEvent(event dto.IngestEventRequest, limiter *rate.Limiter, wg *sync.WaitGroup, results chan<- time.Duration, errors chan<- error) {

--- a/scripts/internal/seed_events.go
+++ b/scripts/internal/seed_events.go
@@ -64,7 +64,7 @@ func (g *EventGenerator) generateEvent(index int) dto.IngestEventRequest {
 		// For sum/avg aggregation, we need to generate a value for the aggregation field
 		if selectedMeter.Aggregation.Field != "" {
 			// Generate a random value between 1 and 1000
-			properties[selectedMeter.Aggregation.Field] = rand.Int63n(1000) + 1
+			properties[selectedMeter.Aggregation.Field] = rand.Int63n(1000) + 1 // #nosec G404 -- seed tooling, non-prod
 		}
 	}
 
@@ -72,7 +72,7 @@ func (g *EventGenerator) generateEvent(index int) dto.IngestEventRequest {
 	for _, filter := range selectedMeter.Filters {
 		if len(filter.Values) > 0 {
 			// Select a random value from the filter values
-			properties[filter.Key] = filter.Values[rand.Intn(len(filter.Values))]
+			properties[filter.Key] = filter.Values[rand.Intn(len(filter.Values))] // #nosec G404 -- seed tooling, non-prod
 		}
 	}
 
@@ -81,7 +81,7 @@ func (g *EventGenerator) generateEvent(index int) dto.IngestEventRequest {
 
 	return dto.IngestEventRequest{
 		EventID:            types.GenerateUUIDWithPrefix(types.UUID_PREFIX_EVENT),
-		ExternalCustomerID: g.customerIDs[rand.Intn(len(g.customerIDs))],
+		ExternalCustomerID: g.customerIDs[rand.Intn(len(g.customerIDs))], // #nosec G404 -- seed tooling, non-prod
 		EventName:          selectedMeter.EventName,
 		Timestamp:          timestamp,
 		Properties:         properties,

--- a/scripts/internal/setup_dummy_billing_customer.go
+++ b/scripts/internal/setup_dummy_billing_customer.go
@@ -396,12 +396,12 @@ func eventPropertiesForMeter(m *meter.Meter) map[string]interface{} {
 	if m.Aggregation.Type == types.AggregationSum ||
 		m.Aggregation.Type == types.AggregationAvg {
 		if m.Aggregation.Field != "" {
-			properties[m.Aggregation.Field] = rand.Int63n(1000) + 1
+			properties[m.Aggregation.Field] = rand.Int63n(1000) + 1 // #nosec G404 -- seed tooling, non-prod
 		}
 	}
 	for _, filter := range m.Filters {
 		if len(filter.Values) > 0 {
-			properties[filter.Key] = filter.Values[rand.Intn(len(filter.Values))]
+			properties[filter.Key] = filter.Values[rand.Intn(len(filter.Values))] // #nosec G404 -- seed tooling, non-prod
 		}
 	}
 	return properties


### PR DESCRIPTION
From the SAST baseline — gosec **G404** (weak RNG) and **G118** (goroutine context).

## G404 — 0 conversions to crypto/rand, all verified non-security

Every flagged `math/rand` use was traced; none produces a token, secret, id, or anything an attacker must not predict:

| Use | Sites |
|---|---|
| Watermill message **dedup salt** (`event.ID + nanos + rand`) | meter_usage_tracking, raw_event_consumption, raw_events_reprocessing |
| Workflow-trigger **jitter** (900–1200s) | update_billing_period_activities |
| **Synthetic demo** meter values (onboarding) | onboarding.go |
| **Seed / load-gen** tooling | scripts/internal/*, e2eprobe event_deck |
| Public SDK `GenerateID` convenience suffix | api/custom/go/helpers.go |

Each carries `// #nosec G404 -- <specific reason>`. crypto/rand is not warranted for jitter/dedup/demo/seed data.

## G118 — goroutine ctx

`e2eprobe/listener.go`: the goroutine blocks on `<-ctx.Done()` first, so it deliberately needs a **fresh** (non-cancelled) `context.Background()` to carry the shutdown deadline — deriving from the already-done parent would be a no-op. Annotated with that reason.

## Verification
- `go build ./internal/... ./scripts/...` — clean
- `go test` on all touched packages — pass
- `gosec -include=G404,G118 ./internal/... ./scripts/...` — **0**
- No interface changes → no `make mocks`

Note: `api/custom/go/helpers.go` is a separate module (own go.mod), annotated but not built in this pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Clarified security-scan findings for non-security randomization used in testing, event generation, billing workflows, and development tools.
  * Documented the intended use of pseudo-random values in webhook shutdown handling and test data generation.
  * No end-user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->