### PR TITLE
fix(customers): return archived customers when search filters status IN

### DIFF
--- a/internal/ee/service/customer_test.go
+++ b/internal/ee/service/customer_test.go
@@ -264,6 +264,94 @@ func (s *CustomerServiceSuite) TestGetCustomers() {
 	}
 }
 
+func (s *CustomerServiceSuite) TestGetCustomersStatusFilter() {
+	_ = s.GetStores().CustomerRepo.Create(s.ctx, &domainCustomer.Customer{
+		ID:    "cust-published",
+		Name:  "Published Customer",
+		Email: "published@example.com",
+		BaseModel: types.BaseModel{
+			Status: types.StatusPublished,
+		},
+	})
+	_ = s.GetStores().CustomerRepo.Create(s.ctx, &domainCustomer.Customer{
+		ID:    "cust-archived",
+		Name:  "Archived Customer",
+		Email: "archived@example.com",
+		BaseModel: types.BaseModel{
+			Status: types.StatusArchived,
+		},
+	})
+
+	statusIn := func(values ...string) []*types.FilterCondition {
+		return []*types.FilterCondition{
+			{
+				Field:    lo.ToPtr("status"),
+				Operator: lo.ToPtr(types.IN),
+				DataType: lo.ToPtr(types.DataTypeArray),
+				Value:    &types.Value{Array: values},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name          string
+		filter        *types.CustomerFilter
+		expectedIDs   []string
+		expectedCount int
+	}{
+		{
+			name: "default_excludes_archived",
+			filter: &types.CustomerFilter{
+				QueryFilter: &types.QueryFilter{
+					Limit:  lo.ToPtr(10),
+					Offset: lo.ToPtr(0),
+				},
+			},
+			expectedIDs:   []string{"cust-published"},
+			expectedCount: 1,
+		},
+		{
+			name: "dsl_in_published_and_archived_returns_both",
+			filter: &types.CustomerFilter{
+				QueryFilter: &types.QueryFilter{
+					Limit:  lo.ToPtr(10),
+					Offset: lo.ToPtr(0),
+				},
+				Filters: statusIn(string(types.StatusPublished), string(types.StatusArchived)),
+			},
+			expectedIDs:   []string{"cust-published", "cust-archived"},
+			expectedCount: 2,
+		},
+		{
+			name: "dsl_in_archived_only",
+			filter: &types.CustomerFilter{
+				QueryFilter: &types.QueryFilter{
+					Limit:  lo.ToPtr(10),
+					Offset: lo.ToPtr(0),
+				},
+				Filters: statusIn(string(types.StatusArchived)),
+			},
+			expectedIDs:   []string{"cust-archived"},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			resp, err := s.service.GetCustomers(s.ctx, tc.filter)
+			s.NoError(err)
+			s.NotNil(resp)
+			s.Equal(tc.expectedCount, len(resp.Items))
+			s.Equal(tc.expectedCount, resp.Pagination.Total)
+
+			gotIDs := lo.Map(resp.Items, func(item *dto.CustomerResponse, _ int) string {
+				return item.Customer.ID
+			})
+			s.ElementsMatch(tc.expectedIDs, gotIDs)
+		})
+	}
+}
+
 func (s *CustomerServiceSuite) TestUpdateCustomer() {
 	// Prepopulate the repository with a customer
 	_ = s.GetStores().CustomerRepo.Create(s.ctx, &domainCustomer.Customer{

--- a/internal/repository/ent/customer.go
+++ b/internal/repository/ent/customer.go
@@ -448,8 +448,10 @@ func (o CustomerQueryOptions) ApplyEnvironmentFilter(ctx context.Context, query 
 }
 
 func (o CustomerQueryOptions) ApplyStatusFilter(query CustomerQuery, status string) CustomerQuery {
+	// Empty means skip the default published-only predicate. CustomerFilter.GetStatus
+	// returns "published" when unset, or "" when DSL filters already constrain status.
 	if status == "" {
-		return query.Where(customer.StatusEQ(string(types.StatusPublished)))
+		return query
 	}
 	return query.Where(customer.Status(status))
 }

--- a/internal/testutil/inmemory_customer_store.go
+++ b/internal/testutil/inmemory_customer_store.go
@@ -190,6 +190,47 @@ func customerFilterFn(ctx context.Context, c *customer.Customer, filter interfac
 		}
 	}
 
+	// Mirror CustomerQueryOptions.ApplyStatusFilter: a non-empty GetStatus is an
+	// equality predicate. Empty means skip (DSL owns status, or no default).
+	// Unset customer status is treated as published so test fixtures still match.
+	if status := f.GetStatus(); status != "" {
+		cs := string(c.Status)
+		if cs == "" {
+			cs = string(types.StatusPublished)
+		}
+		if cs != status {
+			return false
+		}
+	}
+
+	for _, cond := range f.Filters {
+		if !customerMatchesStatusFilter(c, cond) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func customerMatchesStatusFilter(c *customer.Customer, cond *types.FilterCondition) bool {
+	if cond == nil || lo.FromPtr(cond.Field) != "status" {
+		return true
+	}
+	status := string(c.Status)
+	if status == "" {
+		status = string(types.StatusPublished)
+	}
+	if cond.Value == nil {
+		return true
+	}
+	switch lo.FromPtr(cond.Operator) {
+	case types.IN:
+		return lo.Contains(cond.Value.Array, status)
+	case types.EQUAL:
+		if cond.Value.String != nil {
+			return status == *cond.Value.String
+		}
+	}
 	return true
 }
 

--- a/internal/types/customer.go
+++ b/internal/types/customer.go
@@ -96,12 +96,21 @@ func (f *CustomerFilter) GetOrder() string {
 	return f.QueryFilter.GetOrder()
 }
 
-// GetStatus implements BaseFilter interface
+// GetStatus implements BaseFilter interface.
+// An unset query status defaults to published so listings hide archived customers.
+// When DSL filters already constrain status, return empty so the repository skips
+// that default and lets the DSL IN/eq predicate apply (e.g. published+archived).
 func (f *CustomerFilter) GetStatus() string {
-	if f.QueryFilter == nil {
-		return NewDefaultQueryFilter().GetStatus()
+	if f == nil {
+		return string(StatusPublished)
 	}
-	return f.QueryFilter.GetStatus()
+	if f.QueryFilter != nil && f.QueryFilter.Status != nil {
+		return string(*f.QueryFilter.Status)
+	}
+	if HasFieldFilter(f.Filters, "status") {
+		return ""
+	}
+	return string(StatusPublished)
 }
 
 // GetExpand implements BaseFilter interface

--- a/internal/types/customer.go
+++ b/internal/types/customer.go
@@ -105,7 +105,9 @@ func (f *CustomerFilter) GetStatus() string {
 		return string(StatusPublished)
 	}
 	if f.QueryFilter != nil && f.QueryFilter.Status != nil {
-		return string(*f.QueryFilter.Status)
+		if status := string(*f.QueryFilter.Status); status != "" {
+			return status
+		}
 	}
 	if HasFieldFilter(f.Filters, "status") {
 		return ""

--- a/internal/types/customer_test.go
+++ b/internal/types/customer_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomerFilter_GetStatus(t *testing.T) {
+	statusInPublishedAndArchived := []*FilterCondition{
+		{
+			Field:    lo.ToPtr("status"),
+			Operator: lo.ToPtr(IN),
+			DataType: lo.ToPtr(DataTypeArray),
+			Value:    &Value{Array: []string{string(StatusPublished), string(StatusArchived)}},
+		},
+	}
+
+	t.Run("defaults to published when no status is specified", func(t *testing.T) {
+		f := NewCustomerFilter()
+		assert.Equal(t, string(StatusPublished), f.GetStatus())
+	})
+
+	t.Run("skips default when DSL filters status so archived can be included", func(t *testing.T) {
+		f := NewCustomerFilter()
+		f.Filters = statusInPublishedAndArchived
+		assert.Equal(t, "", f.GetStatus())
+	})
+
+	t.Run("honors explicit query status over DSL", func(t *testing.T) {
+		f := NewCustomerFilter()
+		f.Status = lo.ToPtr(StatusArchived)
+		f.Filters = statusInPublishedAndArchived
+		assert.Equal(t, string(StatusArchived), f.GetStatus())
+	})
+}

--- a/internal/types/customer_test.go
+++ b/internal/types/customer_test.go
@@ -34,4 +34,10 @@ func TestCustomerFilter_GetStatus(t *testing.T) {
 		f.Filters = statusInPublishedAndArchived
 		assert.Equal(t, string(StatusArchived), f.GetStatus())
 	})
+
+	t.Run("empty query status is treated as unset", func(t *testing.T) {
+		f := NewCustomerFilter()
+		f.Status = lo.ToPtr(Status(""))
+		assert.Equal(t, string(StatusPublished), f.GetStatus())
+	})
 }

--- a/internal/types/search_filter.go
+++ b/internal/types/search_filter.go
@@ -128,6 +128,16 @@ func (f *FilterCondition) Validate() error {
 	return nil
 }
 
+// HasFieldFilter reports whether any filter condition targets the given field.
+func HasFieldFilter(filters []*FilterCondition, field string) bool {
+	for _, f := range filters {
+		if f != nil && lo.FromPtr(f.Field) == field {
+			return true
+		}
+	}
+	return false
+}
+
 // sorting options
 type SortDirection string
 


### PR DESCRIPTION
## Summary
- Customer search (`POST /customers/search`) was ignoring DSL `status IN [published, archived]` because an unset query-level `status` still applied a default `published`-only predicate.
- Skip that default when DSL already filters `status`, so archived customers are included when the frontend asks for them. Unfiltered lists still default to published only.

## Test plan
- [x] `go test -race ./internal/types -run TestCustomerFilter_GetStatus`
- [x] `go test -race ./internal/ee/service -run TestCustomerService/TestGetCustomersStatusFilter`
- [ ] Confirm `POST /customers/search` with `filters: [{field: status, operator: in, value.array: [published, archived]}]` returns the archived customer when total count is under the page limit


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Customer listings now exclude archived customers by default.
  - Explicit status selections correctly return published or archived customers.
  - Equality and “IN” status filters now produce consistent results.
  - Pagination totals and item counts accurately reflect applied status filters.
  - Explicit status settings take precedence where applicable, while status-based filters can include archived customers when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->