### PR TITLE
chore(enhancements): Minor fixes and enhancements

### DIFF
--- a/internal/api/dto/subscription.go
+++ b/internal/api/dto/subscription.go
@@ -201,11 +201,10 @@ func (c *LineItemCommitmentConfig) Validate() error {
 		}
 	}
 
-	// overage_factor is required; 1.0 means usage beyond commitment bills at the base rate.
+	// overage_factor is optional; omitting it defaults to 1.0, meaning usage beyond
+	// the commitment bills at the base rate.
 	if c.OverageFactor == nil {
-		return ierr.NewError("overage_factor is required when commitment is set").
-			WithHint("Specify an overage_factor of 1.0 or greater").
-			Mark(ierr.ErrValidation)
+		c.OverageFactor = types.DefaultOverageFactor()
 	}
 
 	if c.OverageFactor.LessThan(decimal.NewFromInt(1)) {

--- a/internal/api/dto/subscription_line_item.go
+++ b/internal/api/dto/subscription_line_item.go
@@ -392,15 +392,9 @@ func validateCommitmentFieldsCommon(
 		}
 	}
 
-	// Rule 5: Overage factor is required and must be at least 1.0.
-	// Exactly 1.0 means usage beyond commitment bills at the base rate (no premium).
-	if commitmentOverageFactor == nil {
-		return ierr.NewError("commitment_overage_factor is required when commitment is set").
-			WithHint("Specify a commitment_overage_factor of 1.0 or greater").
-			Mark(ierr.ErrValidation)
-	}
-
-	if commitmentOverageFactor.LessThan(decimal.NewFromFloat(1)) {
+	// Rule 5: Overage factor is optional; when omitted it defaults to 1.0 (usage
+	// beyond commitment bills at the base rate). When supplied it must be >= 1.0.
+	if commitmentOverageFactor != nil && commitmentOverageFactor.LessThan(decimal.NewFromFloat(1)) {
 		return ierr.NewError("commitment_overage_factor must be at least 1.0").
 			WithHint("Overage factor determines the multiplier for usage beyond commitment").
 			WithReportableDetails(map[string]interface{}{
@@ -454,6 +448,12 @@ func (r *CreateSubscriptionLineItemRequest) validateCommitmentFields() error {
 	}
 	if err := validateTimeOfDayBuckets(r.CommitmentTimeBuckets); err != nil {
 		return err
+	}
+
+	// Omitted commitment_overage_factor defaults to 1.0 (base rate for overage);
+	// the field is optional in the API contract.
+	if r.HasCommitment() && r.CommitmentOverageFactor == nil {
+		r.CommitmentOverageFactor = types.DefaultOverageFactor()
 	}
 
 	// Auto-set commitment type if not provided (only for create requests)
@@ -716,7 +716,7 @@ func (r CommitmentBucketRequest) Validate(idx int) error {
 		End:             r.End,
 		CommitmentType:  r.CommitmentType,
 		CommitmentValue: r.CommitmentValue,
-		OverageFactor:   r.OverageFactor,
+		OverageFactor:   r.overageFactorOrDefault(),
 		TrueUpEnabled:   r.TrueUpEnabled,
 	}
 	if err := tmp.Validate(); err != nil {
@@ -743,9 +743,18 @@ func (r CommitmentBucketRequest) ToTimeOfDayBucket() types.TimeOfDayBucket {
 		End:             r.End,
 		CommitmentType:  r.CommitmentType,
 		CommitmentValue: r.CommitmentValue,
-		OverageFactor:   r.OverageFactor,
+		OverageFactor:   r.overageFactorOrDefault(),
 		TrueUpEnabled:   r.TrueUpEnabled,
 	}
+}
+
+// overageFactorOrDefault returns the bucket's overage factor, falling back to
+// 1.0 when omitted — overage_factor is optional on the wire.
+func (r CommitmentBucketRequest) overageFactorOrDefault() *decimal.Decimal {
+	if r.OverageFactor != nil {
+		return r.OverageFactor
+	}
+	return types.DefaultOverageFactor()
 }
 
 // bucketRequestsToDomain maps a slice of bucket requests to domain buckets

--- a/internal/api/dto/subscription_line_item_test.go
+++ b/internal/api/dto/subscription_line_item_test.go
@@ -2,6 +2,7 @@ package dto
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,7 +65,8 @@ func TestCommitmentBucketRequest_Validate(t *testing.T) {
 			wantErr: true, errSub: "hour",
 		},
 		{
-			name: "rejects missing overage factor",
+			// overage_factor is optional on the wire and defaults to 1.0.
+			name: "accepts missing overage factor",
 			req: CommitmentBucketRequest{
 				Start:           types.Bucket{Hour: 9, Minute: 0},
 				End:             types.Bucket{Hour: 10, Minute: 0},
@@ -72,7 +74,6 @@ func TestCommitmentBucketRequest_Validate(t *testing.T) {
 				CommitmentType:  types.COMMITMENT_TYPE_AMOUNT,
 				CommitmentValue: decimal.NewFromInt(100),
 			},
-			wantErr: true, errSub: "overage_factor is required",
 		},
 		{
 			// Exactly 1.0 is valid for buckets: overage bills at base rate.
@@ -369,5 +370,65 @@ func TestCreateSubscriptionLineItemRequest_Validate_CadenceMustDivideSub(t *test
 				require.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestCreateSubscriptionLineItemRequest_DefaultsCommitmentOverageFactor(t *testing.T) {
+	t.Run("defaults to 1.0 when omitted", func(t *testing.T) {
+		req := CreateSubscriptionLineItemRequest{
+			PriceID:          "price_test",
+			CommitmentAmount: lo.ToPtr(decimal.NewFromInt(100)),
+		}
+		if err := req.Validate(nil, nil); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if req.CommitmentOverageFactor == nil {
+			t.Fatal("expected commitment_overage_factor to be defaulted")
+		}
+		if !req.CommitmentOverageFactor.Equal(decimal.NewFromInt(1)) {
+			t.Fatalf("expected default of 1, got: %s", req.CommitmentOverageFactor)
+		}
+	})
+
+	t.Run("keeps an explicit factor", func(t *testing.T) {
+		req := CreateSubscriptionLineItemRequest{
+			PriceID:                 "price_test",
+			CommitmentAmount:        lo.ToPtr(decimal.NewFromInt(100)),
+			CommitmentOverageFactor: lo.ToPtr(decimal.NewFromFloat(1.5)),
+		}
+		if err := req.Validate(nil, nil); err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if !req.CommitmentOverageFactor.Equal(decimal.NewFromFloat(1.5)) {
+			t.Fatalf("expected 1.5, got: %s", req.CommitmentOverageFactor)
+		}
+	})
+
+	t.Run("still rejects a factor below 1.0", func(t *testing.T) {
+		req := CreateSubscriptionLineItemRequest{
+			PriceID:                 "price_test",
+			CommitmentAmount:        lo.ToPtr(decimal.NewFromInt(100)),
+			CommitmentOverageFactor: lo.ToPtr(decimal.NewFromFloat(0.5)),
+		}
+		err := req.Validate(nil, nil)
+		if err == nil {
+			t.Fatal("expected validation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "commitment_overage_factor must be at least 1.0") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestCommitmentBucketRequest_ToTimeOfDayBucket_DefaultsOverageFactor(t *testing.T) {
+	b := CommitmentBucketRequest{
+		Start:           types.Bucket{Hour: 9, Minute: 0},
+		End:             types.Bucket{Hour: 10, Minute: 0},
+		CommitmentType:  types.COMMITMENT_TYPE_AMOUNT,
+		CommitmentValue: decimal.NewFromInt(100),
+	}.ToTimeOfDayBucket()
+
+	if b.OverageFactor == nil || !b.OverageFactor.Equal(decimal.NewFromInt(1)) {
+		t.Fatalf("expected overage factor to default to 1, got: %v", b.OverageFactor)
 	}
 }

--- a/internal/ee/service/billing_meter_usage.go
+++ b/internal/ee/service/billing_meter_usage.go
@@ -29,6 +29,24 @@ type meterUsageBaseChargeInfo struct {
 	adjustedEntitlementQuantity *decimal.Decimal
 }
 
+// elapsedLineItemWindow clips a line item's overlap with [periodStart, periodEnd)
+// against asOf. ok is false when nothing has elapsed yet — the line starts in
+// the future, has already ended, or is zero-length (EndDate == StartDate).
+func elapsedLineItemWindow(item *subscription.SubscriptionLineItem, periodStart, periodEnd, asOf time.Time) (start, end time.Time, ok bool) {
+	start = item.GetPeriodStart(periodStart)
+	end = item.GetPeriodEnd(periodEnd)
+	if start.After(asOf) {
+		return start, end, false
+	}
+	if !item.EndDate.IsZero() && !item.EndDate.After(item.StartDate) {
+		return start, end, false
+	}
+	if end.After(asOf) {
+		end = asOf
+	}
+	return start, end, end.After(start) || start.Equal(asOf)
+}
+
 // CalculateMeterUsageCharges computes usage-based invoice line items from the meter_usage table.
 // All queries (bucketed meters, windowed entitlements, windowed commitments) read from
 // MeterUsageRepo — never from raw events.
@@ -134,6 +152,22 @@ func (s *billingService) CalculateMeterUsageCharges(
 
 	for _, item := range sub.LineItems {
 		if item.PriceType != types.PRICE_TYPE_USAGE {
+			continue
+		}
+
+		// Clip the line's period to elapsed time so a version that has not started yet (or a zero-length EndDate==StartDate leftover)
+		// cannot contribute commitment to wallet/invoice totals.
+		if _, _, active := elapsedLineItemWindow(item, periodStart, periodEnd, asOf); !active {
+			s.Logger.Debug(ctx, "skipping meter-usage line item: item inactive during elapsed window",
+				"subscription_id", sub.ID,
+				"line_item_id", item.ID,
+				"price_id", item.PriceID,
+				"invoice_period_start", periodStart,
+				"invoice_period_end", periodEnd,
+				"item_start_date", item.StartDate,
+				"item_end_date", item.EndDate,
+				"as_of", asOf,
+			)
 			continue
 		}
 
@@ -305,21 +339,8 @@ func (s *billingService) CalculateMeterUsageCharges(
 				}
 			}
 
-			// Clip the invoice period against the line item's own active range.
 			psStart := item.GetPeriodStart(periodStart)
 			psEnd := item.GetPeriodEnd(periodEnd)
-			if !psEnd.After(psStart) {
-				s.Logger.Debug(ctx, "skipping meter-usage line item: item inactive during invoice window",
-					"subscription_id", sub.ID,
-					"line_item_id", item.ID,
-					"price_id", item.PriceID,
-					"invoice_period_start", periodStart,
-					"invoice_period_end", periodEnd,
-					"item_start_date", item.StartDate,
-					"item_end_date", item.EndDate,
-				)
-				continue
-			}
 			usageCharges = append(usageCharges, dto.CreateInvoiceLineItemRequest{
 				EntityID:                    lo.ToPtr(item.EntityID),
 				EntityType:                  lo.ToPtr(string(item.EntityType)),
@@ -564,10 +585,10 @@ func (s *billingService) applyMeterUsageCommitment(
 	// Windowed commitment — needs bucketed values from meter_usage
 	linePeriodStart := item.GetPeriodStart(periodStart)
 	linePeriodEnd := item.GetPeriodEnd(periodEnd)
-	effectiveEnd := asOf
-	if effectiveEnd.Before(linePeriodStart) {
-		effectiveEnd = linePeriodStart
+	if asOf.Before(linePeriodStart) {
+		return decimal.Zero, nil, nil
 	}
+	effectiveEnd := asOf
 	if effectiveEnd.After(linePeriodEnd) {
 		effectiveEnd = linePeriodEnd
 	}

--- a/internal/ee/service/billing_test.go
+++ b/internal/ee/service/billing_test.go
@@ -3106,6 +3106,128 @@ func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_WindowedTrueUp_Uses
 	s.True(totalAmount.LessThan(fullPeriodTotal), "amount should not project full-period commitment")
 }
 
+func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_DeferredCommitment_DoesNotChargeUntilStart() {
+	ctx := s.GetContext()
+	s.setupTestData()
+
+	now := time.Now().UTC()
+	periodStart := now.Add(-48 * time.Hour)
+	periodEnd := now.Add(20 * 24 * time.Hour)
+	futureStart := now.Add(13 * 24 * time.Hour)
+
+	flatPrice := &price.Price{
+		ID:                 "price_deferred_commitment_flat",
+		Amount:             decimal.RequireFromString("12.50"),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_USAGE,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		MeterID:            s.testData.meters.apiCalls.ID,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, flatPrice))
+
+	commitmentQty := decimal.NewFromInt(30)
+	overageFactor := decimal.NewFromInt(1)
+
+	newDeferredItem := func(id string, start, end time.Time, windowed bool) *subscription.SubscriptionLineItem {
+		return &subscription.SubscriptionLineItem{
+			ID:                      id,
+			SubscriptionID:          s.testData.subscription.ID,
+			CustomerID:              s.testData.subscription.CustomerID,
+			EntityID:                s.testData.plan.ID,
+			EntityType:              types.SubscriptionLineItemEntityTypePlan,
+			PlanDisplayName:         s.testData.plan.Name,
+			PriceID:                 flatPrice.ID,
+			PriceType:               types.PRICE_TYPE_USAGE,
+			MeterID:                 s.testData.meters.apiCalls.ID,
+			MeterDisplayName:        s.testData.meters.apiCalls.Name,
+			DisplayName:             "Deferred commitment",
+			Quantity:                decimal.Zero,
+			Currency:                s.testData.subscription.Currency,
+			BillingPeriod:           s.testData.subscription.BillingPeriod,
+			InvoiceCadence:          types.InvoiceCadenceArrear,
+			StartDate:               start,
+			EndDate:                 end,
+			CommitmentType:          types.COMMITMENT_TYPE_QUANTITY,
+			CommitmentQuantity:      &commitmentQty,
+			CommitmentOverageFactor: &overageFactor,
+			CommitmentTrueUpEnabled: true,
+			CommitmentWindowed:      windowed,
+			BaseModel:               types.GetDefaultBaseModel(ctx),
+		}
+	}
+
+	tests := []struct {
+		name     string
+		item     *subscription.SubscriptionLineItem
+		wantZero bool
+	}{
+		{
+			name:     "future_start_non_windowed",
+			item:     newDeferredItem("sub_li_deferred_flat", futureStart, time.Time{}, false),
+			wantZero: true,
+		},
+		{
+			name:     "future_start_windowed",
+			item:     newDeferredItem("sub_li_deferred_windowed", futureStart, time.Time{}, true),
+			wantZero: true,
+		},
+		{
+			name:     "zero_length_at_future_start",
+			item:     newDeferredItem("sub_li_deferred_zero_length", futureStart, futureStart, false),
+			wantZero: true,
+		},
+		{
+			name:     "already_started_non_windowed_still_charges",
+			item:     newDeferredItem("sub_li_active_commitment", s.testData.subscription.StartDate, time.Time{}, false),
+			wantZero: false,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			subCopy := *s.testData.subscription
+			subCopy.CurrentPeriodStart = periodStart
+			subCopy.CurrentPeriodEnd = periodEnd
+			subCopy.LineItems = []*subscription.SubscriptionLineItem{tt.item}
+
+			usage := &dto.GetUsageBySubscriptionResponse{
+				StartTime: periodStart,
+				EndTime:   periodEnd,
+				Currency:  subCopy.Currency,
+				Charges: []*dto.SubscriptionUsageByMetersResponse{
+					{
+						SubscriptionLineItemID: tt.item.ID,
+						Price:                  flatPrice,
+						Quantity:               0,
+						Amount:                 0,
+						IsOverage:              false,
+					},
+				},
+			}
+
+			lineItems, totalAmount, err := s.service.CalculateMeterUsageCharges(ctx, &subCopy, usage,
+				periodStart, periodEnd, types.UsageSourceWallet,
+			)
+			s.NoError(err)
+			if tt.wantZero {
+				s.True(totalAmount.IsZero(), "deferred/zero-length commitment must not affect balance, got %s", totalAmount)
+				s.Empty(lineItems)
+				return
+			}
+			expected := flatPrice.Amount.Mul(commitmentQty)
+			s.True(totalAmount.Equal(expected), "active commitment should true-up to %s, got %s", expected, totalAmount)
+			s.Len(lineItems, 1)
+		})
+	}
+}
+
 func (s *BillingServiceSuite) TestCalculateMeterUsageCharges_CumulativeCommitment() {
 	// Monthly subscription with annual commitment ($60), overage factor 2x
 	ctx := s.GetContext()

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -482,19 +483,14 @@ func (s *subscriptionService) deleteSubscriptionLineItem(ctx context.Context, li
 }
 
 // cancelScheduledLineItem removes a line item that has not started yet and
-// reopens the predecessor that was terminated at this item's start date.
+// reopens the predecessor this successor replaced, if one was recorded.
 func (s *subscriptionService) cancelScheduledLineItem(ctx context.Context, lineItem *subscription.SubscriptionLineItem) (*dto.SubscriptionLineItemResponse, error) {
 	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
-		filter := types.NewNoLimitSubscriptionLineItemFilter()
-		filter.SubscriptionIDs = []string{lineItem.SubscriptionID}
-		filter.ActiveFilter = false
-		filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
-		allLineItems, err := s.SubscriptionLineItemRepo.List(ctx, filter)
-		if err != nil {
-			return err
-		}
-
-		for _, pred := range findScheduledLinePredecessors(allLineItems, lineItem) {
+		if predID := predecessorLineItemID(lineItem); predID != "" {
+			pred, err := s.SubscriptionLineItemRepo.Get(ctx, predID)
+			if err != nil {
+				return err
+			}
 			pred.EndDate = lineItem.EndDate
 			if err := s.SubscriptionLineItemRepo.Update(ctx, pred); err != nil {
 				return err
@@ -510,34 +506,21 @@ func (s *subscriptionService) cancelScheduledLineItem(ctx context.Context, lineI
 	return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: lineItem}, nil
 }
 
-func findScheduledLinePredecessors(allLineItems []*subscription.SubscriptionLineItem, scheduled *subscription.SubscriptionLineItem) []*subscription.SubscriptionLineItem {
-	var byEndDate []*subscription.SubscriptionLineItem
-	for _, item := range allLineItems {
-		if item == nil || item.ID == scheduled.ID {
-			continue
-		}
-		if item.EndDate.IsZero() || item.EndDate.Unix() != scheduled.StartDate.Unix() {
-			continue
-		}
-		byEndDate = append(byEndDate, item)
+func predecessorLineItemID(item *subscription.SubscriptionLineItem) string {
+	if item == nil || item.Metadata == nil {
+		return ""
 	}
-	if len(byEndDate) == 0 {
-		return nil
-	}
+	return item.Metadata[types.SubscriptionLineItemMetadataKeyPredecessorID]
+}
 
-	var matched []*subscription.SubscriptionLineItem
-	for _, pred := range byEndDate {
-		if pred.PriceID == scheduled.PriceID || (scheduled.MeterID != "" && pred.MeterID == scheduled.MeterID) {
-			matched = append(matched, pred)
-		}
+func setPredecessorLineItemID(item *subscription.SubscriptionLineItem, predecessorID string) {
+	if item == nil || predecessorID == "" {
+		return
 	}
-	if len(matched) > 0 {
-		return matched
-	}
-	if len(byEndDate) == 1 {
-		return byEndDate
-	}
-	return nil
+	copied := make(map[string]string, len(item.Metadata)+1)
+	maps.Copy(copied, item.Metadata)
+	copied[types.SubscriptionLineItemMetadataKeyPredecessorID] = predecessorID
+	item.Metadata = copied
 }
 
 // UpdateSubscriptionLineItem updates a subscription line item by terminating the existing one and creating a new one
@@ -658,6 +641,7 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			if !oldEndDate.IsZero() {
 				newLineItem.EndDate = oldEndDate // Fill the gap freed up by the backdate
 			}
+			setPredecessorLineItemID(newLineItem, lineItemID)
 
 			// Materialize bucket prices when the update request carries
 			// commitment_time_buckets: ToSubscriptionLineItem rebuilt

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -140,10 +140,10 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 
 	priceResp, priceErr := NewPriceService(s.ServiceParams).GetPrice(ctx, lineItem.PriceID)
 	if priceErr != nil {
-		return nil, priceErr
+		s.Logger.Info(ctx, "skipped price expansion for created line item", "line_item_id", lineItem.ID, "price_id", lineItem.PriceID, "error", priceErr)
 	}
 
-	if lineItem != nil && !lineItem.IsUsage() && lineItem.Meter == nil {
+	if lineItem != nil && lineItem.IsUsage() && lineItem.Meter == nil {
 		m, err := s.MeterRepo.GetMeter(ctx, lineItem.MeterID)
 		if err != nil {
 			s.Logger.Info(ctx, "skipped meter expansion for line item", "line_item_id", lineItem.ID, "meter_id", lineItem.MeterID, "error", err)
@@ -171,6 +171,10 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 		})
 		if err != nil {
 			return nil, err
+		}
+
+		if priceResp != nil {
+			return nil, priceErr
 		}
 
 		// Temporarily override current period on a copy so LineItemProrationService

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -140,19 +140,20 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 
 	priceResp, priceErr := NewPriceService(s.ServiceParams).GetPrice(ctx, lineItem.PriceID)
 	if priceErr != nil {
-		s.Logger.Info(ctx, "skipped price expansion for created line item",
-			"line_item_id", lineItem.ID, "price_id", lineItem.PriceID, "error", priceErr)
+		return nil, priceErr
 	}
-	s.attachLineItemMeter(ctx, lineItem)
+
+	if lineItem != nil && !lineItem.IsUsage() && lineItem.Meter == nil {
+		m, err := s.MeterRepo.GetMeter(ctx, lineItem.MeterID)
+		if err != nil {
+			s.Logger.Info(ctx, "skipped meter expansion for line item", "line_item_id", lineItem.ID, "meter_id", lineItem.MeterID, "error", err)
+		}
+		lineItem.Meter = m
+	}
 
 	// Apply proration for the add if requested. Skip usage prices (unknown future consumption).
 	if req.ProrationBehavior == types.ProrationBehaviorCreateProrations &&
 		lineItem.PriceType != types.PRICE_TYPE_USAGE {
-
-		if priceErr != nil {
-			return nil, priceErr
-		}
-
 		effectiveDate := time.Now().UTC()
 		if req.StartDate != nil {
 			effectiveDate = req.StartDate.UTC()
@@ -199,22 +200,6 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 	}
 
 	return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: lineItem, Price: priceResp}, nil
-}
-
-// attachLineItemMeter populates the line item's Meter for usage line items so
-// responses expose it without a follow-up read. A meter lookup failure is not
-// fatal: the line item is already persisted and meter is an optional field.
-func (s *subscriptionService) attachLineItemMeter(ctx context.Context, lineItem *subscription.SubscriptionLineItem) {
-	if lineItem == nil || !lineItem.IsUsage() || lineItem.Meter != nil {
-		return
-	}
-	m, err := s.MeterRepo.GetMeter(ctx, lineItem.MeterID)
-	if err != nil {
-		s.Logger.Info(ctx, "skipped meter expansion for line item",
-			"line_item_id", lineItem.ID, "meter_id", lineItem.MeterID, "error", err)
-		return
-	}
-	lineItem.Meter = m
 }
 
 // buildLineItemParamsForPrice builds LineItemParams for a price, resolving Plan/Addon/Subscription when skipEntitlementCheck is true.

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -137,9 +137,20 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 		return nil, err
 	}
 
+	priceResp, priceErr := NewPriceService(s.ServiceParams).GetPrice(ctx, lineItem.PriceID)
+	if priceErr != nil {
+		s.Logger.Info(ctx, "skipped price expansion for created line item",
+			"line_item_id", lineItem.ID, "price_id", lineItem.PriceID, "error", priceErr)
+	}
+	s.attachLineItemMeter(ctx, lineItem)
+
 	// Apply proration for the add if requested. Skip usage prices (unknown future consumption).
 	if req.ProrationBehavior == types.ProrationBehaviorCreateProrations &&
 		lineItem.PriceType != types.PRICE_TYPE_USAGE {
+
+		if priceErr != nil {
+			return nil, priceErr
+		}
 
 		effectiveDate := time.Now().UTC()
 		if req.StartDate != nil {
@@ -156,12 +167,6 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 			BillingPeriod:    sub.BillingPeriod,
 			Timezone:         sub.Timezone,
 		})
-		if err != nil {
-			return nil, err
-		}
-
-		priceSvc := NewPriceService(s.ServiceParams)
-		priceResp, err := priceSvc.GetPrice(ctx, lineItem.PriceID)
 		if err != nil {
 			return nil, err
 		}
@@ -192,7 +197,23 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 		}
 	}
 
-	return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: lineItem}, nil
+	return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: lineItem, Price: priceResp}, nil
+}
+
+// attachLineItemMeter populates the line item's Meter for usage line items so
+// responses expose it without a follow-up read. A meter lookup failure is not
+// fatal: the line item is already persisted and meter is an optional field.
+func (s *subscriptionService) attachLineItemMeter(ctx context.Context, lineItem *subscription.SubscriptionLineItem) {
+	if lineItem == nil || !lineItem.IsUsage() || lineItem.Meter != nil {
+		return
+	}
+	m, err := s.MeterRepo.GetMeter(ctx, lineItem.MeterID)
+	if err != nil {
+		s.Logger.Info(ctx, "skipped meter expansion for line item",
+			"line_item_id", lineItem.ID, "meter_id", lineItem.MeterID, "error", err)
+		return
+	}
+	lineItem.Meter = m
 }
 
 // buildLineItemParamsForPrice builds LineItemParams for a price, resolving Plan/Addon/Subscription when skipEntitlementCheck is true.
@@ -362,6 +383,13 @@ func (s *subscriptionService) deleteSubscriptionLineItem(ctx context.Context, li
 		effectiveFrom = time.Now().UTC()
 	}
 
+	// A version that has not started yet cannot be "terminated" at now — that
+	// is before its start. Treat DELETE (or effective_from on/before start) as
+	// cancelling the scheduled version and reopening its predecessor.
+	if !effectiveFrom.After(lineItem.StartDate) && lineItem.StartDate.After(time.Now().UTC()) {
+		return s.cancelScheduledLineItem(ctx, lineItem)
+	}
+
 	// Validate effective from date is on or after start date
 	if effectiveFrom.Before(lineItem.StartDate) {
 		return nil, ierr.NewError("effective from date must be on or after start date").
@@ -451,6 +479,65 @@ func (s *subscriptionService) deleteSubscriptionLineItem(ctx context.Context, li
 	}
 
 	return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: lineItem}, nil
+}
+
+// cancelScheduledLineItem removes a line item that has not started yet and
+// reopens the predecessor that was terminated at this item's start date.
+func (s *subscriptionService) cancelScheduledLineItem(ctx context.Context, lineItem *subscription.SubscriptionLineItem) (*dto.SubscriptionLineItemResponse, error) {
+	err := s.DB.WithTx(ctx, func(ctx context.Context) error {
+		filter := types.NewNoLimitSubscriptionLineItemFilter()
+		filter.SubscriptionIDs = []string{lineItem.SubscriptionID}
+		filter.ActiveFilter = false
+		filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+		allLineItems, err := s.SubscriptionLineItemRepo.List(ctx, filter)
+		if err != nil {
+			return err
+		}
+
+		for _, pred := range findScheduledLinePredecessors(allLineItems, lineItem) {
+			pred.EndDate = lineItem.EndDate
+			if err := s.SubscriptionLineItemRepo.Update(ctx, pred); err != nil {
+				return err
+			}
+		}
+
+		lineItem.Status = types.StatusDeleted
+		return s.SubscriptionLineItemRepo.Update(ctx, lineItem)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &dto.SubscriptionLineItemResponse{SubscriptionLineItem: lineItem}, nil
+}
+
+func findScheduledLinePredecessors(allLineItems []*subscription.SubscriptionLineItem, scheduled *subscription.SubscriptionLineItem) []*subscription.SubscriptionLineItem {
+	var byEndDate []*subscription.SubscriptionLineItem
+	for _, item := range allLineItems {
+		if item == nil || item.ID == scheduled.ID {
+			continue
+		}
+		if item.EndDate.IsZero() || item.EndDate.Unix() != scheduled.StartDate.Unix() {
+			continue
+		}
+		byEndDate = append(byEndDate, item)
+	}
+	if len(byEndDate) == 0 {
+		return nil
+	}
+
+	var matched []*subscription.SubscriptionLineItem
+	for _, pred := range byEndDate {
+		if pred.PriceID == scheduled.PriceID || (scheduled.MeterID != "" && pred.MeterID == scheduled.MeterID) {
+			matched = append(matched, pred)
+		}
+	}
+	if len(matched) > 0 {
+		return matched
+	}
+	if len(byEndDate) == 1 {
+		return byEndDate
+	}
+	return nil
 }
 
 // UpdateSubscriptionLineItem updates a subscription line item by terminating the existing one and creating a new one
@@ -779,12 +866,11 @@ func (s *subscriptionService) validateLineItemCommitment(ctx context.Context, li
 			Mark(ierr.ErrValidation)
 	}
 
-	// Rule 2: Overage factor must be at least 1.0 when commitment is set.
-	// Exactly 1.0 means usage beyond commitment bills at the base rate (no premium).
+	// Rule 2: Overage factor is optional and defaults to 1.0 when a commitment is
+	// set without one — usage beyond commitment then bills at the base rate.
+	// When supplied it must be at least 1.0.
 	if lineItem.CommitmentOverageFactor == nil {
-		return ierr.NewError("commitment_overage_factor is required when commitment is set").
-			WithHint("Specify a commitment_overage_factor of 1.0 or greater").
-			Mark(ierr.ErrValidation)
+		lineItem.CommitmentOverageFactor = types.DefaultOverageFactor()
 	}
 
 	if lineItem.CommitmentOverageFactor.LessThan(decimal.NewFromInt(1)) {

--- a/internal/ee/service/subscription_line_item_test.go
+++ b/internal/ee/service/subscription_line_item_test.go
@@ -268,6 +268,51 @@ func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_Effect
 	s.True(li.EndDate.IsZero(), "line item should remain unterminated")
 }
 
+func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_ScheduledVersion_DefaultEffectiveFromCancels() {
+	ctx := s.GetContext()
+	futureStart := time.Now().UTC().Add(13 * 24 * time.Hour)
+
+	scheduled := *s.testData.lineItem
+	scheduled.ID = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM)
+	scheduled.StartDate = futureStart
+	scheduled.EndDate = time.Time{}
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, &scheduled))
+
+	resp, err := s.service.DeleteSubscriptionLineItem(ctx, scheduled.ID, dto.DeleteSubscriptionLineItemRequest{})
+	s.NoError(err)
+	s.NotNil(resp)
+	s.Equal(types.StatusDeleted, resp.SubscriptionLineItem.Status)
+
+	got, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, scheduled.ID)
+	s.NoError(err)
+	s.Equal(types.StatusDeleted, got.Status)
+}
+
+func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_ScheduledVersion_RestoresPredecessor() {
+	ctx := s.GetContext()
+	futureStart := time.Now().UTC().Add(13 * 24 * time.Hour)
+	newAmount := decimal.NewFromInt(75)
+
+	updated, err := s.service.UpdateSubscriptionLineItem(ctx, s.testData.lineItem.ID, dto.UpdateSubscriptionLineItemRequest{
+		Amount:        &newAmount,
+		EffectiveFrom: &futureStart,
+	})
+	s.NoError(err)
+	s.NotEqual(s.testData.lineItem.ID, updated.SubscriptionLineItem.ID)
+
+	oldLi, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, s.testData.lineItem.ID)
+	s.NoError(err)
+	s.Equal(futureStart.Truncate(time.Second).Unix(), oldLi.EndDate.Truncate(time.Second).Unix())
+
+	_, err = s.service.DeleteSubscriptionLineItem(ctx, updated.SubscriptionLineItem.ID, dto.DeleteSubscriptionLineItemRequest{})
+	s.NoError(err)
+
+	restored, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, s.testData.lineItem.ID)
+	s.NoError(err)
+	s.True(restored.EndDate.IsZero(), "cancelling the scheduled version should reopen the prior line")
+	s.Equal(types.StatusPublished, restored.Status)
+}
+
 func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_EffectiveFromOnOrAfterStartDate() {
 	ctx := s.GetContext()
 	effectiveFrom := s.testData.lineItem.StartDate.Add(24 * time.Hour) // 1 day after start
@@ -2077,4 +2122,85 @@ func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItemInternal_D
 	})
 	s.Require().NoError(err)
 	s.Equal(0, s.countSubscriptionUpdated())
+}
+
+// TestAddSubscriptionLineItem_ResponseCarriesExpandedPrice asserts the create
+// response embeds the resulting price, so a caller creating an inline price
+// learns its amount and currency without a second call.
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_ResponseCarriesExpandedPrice() {
+	ctx := s.GetContext()
+
+	req := dto.CreateSubscriptionLineItemRequest{
+		Price: &dto.SubscriptionPriceCreateRequest{
+			Type:               types.PRICE_TYPE_FIXED,
+			PriceUnitType:      types.PRICE_UNIT_TYPE_FIAT,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+			InvoiceCadence:     types.InvoiceCadenceAdvance,
+			Amount:             lo.ToPtr(decimal.NewFromInt(42)),
+			LookupKey:          "inline_price_expansion",
+		},
+		SkipEntitlementCheck: true,
+	}
+
+	resp, err := s.service.AddSubscriptionLineItem(ctx, s.testData.subscription.ID, req)
+	s.Require().NoError(err)
+	s.Require().NotNil(resp.Price, "create response must embed the resulting price")
+	s.Equal(resp.PriceID, resp.Price.ID)
+	s.True(decimal.NewFromInt(42).Equal(resp.Price.Amount), "expected amount 42, got %s", resp.Price.Amount)
+	s.Equal(s.testData.subscription.Currency, resp.Price.Currency)
+}
+
+// TestAddSubscriptionLineItem_CommitmentOverageFactorDefaultsToOne asserts a
+// commitment without commitment_overage_factor is accepted and stored as 1.0,
+// matching the field being optional in the OpenAPI spec.
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_CommitmentOverageFactorDefaultsToOne() {
+	ctx := s.GetContext()
+
+	m := &meter.Meter{
+		ID:        types.GenerateUUIDWithPrefix(types.UUID_PREFIX_METER),
+		Name:      "Commitment Default Meter",
+		EventName: "commitment_default_event",
+		Aggregation: meter.Aggregation{
+			Type:  types.AggregationSum,
+			Field: "value",
+		},
+		ResetUsage: types.ResetUsageBillingPeriod,
+		BaseModel:  types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().MeterRepo.CreateMeter(ctx, m))
+
+	usagePrice := &price.Price{
+		ID:                 types.GenerateUUIDWithPrefix(types.UUID_PREFIX_PRICE),
+		Amount:             decimal.NewFromInt(2),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_SUBSCRIPTION,
+		EntityID:           s.testData.subscription.ID,
+		Type:               types.PRICE_TYPE_USAGE,
+		MeterID:            m.ID,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceArrear,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, usagePrice))
+
+	req := dto.CreateSubscriptionLineItemRequest{
+		PriceID:              usagePrice.ID,
+		SkipEntitlementCheck: true,
+		CommitmentAmount:     lo.ToPtr(decimal.NewFromInt(100)),
+	}
+
+	resp, err := s.service.AddSubscriptionLineItem(ctx, s.testData.subscription.ID, req)
+	s.Require().NoError(err, "commitment without an overage factor must be accepted")
+	s.Require().NotNil(resp.CommitmentOverageFactor)
+	s.True(decimal.NewFromInt(1).Equal(*resp.CommitmentOverageFactor),
+		"expected default overage factor 1, got %s", resp.CommitmentOverageFactor)
+	s.Equal(types.COMMITMENT_TYPE_AMOUNT, resp.CommitmentType)
+
+	// The create response also carries the meter for usage line items.
+	s.Require().NotNil(resp.Meter, "usage line item response must embed its meter")
+	s.Equal(m.ID, resp.Meter.ID)
 }

--- a/internal/ee/service/subscription_line_item_test.go
+++ b/internal/ee/service/subscription_line_item_test.go
@@ -299,6 +299,7 @@ func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_Schedu
 	})
 	s.NoError(err)
 	s.NotEqual(s.testData.lineItem.ID, updated.SubscriptionLineItem.ID)
+	s.Equal(s.testData.lineItem.ID, updated.SubscriptionLineItem.Metadata[types.SubscriptionLineItemMetadataKeyPredecessorID])
 
 	oldLi, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, s.testData.lineItem.ID)
 	s.NoError(err)
@@ -311,6 +312,56 @@ func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_Schedu
 	s.NoError(err)
 	s.True(restored.EndDate.IsZero(), "cancelling the scheduled version should reopen the prior line")
 	s.Equal(types.StatusPublished, restored.Status)
+}
+
+func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_ScheduledVersion_RestoresOnlyReferencedPredecessor() {
+	ctx := s.GetContext()
+	futureStart := time.Now().UTC().Add(13 * 24 * time.Hour)
+	newAmount := decimal.NewFromInt(75)
+
+	neighbor := *s.testData.lineItem
+	neighbor.ID = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM)
+	neighbor.EndDate = futureStart
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, &neighbor))
+
+	updated, err := s.service.UpdateSubscriptionLineItem(ctx, s.testData.lineItem.ID, dto.UpdateSubscriptionLineItemRequest{
+		Amount:        &newAmount,
+		EffectiveFrom: &futureStart,
+	})
+	s.NoError(err)
+
+	_, err = s.service.DeleteSubscriptionLineItem(ctx, updated.SubscriptionLineItem.ID, dto.DeleteSubscriptionLineItemRequest{})
+	s.NoError(err)
+
+	restored, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, s.testData.lineItem.ID)
+	s.NoError(err)
+	s.True(restored.EndDate.IsZero(), "only the referenced predecessor should be reopened")
+
+	untouched, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, neighbor.ID)
+	s.NoError(err)
+	s.Equal(futureStart.Truncate(time.Second).Unix(), untouched.EndDate.Truncate(time.Second).Unix())
+}
+
+func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_ScheduledVersion_NoPredecessorIDSkipsRestore() {
+	ctx := s.GetContext()
+	futureStart := time.Now().UTC().Add(13 * 24 * time.Hour)
+
+	s.testData.lineItem.EndDate = futureStart
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Update(ctx, s.testData.lineItem))
+
+	scheduled := *s.testData.lineItem
+	scheduled.ID = types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM)
+	scheduled.StartDate = futureStart
+	scheduled.EndDate = time.Time{}
+	scheduled.Metadata = nil
+	s.NoError(s.GetStores().SubscriptionLineItemRepo.Create(ctx, &scheduled))
+
+	_, err := s.service.DeleteSubscriptionLineItem(ctx, scheduled.ID, dto.DeleteSubscriptionLineItemRequest{})
+	s.NoError(err)
+
+	oldLi, err := s.GetStores().SubscriptionLineItemRepo.Get(ctx, s.testData.lineItem.ID)
+	s.NoError(err)
+	s.Equal(futureStart.Truncate(time.Second).Unix(), oldLi.EndDate.Truncate(time.Second).Unix())
 }
 
 func (s *SubscriptionLineItemServiceSuite) TestDeleteSubscriptionLineItem_EffectiveFromOnOrAfterStartDate() {

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -725,7 +725,7 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscriptionLineItemCommitments
 		s.False(matched.CommitmentWindowed)
 	})
 
-	s.Run("rejects_invalid_commitment_config_missing_overage_factor", func() {
+	s.Run("defaults_overage_factor_when_omitted", func() {
 		addonID := "addon_commitment_missing_overage"
 		priceID := "price_addon_commitment_missing_overage"
 		createAddonWithUsagePrice(addonID, priceID, s.testData.meters.apiCalls.ID)
@@ -745,7 +745,24 @@ func (s *SubscriptionServiceSuite) TestAddAddonToSubscriptionLineItemCommitments
 				},
 			},
 		})
-		s.Error(err)
+		s.NoError(err)
+
+		filter := types.NewNoLimitSubscriptionLineItemFilter()
+		filter.SubscriptionIDs = []string{s.testData.subscription.ID}
+		items, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, filter)
+		s.NoError(err)
+
+		var matched *subscription.SubscriptionLineItem
+		for _, it := range items {
+			if it.EntityType == types.SubscriptionLineItemEntityTypeAddon && it.EntityID == addonID && it.PriceID == priceID {
+				matched = it
+				break
+			}
+		}
+		s.Require().NotNil(matched)
+		s.Require().NotNil(matched.CommitmentOverageFactor)
+		s.True(decimal.NewFromInt(1).Equal(*matched.CommitmentOverageFactor),
+			"expected default overage factor 1, got %s", matched.CommitmentOverageFactor)
 	})
 
 	s.Run("rejects_window_commitment_when_meter_has_no_bucket_size", func() {

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -221,7 +221,7 @@ func (r *subscriptionLineItemRepository) Update(ctx context.Context, item *subsc
 	)
 
 	client := r.client.Writer(ctx)
-	_, err := client.SubscriptionLineItem.UpdateOneID(item.ID).
+	builder := client.SubscriptionLineItem.UpdateOneID(item.ID).
 		SetNillableEntityID(types.ToNillableString(item.EntityID)).
 		SetNillablePlanDisplayName(types.ToNillableString(item.PlanDisplayName)).
 		SetPriceID(item.PriceID).
@@ -239,7 +239,6 @@ func (r *subscriptionLineItemRepository) Update(ctx context.Context, item *subsc
 		SetCurrency(item.Currency).
 		SetBillingPeriod(item.BillingPeriod).
 		SetNillableStartDate(types.ToNillableTime(item.StartDate)).
-		SetNillableEndDate(types.ToNillableTime(item.EndDate)).
 		SetMetadata(item.Metadata).
 		// Commitment fields
 		SetNillableCommitmentAmount(item.CommitmentAmount).
@@ -251,8 +250,13 @@ func (r *subscriptionLineItemRepository) Update(ctx context.Context, item *subsc
 		SetCommitmentTimeBuckets(item.CommitmentTimeBuckets).
 		SetStatus(string(item.Status)).
 		SetUpdatedBy(item.UpdatedBy).
-		SetUpdatedAt(time.Now()).
-		Save(ctx)
+		SetUpdatedAt(time.Now())
+	if item.EndDate.IsZero() {
+		builder.ClearEndDate()
+	} else {
+		builder.SetEndDate(item.EndDate)
+	}
+	_, err := builder.Save(ctx)
 
 	if err != nil {
 		SetSpanError(span, err)

--- a/internal/types/commitment.go
+++ b/internal/types/commitment.go
@@ -191,3 +191,12 @@ type CommitmentInfo struct {
 	ComputedOverageAmount            decimal.Decimal `json:"computed_overage_amount" swaggertype:"string"`
 	ComputedCommitmentUtilizedAmount decimal.Decimal `json:"computed_commitment_utilized_amount" swaggertype:"string"`
 }
+
+// DefaultOverageFactor returns the overage factor applied when a commitment is
+// configured without an explicit one. 1.0 means usage beyond the commitment
+// bills at the base rate (no premium), which matches the API contract where
+// overage_factor / commitment_overage_factor are optional fields.
+func DefaultOverageFactor() *decimal.Decimal {
+	f := decimal.NewFromInt(1)
+	return &f
+}

--- a/internal/types/subscription.go
+++ b/internal/types/subscription.go
@@ -78,6 +78,10 @@ const (
 	SubscriptionLineItemEntityTypeSubscription SubscriptionLineItemEntityType = "subscription"
 )
 
+// SubscriptionLineItemMetadataKeyPredecessorID is stored on a successor line item
+// created by an update so cancellation can restore only that predecessor.
+const SubscriptionLineItemMetadataKeyPredecessorID = "predecessor_line_item_id"
+
 // SubscriptionStatus is the status of a subscription
 // For now taking inspiration from Stripe's subscription statuses
 // https://stripe.com/docs/api/subscriptions/object#subscription_object-status


### PR DESCRIPTION
1. Mark `overage_factor` optional - overage is 1 by default.
2. Handle effective start and end date of line items while applying commitments
3. Allow deleting the scheduled line items which re-activates it's predecessors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commitment overage factors are optional and default to 1.0 when omitted.
  * Subscription line item responses now include pricing details and usage meters where applicable.
  * Cancelling a scheduled line item can restore its recorded predecessor.
* **Bug Fixes**
  * Prevented charges for future-starting or zero-length line items before activation.
  * Improved handling when clearing or updating a line item’s end date.
* **Tests**
  * Added coverage for default overage factors, deferred commitments, response details, and scheduled item cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->