### PR TITLE
fix(security): tighten file/dir perms and run containers as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ FROM ghcr.io/typst/typst:v0.13.1 AS typst
 
 # Final stage
 FROM alpine:3.20
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata && \
+    addgroup -S app && adduser -S -G app app
 
 WORKDIR /app
 COPY --from=builder /app/server .
@@ -69,8 +70,10 @@ COPY --from=builder /app/assets/email-templates ./assets/email-templates
 COPY --from=typst /bin/typst /usr/local/bin/
 # `./migrate postgres up` execs this; keep it on PATH.
 COPY --from=dbmate /out/dbmate /usr/local/bin/dbmate
+RUN chown -R app:app /app
 
 ENV TZ=UTC
+USER app
 
 EXPOSE 8080
 CMD ["./server"]

--- a/Dockerfile.e2eprobe
+++ b/Dockerfile.e2eprobe
@@ -28,15 +28,18 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 
 # Final stage
 FROM alpine:3.20
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata && \
+    addgroup -S app && adduser -S -G app app
 
 WORKDIR /app
 COPY --from=builder /app/e2eprobe .
+RUN chown -R app:app /app
 
 # All e2eprobe defaults now live in internal/ee/e2eprobe/config.go and match
 # cmd/e2eprobe/.env.example, so nothing needs baking here. Override any knob
 # at runtime with -e VAR=val.
 ENV TZ=UTC
+USER app
 
 # Required at runtime (not baked — keeps secrets out of image layers):
 #   E2EPROBE_API_HOST, E2EPROBE_API_KEY

--- a/internal/typst/typst.go
+++ b/internal/typst/typst.go
@@ -272,7 +272,7 @@ func CopyFile(src, dst string) error {
 
 	// Create destination directory if it doesn't exist
 	dstDir := filepath.Dir(dst)
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
+	if err := os.MkdirAll(dstDir, 0750); err != nil {
 		return fmt.Errorf("failed to create destination directory: %w", err)
 	}
 

--- a/scripts/internal/migrate_to_addon.go
+++ b/scripts/internal/migrate_to_addon.go
@@ -160,7 +160,7 @@ func CopyPlanChargesToAddons() error {
 			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 
-		err = os.WriteFile(filename, jsonData, 0644)
+		err = os.WriteFile(filename, jsonData, 0600)
 		if err != nil {
 			return fmt.Errorf("failed to write JSON file: %w", err)
 		}

--- a/scripts/internal/migrate_to_addon.go
+++ b/scripts/internal/migrate_to_addon.go
@@ -164,6 +164,10 @@ func CopyPlanChargesToAddons() error {
 		if err != nil {
 			return fmt.Errorf("failed to write JSON file: %w", err)
 		}
+		// WriteFile keeps an existing file's mode; force 0600 on reruns.
+		if err := os.Chmod(filename, 0600); err != nil {
+			return fmt.Errorf("failed to chmod JSON file: %w", err)
+		}
 
 		log.Infow("Dry run completed - output written to file", "filename", filename, "prices_to_create", len(newPrices))
 		fmt.Printf("✅ Dry run completed! Output written to: %s\n", filename)

--- a/scripts/internal/onboard_tenents.go
+++ b/scripts/internal/onboard_tenents.go
@@ -184,7 +184,7 @@ func outputTenantsToSync(tenants []*dto.TenantResponse, tenantsToSync []*tenant.
 	if err != nil {
 		logger.Errorw("Failed to marshal tenants to JSON", "error", err)
 	} else {
-		err = os.WriteFile("tenants_to_sync.json", jsonData, 0644)
+		err = os.WriteFile("tenants_to_sync.json", jsonData, 0600)
 		if err != nil {
 			logger.Errorw("Failed to write tenants to file", "error", err)
 		} else {

--- a/scripts/internal/onboard_tenents.go
+++ b/scripts/internal/onboard_tenents.go
@@ -188,6 +188,10 @@ func outputTenantsToSync(tenants []*dto.TenantResponse, tenantsToSync []*tenant.
 		if err != nil {
 			logger.Errorw("Failed to write tenants to file", "error", err)
 		} else {
+			// WriteFile keeps an existing file's mode; force 0600 on reruns.
+			if cerr := os.Chmod("tenants_to_sync.json", 0600); cerr != nil {
+				logger.Errorw("Failed to chmod tenants file", "error", cerr)
+			}
 			fmt.Printf("\nTenants to sync have been written to tenants_to_sync.json for review\n")
 		}
 	}


### PR DESCRIPTION
From the SAST baseline — gosec **G306** (file perms), **G301** (dir perms), and semgrep **dockerfile.security.missing-user**.

## Changes

**G306 — world-readable output files → 0600**
- `scripts/internal/onboard_tenents.go` and `migrate_to_addon.go` write their output JSON at `0600` (owner-only). Dev-ops scripts, no reason for broader access.

**G301 — world-accessible dir → 0750**
- `internal/typst/typst.go` `CopyFile` creates its destination dir at `0750`. The app’s real PDF output uses `os.TempDir()`, so this only affects asset/template copies — 0750 is sufficient. typst tests pass.

**Dockerfile missing-user — containers ran as root**
- `Dockerfile` and `Dockerfile.e2eprobe` final stages (both `alpine:3.20`) ran as root. Added a non-root `app` user (`addgroup -S app && adduser -S -G app app`), `chown -R app:app /app` after the `COPY --from=…` steps, and `USER app` before `CMD`.
- Generated files are written to `/tmp` (world-writable in alpine), so the non-root user needs no extra chown.

## Verification
- `go build ./internal/... ./scripts/...` — clean
- `go test ./internal/typst/...` — pass
- `gosec -include=G306,G301 ./internal/... ./scripts/...` — **0**
- Dockerfiles not docker-built here (no docker in env); stage order verified by hand — `USER` sits in the final stage, after all root `RUN`/`COPY`, before `EXPOSE`/`CMD`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Containers now run as a non-root application user.
  - Application files and directories use more restrictive ownership and permissions.
  - Generated migration and synchronization files are accessible only to their owner.
  - Created destination directories have tightened access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->