### PR TITLE
fix(deploy): remove GitHub-expression syntax from shell comment (breaks workflow load)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,8 +79,8 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          # Compare via the env var, not ${{ }} interpolation, so a crafted
-          # branch name cannot inject shell.
+          # Compare via the env var, not GitHub-expression interpolation, so
+          # a crafted branch name cannot inject shell.
           IS_DEVELOP=$([ "$GITHUB_REF_NAME" = "develop" ] && echo true || echo false)
           IS_MAIN=$([ "$GITHUB_REF_NAME" = "main" ] && echo true || echo false)
 


### PR DESCRIPTION
## Problem

Every `Build, Push & Deploy to AWS ECS` run on `develop` since ~06:51 UTC fails immediately with **"This run likely failed because of a workflow file issue"** — zero jobs start. Example: [run 33847369656](https://github.com/flexprice/flexprice/actions/runs/33847369656).

## Root cause

In the `image-tag` step's `run:` block, a comment reads:

```
# Compare via the env var, not ${{ }} interpolation, so a crafted
```

GitHub evaluates `${{ ... }}` inside `run:` blocks **at workflow-load time**, before the shell ever runs — comment or not. The empty `${{ }}` parses as an expression and fails:

```
deploy.yml:81:49: unexpected end of input while parsing variable access... [expression]
```

That aborts the whole workflow before any job is created — hence the generic "workflow file issue" and no logs.

Introduced by the SAST hardening batch (#2752): it correctly replaced `${{ }}` interpolation with env-var comparisons, but the explanatory comment used the literal syntax.

## Fix

Reword the comment so it contains no expression syntax. Verified with `actionlint`: expression error gone, no other `${{` in any `run:` comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow comments to explain how branch comparisons are handled during image-tag preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->