### PR TITLE
fix(invoice): recalculate at the invoice's original reference point

### DIFF
--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -394,6 +394,25 @@ func (s *invoiceService) CreateDraftInvoiceForSubscription(ctx context.Context, 
 	return s.CreateEmptyDraftInvoice(ctx, req)
 }
 
+// referencePointForBillingReason maps an invoice's billing reason to the reference point
+// its charges were originally computed at. Recomputing an invoice at a different reference
+// point silently changes which charges it carries: only PERIOD_START emits current-period
+// advance charges, so a subscription-create invoice recomputed at PERIOD_END loses them —
+// one-time advance fees in particular, which are never re-emitted under any other reference
+// point. An empty billing reason (legacy rows) falls back to PERIOD_END.
+func referencePointForBillingReason(billingReason string) types.InvoiceReferencePoint {
+	switch types.InvoiceBillingReason(billingReason) {
+	case types.InvoiceBillingReasonSubscriptionCreate,
+		types.InvoiceBillingReasonSubscriptionTrialEnd,
+		types.InvoiceBillingReasonSubscriptionTrialStart,
+		types.InvoiceBillingReasonSubscriptionUpdate:
+		return types.ReferencePointPeriodStart
+	case types.InvoiceBillingReasonProration:
+		return types.ReferencePointCancel
+	}
+	return types.ReferencePointPeriodEnd
+}
+
 // ComputeInvoice computes a draft (or previously-skipped) invoice: computes line items (subscription),
 // applies credits/coupons/taxes, or marks SKIPPED if zero-dollar. Re-runnable on draft and skipped invoices.
 // Invoice number is NOT assigned here — it is assigned during FinalizeInvoice.
@@ -444,19 +463,7 @@ func (s *invoiceService) ComputeInvoice(ctx context.Context, invoiceID string, r
 		if err != nil {
 			return nil, false, err
 		}
-		refPoint := types.ReferencePointPeriodEnd
-		switch types.InvoiceBillingReason(inv.BillingReason) {
-		case types.InvoiceBillingReasonSubscriptionCreate,
-			types.InvoiceBillingReasonSubscriptionTrialEnd,
-			types.InvoiceBillingReasonSubscriptionTrialStart,
-			types.InvoiceBillingReasonSubscriptionUpdate:
-
-			// for create, trial end, trial start, and update, we use the period start as the reference point
-			refPoint = types.ReferencePointPeriodStart
-
-		case types.InvoiceBillingReasonProration:
-			refPoint = types.ReferencePointCancel
-		}
+		refPoint := referencePointForBillingReason(inv.BillingReason)
 		billingService := NewBillingService(s.ServiceParams)
 		params := &dto.PrepareSubscriptionInvoiceRequestParams{
 			Subscription:     sub,
@@ -3515,8 +3522,9 @@ func (s *invoiceService) RecalculateInvoiceV2(ctx context.Context, id string, fi
 		// Line items are reconciled after this call (update-in-place or delete+create).
 		billingService := NewBillingService(s.ServiceParams)
 
-		// Use period_end reference point to include both arrear and advance charges
-		referencePoint := types.ReferencePointPeriodEnd
+		// Recompute with the reference point the invoice was originally billed at, so the
+		// recalculation covers the same charges the invoice was created with.
+		referencePoint := referencePointForBillingReason(inv.BillingReason)
 
 		newInvoiceReq, err := billingService.PrepareSubscriptionInvoiceRequest(txCtx, &dto.PrepareSubscriptionInvoiceRequestParams{
 			Subscription:   sub,
@@ -3690,11 +3698,14 @@ func (s *invoiceService) RecalculateInvoice(ctx context.Context, id string) (*dt
 		sub.GatewayPaymentMethodID,
 	).NormalizePaymentParameters()
 
+	// The replacement stands in for the voided invoice, so it is billed at the same
+	// reference point and carries the same billing reason.
 	newInv, _, err := s.CreateSubscriptionInvoice(ctx, &dto.CreateSubscriptionInvoiceRequest{
 		SubscriptionID: *inv.SubscriptionID,
 		PeriodStart:    *inv.PeriodStart,
 		PeriodEnd:      *inv.PeriodEnd,
-		ReferencePoint: types.ReferencePointPeriodEnd,
+		ReferencePoint: referencePointForBillingReason(inv.BillingReason),
+		BillingReason:  types.InvoiceBillingReason(inv.BillingReason),
 	}, paymentParams, types.InvoiceFlowManual, false)
 	if err != nil {
 		s.Logger.Error(ctx, "invoice recalculation failed after voiding, invoice left voided with no replacement",

--- a/internal/ee/service/invoice_void_recalculate_test.go
+++ b/internal/ee/service/invoice_void_recalculate_test.go
@@ -1126,3 +1126,99 @@ func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoiceV2_HappyPath_Finaliz
 	s.Equal(types.InvoiceStatusFinalized, result.InvoiceStatus,
 		"invoice must be FINALIZED when finalize=true")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reference point derivation (one-time advance charges)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// addOneTimeAdvanceLineItem attaches a ONETIME + ADVANCE fixed charge (e.g. an
+// implementation fee) billed on the first day of the subscription's current period.
+func (s *InvoiceVoidRecalculateSuite) addOneTimeAdvanceLineItem(priceID string, amount decimal.Decimal) *subscription.SubscriptionLineItem {
+	onetimePrice := &price.Price{
+		ID:                 priceID,
+		Amount:             amount,
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_ONETIME,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(s.GetContext(), onetimePrice))
+
+	lineItem := &subscription.SubscriptionLineItem{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		SubscriptionID:  s.testData.subscription.ID,
+		CustomerID:      s.testData.customer.ID,
+		EntityID:        s.testData.plan.ID,
+		EntityType:      types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName: s.testData.plan.Name,
+		PriceID:         onetimePrice.ID,
+		PriceType:       onetimePrice.Type,
+		DisplayName:     "Implementation Fee",
+		Quantity:        decimal.NewFromInt(1),
+		Currency:        "usd",
+		BillingPeriod:   types.BILLING_PERIOD_ONETIME,
+		InvoiceCadence:  types.InvoiceCadenceAdvance,
+		StartDate:       s.testData.subscription.CurrentPeriodStart,
+		BaseModel:       types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(s.GetContext(), lineItem))
+	return lineItem
+}
+
+// buildDraftInvoiceWithBillingReason stores a DRAFT subscription invoice carrying an
+// explicit billing reason.
+func (s *InvoiceVoidRecalculateSuite) buildDraftInvoiceWithBillingReason(id string, reason types.InvoiceBillingReason) *invoice.Invoice {
+	inv := s.buildDraftInvoice(id)
+	inv.BillingReason = string(reason)
+	s.NoError(s.invoiceRepo.Update(s.GetContext(), inv))
+	return inv
+}
+
+// A one-time advance charge is classified as a current-period advance charge, which only
+// the PERIOD_START reference point emits. Recalculation must derive the reference point
+// from the invoice's billing reason instead of assuming PERIOD_END, otherwise the charge
+// is dropped from the invoice it was originally billed on.
+func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoiceV2_SubscriptionCreate_KeepsOneTimeAdvanceCharge() {
+	s.addOneTimeAdvanceLineItem("price_vr_onetime", decimal.NewFromFloat(500))
+	inv := s.buildDraftInvoiceWithBillingReason("inv_v2_onetime", types.InvoiceBillingReasonSubscriptionCreate)
+
+	result, err := s.service.RecalculateInvoiceV2(s.GetContext(), inv.ID, false)
+	s.NoError(err)
+	s.NotNil(result)
+
+	onetimeLines := lo.Filter(result.LineItems, func(li *dto.InvoiceLineItemResponse, _ int) bool {
+		return lo.FromPtr(li.PriceID) == "price_vr_onetime"
+	})
+	s.Require().Len(onetimeLines, 1, "one-time advance charge must survive recalculation")
+	s.True(onetimeLines[0].Amount.Equal(decimal.NewFromFloat(500)),
+		"one-time advance charge must keep its amount, got %s", onetimeLines[0].Amount)
+}
+
+// The replacement invoice stands in for the voided one, so it must be billed at the same
+// reference point — otherwise a subscription-create invoice is replaced by a period-end
+// invoice that silently drops its one-time advance charges.
+func (s *InvoiceVoidRecalculateSuite) TestRecalculateInvoice_SubscriptionCreate_KeepsOneTimeAdvanceCharge() {
+	s.addOneTimeAdvanceLineItem("price_vr_onetime_v1", decimal.NewFromFloat(500))
+	inv := s.buildFinalizedInvoice("inv_v1_onetime", decimal.Zero, decimal.Zero, types.PaymentStatusPending)
+	inv.BillingReason = string(types.InvoiceBillingReasonSubscriptionCreate)
+	s.NoError(s.invoiceRepo.Update(s.GetContext(), inv))
+
+	newInv, err := s.service.RecalculateInvoice(s.GetContext(), inv.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(newInv)
+
+	onetimeLines := lo.Filter(newInv.LineItems, func(li *dto.InvoiceLineItemResponse, _ int) bool {
+		return lo.FromPtr(li.PriceID) == "price_vr_onetime_v1"
+	})
+	s.Require().Len(onetimeLines, 1, "one-time advance charge must survive void-and-replace recalculation")
+	s.True(onetimeLines[0].Amount.Equal(decimal.NewFromFloat(500)),
+		"one-time advance charge must keep its amount, got %s", onetimeLines[0].Amount)
+	s.Equal(string(types.InvoiceBillingReasonSubscriptionCreate), newInv.BillingReason,
+		"replacement invoice must carry the original billing reason")
+}


### PR DESCRIPTION
## Problem

Recalculating a subscription invoice silently drops one-time advance charges — an implementation fee billed as `ONETIME` + `ADVANCE` disappears from the invoice it was originally billed on.

Both recalculation paths hardcoded `ReferencePointPeriodEnd`:

- `RecalculateInvoiceV2` — `internal/ee/service/invoice.go`
- `RecalculateInvoice` (void + replace) — same file

`PERIOD_END` only emits `CurrentPeriodArrear` + `NextPeriodAdvance` (`billing.go`, `PrepareSubscriptionInvoiceRequest`). A `ONETIME` + `ADVANCE` line item whose billing date falls inside the invoice period is classified into `CurrentPeriodAdvance` (`ClassifyLineItems`), and **`PERIOD_START` is the only reference point that emits that bucket**. So the fresh compute never produced the charge, and:

- `RecalculateInvoiceV2` archived the existing row through `reconcileLineItems` (unmatched items are removed)
- `RecalculateInvoice` built a replacement invoice without it

`ComputeInvoice` was already correct — it derives the reference point from the invoice's `billing_reason`. The recalculation paths just never picked that logic up.

## Fix

Extract the mapping into `referencePointForBillingReason` and use it in all three places:

| billing_reason | reference point |
|---|---|
| `SUBSCRIPTION_CREATE`, `SUBSCRIPTION_UPDATE`, `SUBSCRIPTION_TRIAL_START`, `SUBSCRIPTION_TRIAL_END` | `PERIOD_START` |
| `PRORATION` | `CANCEL` |
| everything else (and empty) | `PERIOD_END` |

`RecalculateInvoice` additionally carries the original `billing_reason` onto the replacement invoice. It previously defaulted to `SUBSCRIPTION_CYCLE` via `ToDraftRequest`, which meant the replacement was mislabelled and any later recompute would drop the charge again.

## Compatibility

An empty `billing_reason` (legacy rows) resolves to `PERIOD_END`, so behavior is unchanged for every invoice that was already being recalculated at period end. `ComputeInvoice` is a pure refactor — same mapping, same result.

## Tests

Two regression tests in `invoice_void_recalculate_test.go`, both verified to fail on the unpatched code (`"[]" should have 1 item(s), but has 0`) and pass with the fix:

- `TestRecalculateInvoiceV2_SubscriptionCreate_KeepsOneTimeAdvanceCharge`
- `TestRecalculateInvoice_SubscriptionCreate_KeepsOneTimeAdvanceCharge` — also asserts the replacement carries the original billing reason

`go test -race ./internal/...` passes; `make lint-ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1rvELySB7M33muS4Y93g9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice recalculation now preserves the original billing reason and reference point.
  * One-time advance charges remain included when invoices are recalculated.
  * Replacement invoices retain the original billing reason and charge amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->