### PR TITLE
fix(subscription): Lock on line item before update

### DIFF
--- a/internal/domain/subscription/line_item_repository.go
+++ b/internal/domain/subscription/line_item_repository.go
@@ -18,6 +18,10 @@ type LineItemRepository interface {
 	// Get retrieves a subscription line item by ID
 	Get(ctx context.Context, id string) (*SubscriptionLineItem, error)
 
+	// GetForUpdate retrieves a subscription line item by ID and row-locks it for the
+	// duration of the surrounding transaction.
+	GetForUpdate(ctx context.Context, id string) (*SubscriptionLineItem, error)
+
 	// Update updates an existing subscription line item
 	Update(ctx context.Context, lineItem *SubscriptionLineItem) error
 

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -72,6 +72,7 @@ func (s *subscriptionService) addSubscriptionLineItem(ctx context.Context, subsc
 		}
 
 		lineItem = resolvedReq.ToSubscriptionLineItem(txCtx, *params)
+		stripCallerLineageMetadata(lineItem)
 		if usedInlinePrice {
 			s.applySubscriptionScopedLineItemDefaults(lineItem, sub, price)
 		}
@@ -576,17 +577,52 @@ func setSuccessorLineItemID(item *subscription.SubscriptionLineItem, successorID
 	setLineItemMetadataID(item, types.SubscriptionLineItemMetadataKeySuccessorID, successorID)
 }
 
-func clearSuccessorLineItemID(item *subscription.SubscriptionLineItem) {
+// lineageMetadataKeys are service-owned. Callers must never set them: a forged pointer
+// would make delete reopen, or refuse to delete, an unrelated line item.
+var lineageMetadataKeys = []string{
+	types.SubscriptionLineItemMetadataKeyPredecessorID,
+	types.SubscriptionLineItemMetadataKeySuccessorID,
+}
+
+func clearLineItemMetadataIDs(item *subscription.SubscriptionLineItem, keys ...string) {
 	if item == nil || item.Metadata == nil {
 		return
 	}
-	if _, ok := item.Metadata[types.SubscriptionLineItemMetadataKeySuccessorID]; !ok {
+	present := false
+	for _, key := range keys {
+		if _, ok := item.Metadata[key]; ok {
+			present = true
+			break
+		}
+	}
+	if !present {
 		return
 	}
 	copied := make(map[string]string, len(item.Metadata))
 	maps.Copy(copied, item.Metadata)
-	delete(copied, types.SubscriptionLineItemMetadataKeySuccessorID)
+	for _, key := range keys {
+		delete(copied, key)
+	}
 	item.Metadata = copied
+}
+
+func clearSuccessorLineItemID(item *subscription.SubscriptionLineItem) {
+	clearLineItemMetadataIDs(item, types.SubscriptionLineItemMetadataKeySuccessorID)
+}
+
+// stripCallerLineageMetadata drops version pointers that arrived in a request payload.
+func stripCallerLineageMetadata(item *subscription.SubscriptionLineItem) {
+	clearLineItemMetadataIDs(item, lineageMetadataKeys...)
+}
+
+func alreadyScheduledVersionError(lineItemID, successorID string) error {
+	return ierr.NewError("line item already has a scheduled version").
+		WithHint("Update the scheduled version instead, or delete it to revert this line item").
+		WithReportableDetails(map[string]interface{}{
+			"line_item_id":           lineItemID,
+			"successor_line_item_id": successorID,
+		}).
+		Mark(ierr.ErrValidation)
 }
 
 // replaceMetadataPreservingLineage applies caller-supplied metadata without dropping the
@@ -596,12 +632,11 @@ func replaceMetadataPreservingLineage(item *subscription.SubscriptionLineItem, m
 	if item == nil {
 		return
 	}
-	updated := make(map[string]string, len(metadata)+2)
+	updated := make(map[string]string, len(metadata)+len(lineageMetadataKeys))
 	maps.Copy(updated, metadata)
-	for _, key := range []string{
-		types.SubscriptionLineItemMetadataKeyPredecessorID,
-		types.SubscriptionLineItemMetadataKeySuccessorID,
-	} {
+	for _, key := range lineageMetadataKeys {
+		// Drop whatever the caller sent under a reserved key before restoring the stored value.
+		delete(updated, key)
 		if id := item.Metadata[key]; id != "" {
 			updated[key] = id
 		}
@@ -635,17 +670,12 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 
 	// A line item that already has a scheduled version must be edited through that
 	// version. Versioning it again would leave two published lines starting on the
-	// same date and orphan the first successor.
+	// same date and orphan the first successor. The versioning branch re-checks this
+	// under a row lock; this pass just fails fast before any work is done.
 	if successor, err := s.findPublishedSuccessor(ctx, existingLineItem); err != nil {
 		return nil, err
 	} else if successor != nil {
-		return nil, ierr.NewError("line item already has a scheduled version").
-			WithHint("Update the scheduled version instead, or delete it to revert this line item").
-			WithReportableDetails(map[string]interface{}{
-				"line_item_id":           lineItemID,
-				"successor_line_item_id": successor.ID,
-			}).
-			Mark(ierr.ErrValidation)
+		return nil, alreadyScheduledVersionError(lineItemID, successor.ID)
 	}
 
 	// Get the subscription
@@ -719,6 +749,16 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 		// Execute the complex update within a transaction
 		var newLineItem *subscription.SubscriptionLineItem
 		err = s.DB.WithTx(ctx, func(ctx context.Context) error {
+			locked, lockErr := s.SubscriptionLineItemRepo.GetForUpdate(ctx, lineItemID)
+			if lockErr != nil {
+				return lockErr
+			}
+			if successor, findErr := s.findPublishedSuccessor(ctx, locked); findErr != nil {
+				return findErr
+			} else if successor != nil {
+				return alreadyScheduledVersionError(lineItemID, successor.ID)
+			}
+
 			// Process the price override using existing method
 			lineItems := []*subscription.SubscriptionLineItem{existingLineItem}
 			err = s.ProcessSubscriptionPriceOverrides(ctx, sub, []dto.OverrideLineItemRequest{overrideReq}, lineItems, priceMap)

--- a/internal/ee/service/subscription_line_item.go
+++ b/internal/ee/service/subscription_line_item.go
@@ -703,49 +703,6 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 
 	// Check if we need to create a new line item (with price overrides)
 	if req.ShouldCreateNewLineItem() {
-		// Effective date must not be before the line item's start date (avoids end_date < start_date).
-		// Only the versioning path terminates the line item, so an in-place edit of a line
-		// that starts in the future must not be blocked by the default now() end date.
-		if !existingLineItem.StartDate.IsZero() && endDate.Before(existingLineItem.StartDate) {
-			return nil, ierr.NewError("effective date must be on or after line item start date").
-				WithHint("The effective date for terminating this line item cannot be before the line item's start date").
-				WithReportableDetails(map[string]interface{}{
-					"line_item_id":   lineItemID,
-					"start_date":     existingLineItem.StartDate,
-					"effective_from": endDate,
-				}).
-				Mark(ierr.ErrValidation)
-		}
-
-		if err := validateLineItemEndDateChange(existingLineItem, endDate); err != nil {
-			return nil, err
-		}
-
-		// existingLineItem and the repo's copy are the same object, so this must be
-		// read before deleteSubscriptionLineItem below overwrites EndDate in place.
-		oldEndDate := existingLineItem.EndDate
-
-		// Get price for override logic (and ensure endDate >= existing line item start already validated above)
-		priceService := NewPriceService(s.ServiceParams)
-		price, err := priceService.GetPrice(ctx, existingLineItem.PriceID)
-		if err != nil {
-			return nil, err
-		}
-
-		// Convert request to OverrideLineItemRequest format to reuse existing logic
-		overrideReq := dto.OverrideLineItemRequest{
-			PriceID:           existingLineItem.PriceID,
-			Quantity:          &existingLineItem.Quantity,
-			BillingModel:      req.BillingModel,
-			Amount:            req.Amount,
-			TierMode:          req.TierMode,
-			Tiers:             req.Tiers,
-			TransformQuantity: req.TransformQuantity,
-			BucketSize:        req.BucketSize,
-		}
-
-		priceMap := map[string]*dto.PriceResponse{existingLineItem.PriceID: price}
-
 		// Execute the complex update within a transaction
 		var newLineItem *subscription.SubscriptionLineItem
 		err = s.DB.WithTx(ctx, func(ctx context.Context) error {
@@ -753,33 +710,80 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			if lockErr != nil {
 				return lockErr
 			}
+			if locked.Status != types.StatusPublished {
+				return ierr.NewError("line item is not active").
+					WithHint("Cannot update an inactive line item").
+					WithReportableDetails(map[string]interface{}{
+						"line_item_id": lineItemID,
+						"status":       locked.Status,
+					}).
+					Mark(ierr.ErrValidation)
+			}
 			if successor, findErr := s.findPublishedSuccessor(ctx, locked); findErr != nil {
 				return findErr
 			} else if successor != nil {
 				return alreadyScheduledVersionError(lineItemID, successor.ID)
 			}
 
-			// Process the price override using existing method
-			lineItems := []*subscription.SubscriptionLineItem{existingLineItem}
-			err = s.ProcessSubscriptionPriceOverrides(ctx, sub, []dto.OverrideLineItemRequest{overrideReq}, lineItems, priceMap)
+			// Effective date must not be before the line item's start date (avoids end_date < start_date).
+			// Only the versioning path terminates the line item, so an in-place edit of a line
+			// that starts in the future must not be blocked by the default now() end date.
+			if !locked.StartDate.IsZero() && endDate.Before(locked.StartDate) {
+				return ierr.NewError("effective date must be on or after line item start date").
+					WithHint("The effective date for terminating this line item cannot be before the line item's start date").
+					WithReportableDetails(map[string]interface{}{
+						"line_item_id":   lineItemID,
+						"start_date":     locked.StartDate,
+						"effective_from": endDate,
+					}).
+					Mark(ierr.ErrValidation)
+			}
+
+			if err := validateLineItemEndDateChange(locked, endDate); err != nil {
+				return err
+			}
+
+			// locked and the repo's copy can be the same object, so this must be read
+			// before deleteSubscriptionLineItem below overwrites EndDate in place.
+			oldEndDate := locked.EndDate
+
+			price, err := NewPriceService(s.ServiceParams).GetPrice(ctx, locked.PriceID)
 			if err != nil {
 				return err
 			}
 
+			// Convert request to OverrideLineItemRequest format to reuse existing logic
+			overrideReq := dto.OverrideLineItemRequest{
+				PriceID:           locked.PriceID,
+				Quantity:          &locked.Quantity,
+				BillingModel:      req.BillingModel,
+				Amount:            req.Amount,
+				TierMode:          req.TierMode,
+				Tiers:             req.Tiers,
+				TransformQuantity: req.TransformQuantity,
+				BucketSize:        req.BucketSize,
+			}
+			priceMap := map[string]*dto.PriceResponse{locked.PriceID: price}
+
+			// Process the price override using existing method
+			lineItems := []*subscription.SubscriptionLineItem{locked}
+			if err := s.ProcessSubscriptionPriceOverrides(ctx, sub, []dto.OverrideLineItemRequest{overrideReq}, lineItems, priceMap); err != nil {
+				return err
+			}
+
 			// The ProcessSubscriptionPriceOverrides method updates the line item's PriceID
-			newPriceID := existingLineItem.PriceID
+			newPriceID := locked.PriceID
 
 			// Terminate the existing line item using existing method
 			deleteReq := dto.DeleteSubscriptionLineItemRequest{
 				EffectiveFrom: &endDate,
 			}
-			_, err := s.deleteSubscriptionLineItem(ctx, lineItemID, deleteReq)
-			if err != nil {
+			if _, err := s.deleteSubscriptionLineItem(ctx, lineItemID, deleteReq); err != nil {
 				return err
 			}
 
 			// Create new line item using the DTO method
-			newLineItem = req.ToSubscriptionLineItem(ctx, existingLineItem, newPriceID)
+			newLineItem = req.ToSubscriptionLineItem(ctx, locked, newPriceID)
 			newLineItem.StartDate = endDate // Start where the old one ends
 			if !oldEndDate.IsZero() {
 				newLineItem.EndDate = oldEndDate // Fill the gap freed up by the backdate
@@ -799,7 +803,7 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 			// line item's buckets (copied by ToSubscriptionLineItem); supplying an
 			// explicit empty slice clears them.
 			if req.CommitmentTimeBuckets != nil {
-				if err := s.createBucketPrices(ctx, newLineItem.ID, existingLineItem.SubscriptionID, *req.CommitmentTimeBuckets, newLineItem.CommitmentTimeBuckets, existingLineItem.CommitmentTimeBuckets); err != nil {
+				if err := s.createBucketPrices(ctx, newLineItem.ID, locked.SubscriptionID, *req.CommitmentTimeBuckets, newLineItem.CommitmentTimeBuckets, locked.CommitmentTimeBuckets); err != nil {
 					return err
 				}
 			}
@@ -845,7 +849,7 @@ func (s *subscriptionService) UpdateSubscriptionLineItem(ctx context.Context, li
 
 		s.Logger.Info(ctx, "updated subscription line item with price overrides",
 			"subscription_id", sub.ID,
-			"old_line_item_id", existingLineItem.ID,
+			"old_line_item_id", lineItemID,
 			"new_line_item_id", newLineItem.ID,
 			"end_date", endDate,
 		)

--- a/internal/ee/service/subscription_line_item_test.go
+++ b/internal/ee/service/subscription_line_item_test.go
@@ -451,6 +451,65 @@ func (s *SubscriptionLineItemServiceSuite) TestUpdateSubscriptionLineItem_Schedu
 		"predecessor must still be reverted after a metadata-only edit")
 }
 
+// The lineage keys are reserved. A caller that sends them must not be able to forge a
+// link: the stored predecessor wins, and a successor the service never wrote is dropped
+// rather than locking the line against deletion.
+func (s *SubscriptionLineItemServiceSuite) TestUpdateSubscriptionLineItem_MetadataEdit_IgnoresCallerSuppliedLineage() {
+	futureStart := time.Now().UTC().Add(13 * 24 * time.Hour)
+	successor := s.scheduleVersion(s.testData.lineItem.ID, 75, futureStart)
+	forgedTarget := s.stageLineItem(func(li *subscription.SubscriptionLineItem) {
+		li.EndDate = futureStart
+	})
+
+	_, err := s.service.UpdateSubscriptionLineItem(s.GetContext(), successor.ID, dto.UpdateSubscriptionLineItemRequest{
+		Metadata: map[string]string{
+			types.SubscriptionLineItemMetadataKeyPredecessorID: forgedTarget.ID,
+			types.SubscriptionLineItemMetadataKeySuccessorID:   forgedTarget.ID,
+			"note": "kept",
+		},
+	})
+	s.NoError(err)
+
+	stored := s.reloadLineItem(successor.ID)
+	s.Equal("kept", stored.Metadata["note"])
+	s.Equal(s.testData.lineItem.ID, stored.Metadata[types.SubscriptionLineItemMetadataKeyPredecessorID],
+		"a caller must not be able to repoint the predecessor")
+	s.Empty(stored.Metadata[types.SubscriptionLineItemMetadataKeySuccessorID],
+		"a caller must not be able to forge a successor")
+
+	// The forged pointers must not have changed what the revert does.
+	s.NoError(s.revertScheduledVersion(successor.ID))
+	s.True(s.reloadLineItem(s.testData.lineItem.ID).EndDate.IsZero())
+	s.assertEndDate(s.reloadLineItem(forgedTarget.ID), futureStart, "the forged target must be untouched")
+}
+
+// Same reserved keys, other entry point: a future-dated line item created with a forged
+// predecessor would otherwise reopen that line when it is reverted.
+func (s *SubscriptionLineItemServiceSuite) TestAddSubscriptionLineItem_IgnoresCallerSuppliedLineage() {
+	futureStart := time.Now().UTC().Add(13 * 24 * time.Hour)
+	forgedTarget := s.stageLineItem(func(li *subscription.SubscriptionLineItem) {
+		li.EndDate = futureStart
+	})
+
+	added, err := s.service.AddSubscriptionLineItem(s.GetContext(), s.testData.subscription.ID, dto.CreateSubscriptionLineItemRequest{
+		PriceID:   s.testData.price.ID,
+		Quantity:  decimal.NewFromInt(1),
+		StartDate: &futureStart,
+		Metadata: map[string]string{
+			types.SubscriptionLineItemMetadataKeyPredecessorID: forgedTarget.ID,
+			types.SubscriptionLineItemMetadataKeySuccessorID:   forgedTarget.ID,
+			"note": "kept",
+		},
+	})
+	s.NoError(err)
+	s.Equal("kept", added.SubscriptionLineItem.Metadata["note"])
+	s.Empty(added.SubscriptionLineItem.Metadata[types.SubscriptionLineItemMetadataKeyPredecessorID])
+	s.Empty(added.SubscriptionLineItem.Metadata[types.SubscriptionLineItemMetadataKeySuccessorID])
+
+	s.NoError(s.revertScheduledVersion(added.SubscriptionLineItem.ID))
+	s.assertEndDate(s.reloadLineItem(forgedTarget.ID), futureStart, "the forged target must be untouched")
+}
+
 // Amending a pending change goes through the scheduled version: it gets terminated and
 // replaced, and its own predecessor stays closed rather than being reverted.
 func (s *SubscriptionLineItemServiceSuite) TestUpdateSubscriptionLineItem_ScheduledVersion_TerminatesWithoutRevert() {

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -206,6 +206,80 @@ func (r *subscriptionLineItemRepository) Get(ctx context.Context, id string) (*s
 	return lineItemData, nil
 }
 
+// GetForUpdate row-locks the line item so a read-decide-write sequence in the caller's
+// transaction is serialized against concurrent transactions doing the same.
+func (r *subscriptionLineItemRepository) GetForUpdate(ctx context.Context, id string) (*subscription.SubscriptionLineItem, error) {
+	span := StartRepositorySpan(ctx, "subscription_line_item", "get_for_update", map[string]interface{}{
+		"line_item_id": id,
+		"tenant_id":    types.GetTenantID(ctx),
+	})
+	defer FinishSpan(span)
+
+	client := r.client.Writer(ctx)
+	if client == nil {
+		err := ierr.NewError("failed to get database client").
+			WithHint("Database client is not available").
+			Mark(ierr.ErrDatabase)
+		SetSpanError(span, err)
+		return nil, err
+	}
+
+	tenantID := types.GetTenantID(ctx)
+	environmentID := types.GetEnvironmentID(ctx)
+
+	lockQuery := `SELECT id FROM subscription_line_items WHERE id = $1 AND tenant_id = $2 AND environment_id = $3 FOR UPDATE`
+	rows, err := client.QueryContext(ctx, lockQuery, id, tenantID, environmentID)
+	if err != nil {
+		SetSpanError(span, err)
+		return nil, ierr.WithError(err).
+			WithHint("Failed to lock subscription line item").
+			WithReportableDetails(map[string]interface{}{"line_item_id": id}).
+			Mark(ierr.ErrDatabase)
+	}
+	// Check and close before running another query on the same connection.
+	hasRow := rows.Next()
+	rowErr := rows.Err()
+	rows.Close() // #nosec G104 -- best-effort, error non-fatal
+	if rowErr != nil {
+		SetSpanError(span, rowErr)
+		return nil, ierr.WithError(rowErr).
+			WithHint("Failed to lock subscription line item").
+			WithReportableDetails(map[string]interface{}{"line_item_id": id}).
+			Mark(ierr.ErrDatabase)
+	}
+	if !hasRow {
+		return nil, ierr.NewError("subscription line item not found").
+			WithHintf("Subscription line item with ID %s not found", id).
+			WithReportableDetails(map[string]interface{}{"line_item_id": id}).
+			Mark(ierr.ErrNotFound)
+	}
+
+	// Read on the same connection, so this sees the locked row.
+	item, err := client.SubscriptionLineItem.Query().
+		Where(
+			subscriptionlineitem.ID(id),
+			subscriptionlineitem.TenantID(tenantID),
+			subscriptionlineitem.EnvironmentID(environmentID),
+		).
+		Only(ctx)
+	if err != nil {
+		SetSpanError(span, err)
+		if ent.IsNotFound(err) {
+			return nil, ierr.WithError(err).
+				WithHintf("Subscription line item with ID %s not found", id).
+				WithReportableDetails(map[string]interface{}{"line_item_id": id}).
+				Mark(ierr.ErrNotFound)
+		}
+		return nil, ierr.WithError(err).
+			WithHint("Failed to retrieve subscription line item").
+			WithReportableDetails(map[string]interface{}{"line_item_id": id}).
+			Mark(ierr.ErrDatabase)
+	}
+
+	SetSpanSuccess(span)
+	return subscription.SubscriptionLineItemFromEnt(item), nil
+}
+
 // Update updates a subscription line item
 func (r *subscriptionLineItemRepository) Update(ctx context.Context, item *subscription.SubscriptionLineItem) error {
 	// Start a span for this repository operation

--- a/internal/testutil/inmemory_subscription_line_item_store.go
+++ b/internal/testutil/inmemory_subscription_line_item_store.go
@@ -181,6 +181,11 @@ func (s *InMemorySubscriptionLineItemStore) Get(ctx context.Context, id string) 
 	return item, nil
 }
 
+// GetForUpdate has no lock to take: the in-memory store already serializes access.
+func (s *InMemorySubscriptionLineItemStore) GetForUpdate(ctx context.Context, id string) (*subscription.SubscriptionLineItem, error) {
+	return s.Get(ctx, id)
+}
+
 // Update updates a subscription line item
 func (s *InMemorySubscriptionLineItemStore) Update(ctx context.Context, item *subscription.SubscriptionLineItem) error {
 	if item == nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented callers from supplying or modifying subscription line-item predecessor and successor links.
  * Preserved service-managed lineage when updating scheduled line items.
  * Improved concurrent updates to prevent duplicate or conflicting successor versions.
  * Reverting a line item now consistently restores the genuine predecessor relationship without affecting unrelated entries.
  * Ensured updates use the latest line-item state, reducing the risk of overwriting concurrent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->