### PR TITLE
feat(alerts): Tenant level switch for enabling alerts

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -90,14 +90,15 @@ const (
 	PrefixInvoiceLineItem          = "invoice_line_item:v1:"
 	PrefixWalletAlertThrottle      = "wallet_alert_throttle:v1:"
 	PrefixUsageAlertSchedule       = "usage_alert_schedule:v1:"
+	PrefixSettingsByKey            = "settings_by_key:v1:"
 	PrefixCostsheet                = "costsheet:v1:"
 	PrefixPriceUnit                = "price_unit:v1:"
 	PrefixWalletRealTimeBalance    = "wallet_realtime_balance:v1:"
 	PrefixWorkflowExecution        = "workflow_execution:v1:"
 	// PrefixPriceSyncLock is the Redis key prefix for plan-level price sync lock (used with planID).
 	// Used by both API (acquire) and Temporal activity (release); do not change without updating both.
-	PrefixPriceSyncLock             = "price_sync:plan:"
-	PrefixRazorpayWebhookRefundLock = "razorpay:webhook-refund:"
+	PrefixPriceSyncLock              = "price_sync:plan:"
+	PrefixRazorpayWebhookRefundLock  = "razorpay:webhook-refund:"
 	PrefixChargebeeWebhookRefundLock = "chargebee:webhook-refund:"
 	PrefixTabsInvoiceSyncLock        = "tabs:invoice_sync:"
 	// PrefixStripeCustomerSyncLock guards first-time Stripe customer creation for a

--- a/internal/cache/helper.go
+++ b/internal/cache/helper.go
@@ -78,6 +78,9 @@ func StartInMemoryCacheSpan(ctx context.Context, cacheEntity, operation string, 
 
 // FinishSpan safely finishes a span, handling nil spans.
 func FinishSpan(span *tracing.Span) {
+	if span == nil {
+		return
+	}
 	span.Finish()
 }
 

--- a/internal/ee/service/meter_usage_tracking_post_insert.go
+++ b/internal/ee/service/meter_usage_tracking_post_insert.go
@@ -130,6 +130,18 @@ func (s *meterUsageTrackingService) scheduleUsageAlertWorkflow(ctx context.Conte
 		}
 	}
 
+	// Per-tenant gate: settings can turn any alert type off independently of the deployment-level config.
+	walletEnabled, spendEnabled, entitlementEnabled := s.effectiveUsageAlertFlags(ctx)
+	if !walletEnabled && !spendEnabled && !entitlementEnabled {
+		if throttleLock != nil {
+			if releaseErr := throttleLock.Release(ctx); releaseErr != nil {
+				s.Logger.Error(ctx, "failed to release usage alert schedule lock", "error", releaseErr, "customer_id", cust.ID)
+			}
+		}
+		s.Logger.Debug(ctx, "usage alerts disabled for tenant, skipping workflow", "customer_id", cust.ID)
+		return
+	}
+
 	tenantID := types.GetTenantID(ctx)
 	envID := types.GetEnvironmentID(ctx)
 	workflowID := fmt.Sprintf("%s_%s_%s_%s_%s",
@@ -151,9 +163,9 @@ func (s *meterUsageTrackingService) scheduleUsageAlertWorkflow(ctx context.Conte
 		CustomerID:               cust.ID,
 		ScheduledFor:             time.Now().UTC().Add(delay),
 		StaleAfter:               usageAlertConfig.StaleAfter,
-		WalletAlertsEnabled:      usageAlertConfig.WalletAlertsEnabled,
-		SpendAlertsEnabled:       usageAlertConfig.SpendAlertsEnabled,
-		EntitlementAlertsEnabled: usageAlertConfig.EntitlementAlertsEnabled,
+		WalletAlertsEnabled:      walletEnabled,
+		SpendAlertsEnabled:       spendEnabled,
+		EntitlementAlertsEnabled: entitlementEnabled,
 	}
 
 	if _, err := temporalSvc.StartWorkflow(ctx, options, types.TemporalUsageAlertWorkflow, input); err != nil {
@@ -376,4 +388,27 @@ func executeCustomerOnboardingForEvent(ctx context.Context, params ServiceParams
 	)
 
 	return createdCustomer, nil
+}
+
+// effectiveUsageAlertFlags AND-combines the deployment-level config flags with the per-tenant setting toggles.
+// Fail-closed: any settings-read error treats that setting as disabled (matches the wallet gate's behaviour and prevents a transient DB blip from mass-firing evaluations).
+func (s *meterUsageTrackingService) effectiveUsageAlertFlags(ctx context.Context) (wallet, spend, entitlement bool) {
+	settingsSvc := NewSettingsService(s.ServiceParams).(*settingsService)
+
+	if s.Config.UsageAlerts.WalletAlertsEnabled {
+		if walletCfg, err := GetSetting[types.AlertSettings](settingsSvc, ctx, types.SettingKeyWalletBalanceAlertConfig); err == nil && walletCfg.IsAlertEnabled() {
+			wallet = true
+		}
+	}
+	if s.Config.UsageAlerts.SpendAlertsEnabled {
+		if spendCfg, err := GetSetting[types.AlertToggleConfig](settingsSvc, ctx, types.SettingKeySubscriptionAlertConfig); err == nil && spendCfg.IsAlertEnabled() {
+			spend = true
+		}
+	}
+	if s.Config.UsageAlerts.EntitlementAlertsEnabled {
+		if entCfg, err := GetSetting[types.AlertToggleConfig](settingsSvc, ctx, types.SettingKeyEntitlementAlertConfig); err == nil && entCfg.IsAlertEnabled() {
+			entitlement = true
+		}
+	}
+	return
 }

--- a/internal/ee/service/meter_usage_tracking_post_insert.go
+++ b/internal/ee/service/meter_usage_tracking_post_insert.go
@@ -396,19 +396,34 @@ func (s *meterUsageTrackingService) effectiveUsageAlertFlags(ctx context.Context
 	settingsSvc := NewSettingsService(s.ServiceParams).(*settingsService)
 
 	if s.Config.UsageAlerts.WalletAlertsEnabled {
-		if walletCfg, err := GetSetting[types.AlertSettings](settingsSvc, ctx, types.SettingKeyWalletBalanceAlertConfig); err == nil && walletCfg.IsAlertEnabled() {
-			wallet = true
+		walletCfg, err := GetSetting[types.AlertSettings](settingsSvc, ctx, types.SettingKeyWalletBalanceAlertConfig)
+		if err != nil && !ierr.IsNotFound(err) {
+			s.Logger.Error(ctx, "usage alerts: failed to read wallet alert setting, treating as disabled",
+				"error", err,
+				"setting_key", types.SettingKeyWalletBalanceAlertConfig,
+			)
 		}
+		wallet = walletCfg.IsAlertEnabled()
 	}
 	if s.Config.UsageAlerts.SpendAlertsEnabled {
-		if spendCfg, err := GetSetting[types.AlertToggleConfig](settingsSvc, ctx, types.SettingKeySubscriptionAlertConfig); err == nil && spendCfg.IsAlertEnabled() {
-			spend = true
+		spendCfg, err := GetSetting[types.AlertToggleConfig](settingsSvc, ctx, types.SettingKeySubscriptionAlertConfig)
+		if err != nil && !ierr.IsNotFound(err) {
+			s.Logger.Error(ctx, "usage alerts: failed to read subscription alert setting, treating as disabled",
+				"error", err,
+				"setting_key", types.SettingKeySubscriptionAlertConfig,
+			)
 		}
+		spend = spendCfg.IsAlertEnabled()
 	}
 	if s.Config.UsageAlerts.EntitlementAlertsEnabled {
-		if entCfg, err := GetSetting[types.AlertToggleConfig](settingsSvc, ctx, types.SettingKeyEntitlementAlertConfig); err == nil && entCfg.IsAlertEnabled() {
-			entitlement = true
+		entCfg, err := GetSetting[types.AlertToggleConfig](settingsSvc, ctx, types.SettingKeyEntitlementAlertConfig)
+		if err != nil && !ierr.IsNotFound(err) {
+			s.Logger.Error(ctx, "usage alerts: failed to read entitlement alert setting, treating as disabled",
+				"error", err,
+				"setting_key", types.SettingKeyEntitlementAlertConfig,
+			)
 		}
+		entitlement = entCfg.IsAlertEnabled()
 	}
 	return
 }

--- a/internal/ee/service/settings.go
+++ b/internal/ee/service/settings.go
@@ -352,6 +352,8 @@ func (s *settingsService) GetSettingByKeyUnchecked(ctx context.Context, key type
 		return getSettingByKey[types.CustomAnalyticsConfig](s, ctx, key)
 	case types.SettingKeyWalletBalanceAlertConfig:
 		return getSettingByKey[types.AlertSettings](s, ctx, key)
+	case types.SettingKeySubscriptionAlertConfig, types.SettingKeyEntitlementAlertConfig:
+		return getSettingByKey[types.AlertToggleConfig](s, ctx, key)
 	case types.SettingKeyCustomerPortalConfig:
 		return getSettingByKey[types.CustomerPortalConfig](s, ctx, key)
 	case types.SettingKeyEventIngestionFilter:
@@ -410,6 +412,8 @@ func (s *settingsService) UpdateSettingByKey(ctx context.Context, key types.Sett
 		return updateSettingByKey[types.CustomAnalyticsConfig](s, ctx, key, req)
 	case types.SettingKeyWalletBalanceAlertConfig:
 		return updateSettingByKey[*types.AlertSettings](s, ctx, key, req)
+	case types.SettingKeySubscriptionAlertConfig, types.SettingKeyEntitlementAlertConfig:
+		return updateSettingByKey[*types.AlertToggleConfig](s, ctx, key, req)
 	case types.SettingKeyCustomerPortalConfig:
 		return updateSettingByKey[types.CustomerPortalConfig](s, ctx, key, req)
 	case types.SettingKeyEventIngestionFilter:

--- a/internal/repository/clickhouse/helper.go
+++ b/internal/repository/clickhouse/helper.go
@@ -33,6 +33,9 @@ func StartRepositorySpan(ctx context.Context, repository, operation string, para
 
 // FinishSpan safely finishes a span, handling nil spans.
 func FinishSpan(span *tracing.Span) {
+	if span == nil {
+		return
+	}
 	span.Finish()
 }
 

--- a/internal/repository/ent/helper.go
+++ b/internal/repository/ent/helper.go
@@ -33,6 +33,9 @@ func StartRepositorySpan(ctx context.Context, repository, operation string, para
 
 // FinishSpan safely finishes a span, handling nil spans.
 func FinishSpan(span *tracing.Span) {
+	if span == nil {
+		return
+	}
 	span.Finish()
 }
 

--- a/internal/repository/ent/settings.go
+++ b/internal/repository/ent/settings.go
@@ -18,16 +18,16 @@ import (
 )
 
 type settingsRepository struct {
-	client     postgres.IClient
-	log        *logger.Logger
-	redisCache cache.RedisCache
+	client postgres.IClient
+	log    *logger.Logger
+	cache  cache.InMemoryCache
 }
 
-func NewSettingsRepository(client postgres.IClient, log *logger.Logger, redisCache cache.RedisCache) domainSettings.Repository {
+func NewSettingsRepository(client postgres.IClient, log *logger.Logger, cache cache.InMemoryCache) domainSettings.Repository {
 	return &settingsRepository{
-		client:     client,
-		log:        log,
-		redisCache: redisCache,
+		client: client,
+		log:    log,
+		cache:  cache,
 	}
 }
 
@@ -78,6 +78,10 @@ func (r *settingsRepository) Create(ctx context.Context, s *domainSettings.Setti
 	}
 
 	*s = *domainSettings.FromEnt(setting)
+	// Bust any stale entries (including negative-hits from before this row
+	// existed) so the next read hits the DB and re-populates.
+	r.DeleteCache(ctx, s)
+	r.DeleteCacheByKey(ctx, s.Key, s.EnvironmentID)
 	return nil
 }
 
@@ -118,6 +122,7 @@ func (r *settingsRepository) Update(ctx context.Context, s *domainSettings.Setti
 	}
 
 	r.DeleteCache(ctx, s)
+	r.DeleteCacheByKey(ctx, s.Key, s.EnvironmentID)
 	return nil
 }
 
@@ -199,6 +204,14 @@ func (r *settingsRepository) Get(ctx context.Context, id string) (*domainSetting
 }
 
 func (r *settingsRepository) GetByKey(ctx context.Context, key types.SettingKey) (*domainSettings.Setting, error) {
+	tenantID := types.GetTenantID(ctx)
+	envID := types.GetEnvironmentID(ctx)
+
+	if cachedSetting, notFound := r.GetCacheByKey(ctx, key, envID); cachedSetting != nil {
+		return cachedSetting, nil
+	} else if notFound {
+		return nil, notFoundSettingErr(key)
+	}
 
 	client := r.client.Reader(ctx)
 	r.log.Debug(ctx, "getting setting by key", "key", key)
@@ -206,14 +219,15 @@ func (r *settingsRepository) GetByKey(ctx context.Context, key types.SettingKey)
 	s, err := client.Settings.Query().
 		Where(
 			settings.Key(string(key)),
-			settings.TenantID(types.GetTenantID(ctx)),
-			settings.EnvironmentID(types.GetEnvironmentID(ctx)),
+			settings.TenantID(tenantID),
+			settings.EnvironmentID(envID),
 			settings.Status(string(types.StatusPublished)),
 		).
 		Only(ctx)
 
 	if err != nil {
 		if ent.IsNotFound(err) {
+			r.SetCacheByKeyNotFound(ctx, key, envID)
 			return nil, ierr.WithError(err).
 				WithHintf("Setting with key %s was not found", string(key)).
 				WithReportableDetails(map[string]any{
@@ -227,19 +241,29 @@ func (r *settingsRepository) GetByKey(ctx context.Context, key types.SettingKey)
 	}
 
 	setting := domainSettings.FromEnt(s)
+	r.SetCacheByKey(ctx, key, envID, setting)
 	return setting, nil
 }
 
 // GetTenantLevelSettingByKey retrieves a tenant-level setting by key (without environment_id)
 // This is for settings that apply tenant-wide across all environments
 func (r *settingsRepository) GetTenantLevelSettingByKey(ctx context.Context, key types.SettingKey) (*domainSettings.Setting, error) {
+	tenantID := types.GetTenantID(ctx)
+
+	// Tenant-level rows carry environment_id = ""
+	if cachedSetting, notFound := r.GetCacheByKey(ctx, key, ""); cachedSetting != nil {
+		return cachedSetting, nil
+	} else if notFound {
+		return nil, notFoundSettingErr(key)
+	}
+
 	client := r.client.Reader(ctx)
 	r.log.Debug(ctx, "getting tenant-level setting by key", "key", key)
 
 	s, err := client.Settings.Query().
 		Where(
 			settings.Key(string(key)),
-			settings.TenantID(types.GetTenantID(ctx)),
+			settings.TenantID(tenantID),
 			settings.EnvironmentID(""),
 			settings.Status(string(types.StatusPublished)),
 		).
@@ -247,6 +271,7 @@ func (r *settingsRepository) GetTenantLevelSettingByKey(ctx context.Context, key
 
 	if err != nil {
 		if ent.IsNotFound(err) {
+			r.SetCacheByKeyNotFound(ctx, key, "")
 			return nil, ierr.WithError(err).
 				WithHintf("Setting with key %s was not found", string(key)).
 				WithReportableDetails(map[string]any{
@@ -260,6 +285,7 @@ func (r *settingsRepository) GetTenantLevelSettingByKey(ctx context.Context, key
 	}
 
 	setting := domainSettings.FromEnt(s)
+	r.SetCacheByKey(ctx, key, "", setting)
 	return setting, nil
 }
 
@@ -278,6 +304,7 @@ func (r *settingsRepository) DeleteByKey(ctx context.Context, key types.SettingK
 
 	// Delete from cache
 	r.DeleteCache(ctx, setting)
+	r.DeleteCacheByKey(ctx, key, types.GetEnvironmentID(ctx))
 	return nil
 }
 
@@ -341,28 +368,40 @@ func (r *settingsRepository) DeleteTenantLevelSettingByKey(ctx context.Context, 
 
 	// Delete from cache
 	r.DeleteCache(ctx, setting)
+	r.DeleteCacheByKey(ctx, key, "")
 	return nil
 }
 
+// notFoundSettingErr rebuilds the ErrNotFound this repo returns on a real
+// DB miss so a negative-cache hit is indistinguishable to the caller.
+func notFoundSettingErr(key types.SettingKey) error {
+	return ierr.NewErrorf("setting with key %s was not found", string(key)).
+		WithHintf("Setting with key %s was not found", string(key)).
+		WithReportableDetails(map[string]any{
+			"key": string(key),
+		}).
+		Mark(ierr.ErrNotFound)
+}
+
 func (r *settingsRepository) SetCache(ctx context.Context, setting *domainSettings.Setting) {
-	span, ctx := cache.StartRedisCacheSpan(ctx, "settings", "set", map[string]interface{}{
+	span, ctx := cache.StartInMemoryCacheSpan(ctx, "settings", "set", map[string]interface{}{
 		"setting_id": setting.ID,
 		"key":        setting.Key,
 	})
 	defer cache.FinishSpan(span)
 
 	cacheKey := cache.GenerateKey(ctx, cache.PrefixSettings, setting.ID)
-	r.redisCache.Set(ctx, cacheKey, setting, cache.ExpiryDefaultRedis)
+	r.cache.Set(ctx, cacheKey, setting, cache.ExpiryDefaultInMemory)
 }
 
 func (r *settingsRepository) GetCache(ctx context.Context, id string) *domainSettings.Setting {
-	span, ctx := cache.StartRedisCacheSpan(ctx, "settings", "get", map[string]interface{}{
+	span, ctx := cache.StartInMemoryCacheSpan(ctx, "settings", "get", map[string]interface{}{
 		"key": id,
 	})
 	defer cache.FinishSpan(span)
 
 	cacheKey := cache.GenerateKey(ctx, cache.PrefixSettings, id)
-	value, found := r.redisCache.Get(ctx, cacheKey)
+	value, found := r.cache.Get(ctx, cacheKey)
 	if !found {
 		return nil
 	}
@@ -374,14 +413,86 @@ func (r *settingsRepository) GetCache(ctx context.Context, id string) *domainSet
 }
 
 func (r *settingsRepository) DeleteCache(ctx context.Context, setting *domainSettings.Setting) {
-	span, ctx := cache.StartRedisCacheSpan(ctx, "settings", "delete", map[string]interface{}{
+	span, ctx := cache.StartInMemoryCacheSpan(ctx, "settings", "delete", map[string]interface{}{
 		"setting_id": setting.ID,
 		"key":        setting.Key,
 	})
 	defer cache.FinishSpan(span)
 
 	cacheKey := cache.GenerateKey(ctx, cache.PrefixSettings, setting.ID)
-	r.redisCache.Delete(ctx, cacheKey)
+	r.cache.Delete(ctx, cacheKey)
+}
+
+// settingNotFoundSentinel marks a negative cache hit — the row is
+// known-absent for this (tenant, env, key). Without it, every
+// GetSetting → default-value lookup would still round-trip Postgres.
+type settingNotFoundSentinel struct{}
+
+// settingsByKeyCacheKey scopes the cache entry to the exact
+// (tenant, environment, key) tuple. Built by hand rather than through
+// cache.GenerateKey because that helper folds ctx.environment_id in
+// automatically — wrong for tenant-level settings (envID = "") and
+// would let a caller in env A miss/hide an entry cached from env B.
+func settingsByKeyCacheKey(tenantID, envID string, key types.SettingKey) string {
+	return cache.PrefixSettingsByKey + tenantID + ":" + envID + ":" + string(key)
+}
+
+// GetCacheByKey returns (setting, notFound). notFound=true means a
+// negative-hit sentinel was stored and the caller should short-circuit
+// with ErrNotFound. setting=nil && notFound=false is a plain cache miss.
+func (r *settingsRepository) GetCacheByKey(ctx context.Context, key types.SettingKey, envID string) (*domainSettings.Setting, bool) {
+	span, ctx := cache.StartInMemoryCacheSpan(ctx, "settings", "get_by_key", map[string]interface{}{
+		"key": key,
+	})
+	defer cache.FinishSpan(span)
+
+	cacheKey := settingsByKeyCacheKey(types.GetTenantID(ctx), envID, key)
+	value, found := r.cache.Get(ctx, cacheKey)
+	if !found {
+		return nil, false
+	}
+	if _, isNF := value.(settingNotFoundSentinel); isNF {
+		return nil, true
+	}
+	s, ok := cache.UnmarshalCacheValue[domainSettings.Setting](value)
+	if !ok {
+		return nil, false
+	}
+	return s, false
+}
+
+func (r *settingsRepository) SetCacheByKey(ctx context.Context, key types.SettingKey, envID string, setting *domainSettings.Setting) {
+	span, ctx := cache.StartInMemoryCacheSpan(ctx, "settings", "set_by_key", map[string]interface{}{
+		"key": key,
+	})
+	defer cache.FinishSpan(span)
+
+	cacheKey := settingsByKeyCacheKey(types.GetTenantID(ctx), envID, key)
+	r.cache.Set(ctx, cacheKey, setting, cache.ExpiryDefaultInMemory)
+}
+
+// SetCacheByKeyNotFound caches a negative hit for a lookup that missed.
+// A subsequent read for the same (tenant, env, key) returns from cache
+// without a DB round-trip until either the TTL expires or a Create /
+// Update / Delete invalidates via DeleteCacheByKey.
+func (r *settingsRepository) SetCacheByKeyNotFound(ctx context.Context, key types.SettingKey, envID string) {
+	span, ctx := cache.StartInMemoryCacheSpan(ctx, "settings", "set_by_key_not_found", map[string]interface{}{
+		"key": key,
+	})
+	defer cache.FinishSpan(span)
+
+	cacheKey := settingsByKeyCacheKey(types.GetTenantID(ctx), envID, key)
+	r.cache.Set(ctx, cacheKey, settingNotFoundSentinel{}, cache.ExpiryDefaultInMemory)
+}
+
+func (r *settingsRepository) DeleteCacheByKey(ctx context.Context, key types.SettingKey, envID string) {
+	span, ctx := cache.StartInMemoryCacheSpan(ctx, "settings", "delete_by_key", map[string]interface{}{
+		"key": key,
+	})
+	defer cache.FinishSpan(span)
+
+	cacheKey := settingsByKeyCacheKey(types.GetTenantID(ctx), envID, key)
+	r.cache.Delete(ctx, cacheKey)
 }
 
 // ListAllTenantEnvSettingsByKey returns all settings for a given key across all tenants and environments

--- a/internal/repository/factory.go
+++ b/internal/repository/factory.go
@@ -256,7 +256,7 @@ func NewAddonAssociationRepository(p RepositoryParams) addonassociation.Reposito
 }
 
 func NewSettingsRepository(p RepositoryParams) settings.Repository {
-	return entRepo.NewSettingsRepository(p.EntClient, p.Logger, p.RedisCache)
+	return entRepo.NewSettingsRepository(p.EntClient, p.Logger, p.InMemoryCache)
 }
 
 func NewAlertLogsRepository(p RepositoryParams) alertlogs.Repository {

--- a/internal/types/alert.go
+++ b/internal/types/alert.go
@@ -584,3 +584,16 @@ func (At *AlertSettings) AlertState(ongoingBalance decimal.Decimal) (AlertState,
 func (at *AlertSettings) IsAlertEnabled() bool {
 	return at.AlertEnabled != nil && *at.AlertEnabled
 }
+
+// AlertToggleConfig is the tenant-wide on/off used by settings that have no
+// tenant-level thresholds (subscription spend and entitlement grant alerts —
+// thresholds for those live per-row in alert_settings or per-grant).
+type AlertToggleConfig struct {
+	AlertEnabled *bool `json:"alert_enabled"`
+}
+
+func (c AlertToggleConfig) Validate() error { return nil }
+
+func (c *AlertToggleConfig) IsAlertEnabled() bool {
+	return c != nil && c.AlertEnabled != nil && *c.AlertEnabled
+}

--- a/internal/types/settings.go
+++ b/internal/types/settings.go
@@ -25,6 +25,8 @@ const (
 	SettingKeyTenantConfig                SettingKey = "tenant_config"
 	SettingKeyCustomerOnboarding          SettingKey = "customer_onboarding"
 	SettingKeyWalletBalanceAlertConfig    SettingKey = "wallet_balance_alert_config"
+	SettingKeySubscriptionAlertConfig     SettingKey = "subscription_alert_config"
+	SettingKeyEntitlementAlertConfig      SettingKey = "entitlement_alert_config"
 	SettingKeyPrepareProcessedEvents      SettingKey = "prepare_processed_events_config"
 	SettingKeyCustomAnalytics             SettingKey = "custom_analytics_config"
 	SettingKeyCustomerPortalConfig        SettingKey = "customer_portal_config"
@@ -45,6 +47,8 @@ func (s *SettingKey) Validate() error {
 		SettingKeyTenantConfig,
 		SettingKeyCustomerOnboarding,
 		SettingKeyWalletBalanceAlertConfig,
+		SettingKeySubscriptionAlertConfig,
+		SettingKeyEntitlementAlertConfig,
 		SettingKeyPrepareProcessedEvents,
 		SettingKeyCustomAnalytics,
 		SettingKeyCustomerPortalConfig,
@@ -636,6 +640,19 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 		return nil, err
 	}
 
+	// Subscription and entitlement alert toggles: pure on/off — thresholds live
+	// per-row in alert_settings (subscription) and per-grant (entitlement).
+	defaultSubscriptionAlertConfig := AlertToggleConfig{AlertEnabled: lo.ToPtr(false)}
+	defaultSubscriptionAlertConfigMap, err := utils.ToMap(defaultSubscriptionAlertConfig)
+	if err != nil {
+		return nil, err
+	}
+	defaultEntitlementAlertConfig := AlertToggleConfig{AlertEnabled: lo.ToPtr(false)}
+	defaultEntitlementAlertConfigMap, err := utils.ToMap(defaultEntitlementAlertConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	// Already a map, no conversion needed
 	defaultPrepareProcessedEventsConfigMap := defaultPrepareProcessedEventsConfig
 
@@ -781,6 +798,16 @@ func GetDefaultSettings() (map[SettingKey]DefaultSettingValue, error) {
 			DefaultValue: defaultWalletBalanceAlertConfigMap,
 			Description:  "Default configuration for wallet balance alert configuration",
 		},
+		SettingKeySubscriptionAlertConfig: {
+			Key:          SettingKeySubscriptionAlertConfig,
+			DefaultValue: defaultSubscriptionAlertConfigMap,
+			Description:  "Tenant-wide toggle for subscription spend alert evaluation (per-row thresholds live in alert_settings)",
+		},
+		SettingKeyEntitlementAlertConfig: {
+			Key:          SettingKeyEntitlementAlertConfig,
+			DefaultValue: defaultEntitlementAlertConfigMap,
+			Description:  "Tenant-wide toggle for entitlement grant alert evaluation (threshold/exhaustion)",
+		},
 		SettingKeyPrepareProcessedEvents: {
 			Key:          SettingKeyPrepareProcessedEvents,
 			DefaultValue: defaultPrepareProcessedEventsConfigMap,
@@ -910,6 +937,13 @@ func ValidateSettingValue(key SettingKey, value map[string]interface{}) error {
 
 	case SettingKeyWalletBalanceAlertConfig:
 		config, err := utils.ToStruct[AlertSettings](value)
+		if err != nil {
+			return err
+		}
+		return config.Validate()
+
+	case SettingKeySubscriptionAlertConfig, SettingKeyEntitlementAlertConfig:
+		config, err := utils.ToStruct[AlertToggleConfig](value)
 		if err != nil {
 			return err
 		}

--- a/scripts/internal/add_new_user.go
+++ b/scripts/internal/add_new_user.go
@@ -129,7 +129,7 @@ func AddNewUserToTenant() error {
 
 	if email == "" || tenantID == "" || password == "" {
 		log, _ := logger.NewLogger(config.GetDefaultConfig())
-		log.Fatalf("Usage: go run scripts/local/main.go -user-email=<email> -tenant-name=<tenant_name> -user-password=<password>")
+		log.Fatalf("Usage: go run scripts/local/main.go -user-email=<email> -tenant-id=<tenant_id> -user-password=<password>")
 		return nil
 	}
 

--- a/scripts/internal/setup_dummy_billing_customer.go
+++ b/scripts/internal/setup_dummy_billing_customer.go
@@ -141,7 +141,7 @@ func SetupDummyBillingCustomer() error {
 	addonAssociationRepo := entRepo.NewAddonAssociationRepository(client, appLogger, redisCache)
 	connectionRepo := entRepo.NewConnectionRepository(client, appLogger, redisCache)
 	entityIntegrationMappingRepo := entRepo.NewEntityIntegrationMappingRepository(client, appLogger, redisCache)
-	settingsRepo := entRepo.NewSettingsRepository(client, appLogger, redisCache)
+	settingsRepo := entRepo.NewSettingsRepository(client, appLogger, cacheClient)
 	taskRepo := entRepo.NewTaskRepository(client, appLogger)
 	costSheetRepo := entRepo.NewCostsheetRepository(client, appLogger)
 	alertLogsRepo := entRepo.NewAlertLogsRepository(client, appLogger)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-level controls for enabling or disabling subscription spend and entitlement grant alerts.
  * These alerts are disabled by default until enabled for a tenant.

* **Bug Fixes**
  * Alert evaluation now respects tenant-specific settings.
  * Alerts remain disabled when tenant settings cannot be read, preventing unintended notifications.
  * Settings-read failures are now logged to support troubleshooting.
  * Improved settings retrieval reliability through more consistent caching.
  * Prevented errors when optional monitoring data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->