### PR TITLE
fix(meter): trim whitespace from meter and event lookup keys

### DIFF
--- a/internal/api/dto/meter.go
+++ b/internal/api/dto/meter.go
@@ -1,7 +1,6 @@
 package dto
 
 import (
-	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/meter"
@@ -73,14 +72,14 @@ func ToMeterResponse(m *meter.Meter) *MeterResponse {
 // Convert CreateMeterRequest to domain Meter
 func (r *CreateMeterRequest) ToMeter(tenantID, createdBy string) *meter.Meter {
 	m := meter.NewMeter(r.Name, tenantID, createdBy)
-	m.EventName = strings.TrimSpace(r.EventName)
+	m.EventName = r.EventName
 	m.Aggregation = r.Aggregation
-	m.Aggregation.Field = strings.TrimSpace(m.Aggregation.Field)
-	m.Aggregation.Expression = strings.TrimSpace(m.Aggregation.Expression)
-	m.Aggregation.GroupBy = strings.TrimSpace(m.Aggregation.GroupBy)
 	m.Filters = r.Filters
 	m.ResetUsage = r.ResetUsage
 	m.Status = types.StatusPublished
+	// Normalize before the caller validates, so a field of only whitespace is
+	// rejected as missing rather than persisted as a key that never matches.
+	m.Normalize()
 	return m
 }
 

--- a/internal/api/dto/meter.go
+++ b/internal/api/dto/meter.go
@@ -77,9 +77,9 @@ func (r *CreateMeterRequest) ToMeter(tenantID, createdBy string) *meter.Meter {
 	m.Filters = r.Filters
 	m.ResetUsage = r.ResetUsage
 	m.Status = types.StatusPublished
-	// Normalize before the caller validates, so a field of only whitespace is
+	// Sanitize before the caller validates, so a field of only whitespace is
 	// rejected as missing rather than persisted as a key that never matches.
-	m.Normalize()
+	m.Sanitize()
 	return m
 }
 

--- a/internal/domain/events/model.go
+++ b/internal/domain/events/model.go
@@ -192,12 +192,12 @@ func NewEvent(
 		Source:             source,
 		EventName:          strings.TrimSpace(eventName),
 		Timestamp:          timestamp,
-		Properties:         NormalizeProperties(properties),
+		Properties:         SanitizeProperties(properties),
 		EnvironmentID:      environmentID,
 	}
 }
 
-// NormalizeProperties trims surrounding whitespace from property keys. Meters
+// SanitizeProperties trims surrounding whitespace from property keys. Meters
 // look a property up by exact key, and a meter's aggregation field is always
 // trimmed, so a padded key here could never be metered — the usage would be
 // recorded as zero with no error.
@@ -207,7 +207,7 @@ func NewEvent(
 // that trim onto the same name the lexicographically smallest wins. Ranging over
 // the map and letting iteration order pick would make the same event bill
 // differently run to run.
-func NormalizeProperties(properties map[string]interface{}) map[string]interface{} {
+func SanitizeProperties(properties map[string]interface{}) map[string]interface{} {
 	if properties == nil {
 		return nil
 	}

--- a/internal/domain/events/model.go
+++ b/internal/domain/events/model.go
@@ -191,9 +191,31 @@ func NewEvent(
 		Source:             source,
 		EventName:          strings.TrimSpace(eventName),
 		Timestamp:          timestamp,
-		Properties:         properties,
+		Properties:         NormalizeProperties(properties),
 		EnvironmentID:      environmentID,
 	}
+}
+
+// NormalizeProperties trims surrounding whitespace from property keys. Meters
+// look a property up by exact key, and a meter's aggregation field is always
+// trimmed, so a padded key here could never be metered — the usage would be
+// recorded as zero with no error. A key that trims onto an existing clean key
+// is dropped rather than overwriting it.
+func NormalizeProperties(properties map[string]interface{}) map[string]interface{} {
+	if properties == nil {
+		return nil
+	}
+	for key := range properties {
+		trimmed := strings.TrimSpace(key)
+		if trimmed == key {
+			continue
+		}
+		if _, clash := properties[trimmed]; !clash && trimmed != "" {
+			properties[trimmed] = properties[key]
+		}
+		delete(properties, key)
+	}
+	return properties
 }
 
 // Validate validates the event

--- a/internal/domain/events/model.go
+++ b/internal/domain/events/model.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -199,18 +200,32 @@ func NewEvent(
 // NormalizeProperties trims surrounding whitespace from property keys. Meters
 // look a property up by exact key, and a meter's aggregation field is always
 // trimmed, so a padded key here could never be metered — the usage would be
-// recorded as zero with no error. A key that trims onto an existing clean key
-// is dropped rather than overwriting it.
+// recorded as zero with no error.
+//
+// Collisions resolve deterministically, because the winner decides the billed
+// quantity: an existing clean key always wins, and between several padded keys
+// that trim onto the same name the lexicographically smallest wins. Ranging over
+// the map and letting iteration order pick would make the same event bill
+// differently run to run.
 func NormalizeProperties(properties map[string]interface{}) map[string]interface{} {
 	if properties == nil {
 		return nil
 	}
+
+	var padded []string
 	for key := range properties {
-		trimmed := strings.TrimSpace(key)
-		if trimmed == key {
-			continue
+		if strings.TrimSpace(key) != key {
+			padded = append(padded, key)
 		}
-		if _, clash := properties[trimmed]; !clash && trimmed != "" {
+	}
+	if len(padded) == 0 {
+		return properties
+	}
+	sort.Strings(padded)
+
+	for _, key := range padded {
+		trimmed := strings.TrimSpace(key)
+		if _, taken := properties[trimmed]; !taken && trimmed != "" {
 			properties[trimmed] = properties[key]
 		}
 		delete(properties, key)

--- a/internal/domain/events/normalize_test.go
+++ b/internal/domain/events/normalize_test.go
@@ -1,49 +1,69 @@
 package events
 
 import (
+	"reflect"
 	"testing"
 	"time"
 )
 
-func TestNormalizeProperties_TrimsKeys(t *testing.T) {
-	props := NormalizeProperties(map[string]interface{}{
-		" output_tokens": 100,
-		"input_tokens ":  50,
-		"model":          "gemma-4-31b",
-	})
+func TestNormalizeProperties(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  map[string]interface{}
+	}{
+		{
+			name:  "trims leading and trailing padding",
+			input: map[string]interface{}{" output_tokens": 100, "input_tokens ": 50, "model": "gemma-4-31b"},
+			want:  map[string]interface{}{"output_tokens": 100, "input_tokens": 50, "model": "gemma-4-31b"},
+		},
+		{
+			// A padded key must never clobber a clean key that already carries the real value.
+			name:  "existing clean key wins a collision",
+			input: map[string]interface{}{"tokens": 100, " tokens": 999},
+			want:  map[string]interface{}{"tokens": 100},
+		},
+		{
+			// Map iteration order must not decide the billed quantity: between
+			// padded keys the lexicographically smallest ("  x" < " x") wins.
+			name:  "collision between padded keys resolves deterministically",
+			input: map[string]interface{}{" x": 1, "  x": 2},
+			want:  map[string]interface{}{"x": 2},
+		},
+		{
+			name:  "whitespace-only key is dropped",
+			input: map[string]interface{}{"   ": 1, "tokens": 5},
+			want:  map[string]interface{}{"tokens": 5},
+		},
+		{
+			name:  "clean map is untouched",
+			input: map[string]interface{}{"tokens": 5},
+			want:  map[string]interface{}{"tokens": 5},
+		},
+		{
+			name:  "nil is passed through",
+			input: nil,
+			want:  nil,
+		},
+	}
 
-	if _, ok := props["output_tokens"]; !ok {
-		t.Fatalf("leading-space key not trimmed: %v", props)
-	}
-	if _, ok := props["input_tokens"]; !ok {
-		t.Fatalf("trailing-space key not trimmed: %v", props)
-	}
-	if _, ok := props[" output_tokens"]; ok {
-		t.Fatal("padded key still present")
-	}
-	if props["model"] != "gemma-4-31b" {
-		t.Fatalf("clean key altered: %v", props["model"])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeProperties(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
-// A padded key must never clobber a clean key that already carries the real value.
-func TestNormalizeProperties_ClashKeepsCleanKey(t *testing.T) {
-	props := NormalizeProperties(map[string]interface{}{
-		"tokens":  100,
-		" tokens": 999,
-	})
-
-	if props["tokens"] != 100 {
-		t.Fatalf("clean key was overwritten: %v", props["tokens"])
-	}
-	if len(props) != 1 {
-		t.Fatalf("expected padded duplicate to be dropped: %v", props)
-	}
-}
-
-func TestNormalizeProperties_NilSafe(t *testing.T) {
-	if NormalizeProperties(nil) != nil {
-		t.Fatal("expected nil for nil input")
+// The padded-key winner must be stable across runs, not just within one.
+func TestNormalizeProperties_CollisionIsStableAcrossRuns(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		got := NormalizeProperties(map[string]interface{}{" x": 1, "  x": 2, "\tx": 3})
+		if got["x"] != 3 {
+			t.Fatalf("run %d picked %v, want the lexicographically smallest padded key", i, got["x"])
+		}
 	}
 }
 

--- a/internal/domain/events/normalize_test.go
+++ b/internal/domain/events/normalize_test.go
@@ -1,0 +1,61 @@
+package events
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeProperties_TrimsKeys(t *testing.T) {
+	props := NormalizeProperties(map[string]interface{}{
+		" output_tokens": 100,
+		"input_tokens ":  50,
+		"model":          "gemma-4-31b",
+	})
+
+	if _, ok := props["output_tokens"]; !ok {
+		t.Fatalf("leading-space key not trimmed: %v", props)
+	}
+	if _, ok := props["input_tokens"]; !ok {
+		t.Fatalf("trailing-space key not trimmed: %v", props)
+	}
+	if _, ok := props[" output_tokens"]; ok {
+		t.Fatal("padded key still present")
+	}
+	if props["model"] != "gemma-4-31b" {
+		t.Fatalf("clean key altered: %v", props["model"])
+	}
+}
+
+// A padded key must never clobber a clean key that already carries the real value.
+func TestNormalizeProperties_ClashKeepsCleanKey(t *testing.T) {
+	props := NormalizeProperties(map[string]interface{}{
+		"tokens":  100,
+		" tokens": 999,
+	})
+
+	if props["tokens"] != 100 {
+		t.Fatalf("clean key was overwritten: %v", props["tokens"])
+	}
+	if len(props) != 1 {
+		t.Fatalf("expected padded duplicate to be dropped: %v", props)
+	}
+}
+
+func TestNormalizeProperties_NilSafe(t *testing.T) {
+	if NormalizeProperties(nil) != nil {
+		t.Fatal("expected nil for nil input")
+	}
+}
+
+func TestNewEvent_NormalizesNameAndPropertyKeys(t *testing.T) {
+	e := NewEvent(" llm_usage ", "tenant_1", "cust_1",
+		map[string]interface{}{" output_tokens": 42},
+		time.Time{}, "", "", "", "env_1")
+
+	if e.EventName != "llm_usage" {
+		t.Fatalf("event name not trimmed: %q", e.EventName)
+	}
+	if _, ok := e.Properties["output_tokens"]; !ok {
+		t.Fatalf("property key not trimmed: %v", e.Properties)
+	}
+}

--- a/internal/domain/events/sanitize_test.go
+++ b/internal/domain/events/sanitize_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func TestNormalizeProperties(t *testing.T) {
+func TestSanitizeProperties(t *testing.T) {
 	tests := []struct {
 		name  string
 		input map[string]interface{}
@@ -49,7 +49,7 @@ func TestNormalizeProperties(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NormalizeProperties(tt.input)
+			got := SanitizeProperties(tt.input)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("got %v, want %v", got, tt.want)
 			}
@@ -58,16 +58,16 @@ func TestNormalizeProperties(t *testing.T) {
 }
 
 // The padded-key winner must be stable across runs, not just within one.
-func TestNormalizeProperties_CollisionIsStableAcrossRuns(t *testing.T) {
+func TestSanitizeProperties_CollisionIsStableAcrossRuns(t *testing.T) {
 	for i := 0; i < 100; i++ {
-		got := NormalizeProperties(map[string]interface{}{" x": 1, "  x": 2, "\tx": 3})
+		got := SanitizeProperties(map[string]interface{}{" x": 1, "  x": 2, "\tx": 3})
 		if got["x"] != 3 {
 			t.Fatalf("run %d picked %v, want the lexicographically smallest padded key", i, got["x"])
 		}
 	}
 }
 
-func TestNewEvent_NormalizesNameAndPropertyKeys(t *testing.T) {
+func TestNewEvent_SanitizesNameAndPropertyKeys(t *testing.T) {
 	e := NewEvent(" llm_usage ", "tenant_1", "cust_1",
 		map[string]interface{}{" output_tokens": 42},
 		time.Time{}, "", "", "", "env_1")

--- a/internal/domain/events/transform/transformer.go
+++ b/internal/domain/events/transform/transformer.go
@@ -205,7 +205,7 @@ func TransformBentoToEvent(payload string, tenantID, environmentID string) (*eve
 		EnvironmentID:      environmentID,
 		ExternalCustomerID: input.OrgID,
 		EventName:          strings.TrimSpace(eventName),
-		Properties:         properties,
+		Properties:         events.NormalizeProperties(properties),
 		Source:             source,
 		Timestamp:          timestamp,
 	}

--- a/internal/domain/events/transform/transformer.go
+++ b/internal/domain/events/transform/transformer.go
@@ -66,6 +66,12 @@ func TransformBentoToEvent(payload string, tenantID, environmentID string) (*eve
 		}
 	}
 
+	// Normalize before anything reads the map: the derived fields below look up
+	// promptTokens, numCharacters, channels and friends by exact key, so a padded
+	// key in the payload would silently skip billablePromptTokens and
+	// billable_value even though the stored property itself came out trimmed.
+	properties = events.NormalizeProperties(properties)
+
 	// Compute resolved names
 	resolvedProviderName := ""
 	if input.ProviderName != "" {
@@ -205,7 +211,7 @@ func TransformBentoToEvent(payload string, tenantID, environmentID string) (*eve
 		EnvironmentID:      environmentID,
 		ExternalCustomerID: input.OrgID,
 		EventName:          strings.TrimSpace(eventName),
-		Properties:         events.NormalizeProperties(properties),
+		Properties:         properties,
 		Source:             source,
 		Timestamp:          timestamp,
 	}

--- a/internal/domain/events/transform/transformer.go
+++ b/internal/domain/events/transform/transformer.go
@@ -66,11 +66,11 @@ func TransformBentoToEvent(payload string, tenantID, environmentID string) (*eve
 		}
 	}
 
-	// Normalize before anything reads the map: the derived fields below look up
+	// Sanitize before anything reads the map: the derived fields below look up
 	// promptTokens, numCharacters, channels and friends by exact key, so a padded
 	// key in the payload would silently skip billablePromptTokens and
 	// billable_value even though the stored property itself came out trimmed.
-	properties = events.NormalizeProperties(properties)
+	properties = events.SanitizeProperties(properties)
 
 	// Compute resolved names
 	resolvedProviderName := ""

--- a/internal/domain/events/transform/transformer_test.go
+++ b/internal/domain/events/transform/transformer_test.go
@@ -430,3 +430,27 @@ func TestTransformBentoBatch(t *testing.T) {
 		assert.Equal(t, "800", e.Properties["billablePromptTokens"])
 	}
 }
+
+// Padded keys in the Bento payload must be trimmed before the derived fields are
+// computed. Normalizing only at the end produced trimmed stored properties while
+// silently skipping billablePromptTokens, the model suffix and billable_value.
+func TestTransformBentoToEvent_NormalizesBeforeDerivedFields(t *testing.T) {
+	fields := validBase()
+	fields["data"] = map[string]interface{}{
+		" modelName":          "gpt-4.1",
+		"promptTokens ":       "100",
+		" cachedPromptTokens": "30",
+		"numCharacters ":      "50",
+		" channels":           "2",
+	}
+
+	event, err := TransformBentoToEvent(buildPayload(t, fields), testTenantID, testEnvironmentID)
+	require.NoError(t, err)
+	require.NotNil(t, event)
+
+	assert.Equal(t, "gpt-4.1", event.Properties["modelName"], "padded key not trimmed")
+	assert.Equal(t, "70", event.Properties["billablePromptTokens"], "derived from padded promptTokens")
+	assert.Equal(t, "characters", event.Properties["billable_unit"], "derived from padded numCharacters")
+	assert.Equal(t, "100.000000", event.Properties["billable_value"], "numCharacters * channels")
+	assert.Contains(t, event.EventName, "-gpt-4.1", "model suffix derived from padded modelName")
+}

--- a/internal/domain/events/transform/transformer_test.go
+++ b/internal/domain/events/transform/transformer_test.go
@@ -432,9 +432,9 @@ func TestTransformBentoBatch(t *testing.T) {
 }
 
 // Padded keys in the Bento payload must be trimmed before the derived fields are
-// computed. Normalizing only at the end produced trimmed stored properties while
+// computed. Sanitizing only at the end produced trimmed stored properties while
 // silently skipping billablePromptTokens, the model suffix and billable_value.
-func TestTransformBentoToEvent_NormalizesBeforeDerivedFields(t *testing.T) {
+func TestTransformBentoToEvent_SanitizesBeforeDerivedFields(t *testing.T) {
 	fields := validBase()
 	fields["data"] = map[string]interface{}{
 		" modelName":          "gpt-4.1",

--- a/internal/domain/meter/model.go
+++ b/internal/domain/meter/model.go
@@ -127,9 +127,9 @@ func FromEnt(e *ent.Meter) *Meter {
 			UpdatedBy: e.UpdatedBy,
 		},
 	}
-	// Meters persisted before write-side normalization can carry stray whitespace
-	// in their lookup keys. Normalizing on read heals them without a data migration.
-	m.Normalize()
+	// Meters persisted before write-side sanitization can carry stray whitespace
+	// in their lookup keys. Sanitizing on read heals them without a data migration.
+	m.Sanitize()
 	return m
 }
 
@@ -172,14 +172,14 @@ func (m *Meter) ToEntAggregation() schema.MeterAggregation {
 	}
 }
 
-// Normalize trims stray whitespace from the lookup keys the meter matches events
+// Sanitize trims stray whitespace from the lookup keys the meter matches events
 // on. These are looked up verbatim against event.properties, so a single leading
 // or trailing space makes every lookup miss and silently records zero usage
 // instead of failing loudly. Applied on both write and read.
 //
-// Only identifiers are normalized (event name, aggregation field/expression/group_by,
+// Only identifiers are sanitized (event name, aggregation field/expression/group_by,
 // filter keys) — filter values are matched against tenant data and are left as given.
-func (m *Meter) Normalize() {
+func (m *Meter) Sanitize() {
 	if m == nil {
 		return
 	}

--- a/internal/domain/meter/model.go
+++ b/internal/domain/meter/model.go
@@ -1,6 +1,7 @@
 package meter
 
 import (
+	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/ent"
@@ -102,7 +103,7 @@ func FromEnt(e *ent.Meter) *Meter {
 		}
 	}
 
-	return &Meter{
+	m := &Meter{
 		ID:        e.ID,
 		EventName: e.EventName,
 		Name:      e.Name,
@@ -126,6 +127,10 @@ func FromEnt(e *ent.Meter) *Meter {
 			UpdatedBy: e.UpdatedBy,
 		},
 	}
+	// Meters persisted before write-side normalization can carry stray whitespace
+	// in their lookup keys. Normalizing on read heals them without a data migration.
+	m.Normalize()
+	return m
 }
 
 // FromEntList converts a list of Ent Meters to domain Meters
@@ -164,6 +169,26 @@ func (m *Meter) ToEntAggregation() schema.MeterAggregation {
 		Multiplier: m.Aggregation.Multiplier,
 		BucketSize: m.Aggregation.BucketSize,
 		GroupBy:    m.Aggregation.GroupBy,
+	}
+}
+
+// Normalize trims stray whitespace from the lookup keys the meter matches events
+// on. These are looked up verbatim against event.properties, so a single leading
+// or trailing space makes every lookup miss and silently records zero usage
+// instead of failing loudly. Applied on both write and read.
+//
+// Only identifiers are normalized (event name, aggregation field/expression/group_by,
+// filter keys) — filter values are matched against tenant data and are left as given.
+func (m *Meter) Normalize() {
+	if m == nil {
+		return
+	}
+	m.EventName = strings.TrimSpace(m.EventName)
+	m.Aggregation.Field = strings.TrimSpace(m.Aggregation.Field)
+	m.Aggregation.Expression = strings.TrimSpace(m.Aggregation.Expression)
+	m.Aggregation.GroupBy = strings.TrimSpace(m.Aggregation.GroupBy)
+	for i := range m.Filters {
+		m.Filters[i].Key = strings.TrimSpace(m.Filters[i].Key)
 	}
 }
 

--- a/internal/domain/meter/model_test.go
+++ b/internal/domain/meter/model_test.go
@@ -103,3 +103,59 @@ func TestMeter_Validate_FieldOnlyStillWorks(t *testing.T) {
 		t.Fatalf("plain field-based SUM meter should validate, got %v", err)
 	}
 }
+
+func TestMeter_Normalize_TrimsLookupKeys(t *testing.T) {
+	m := validBase()
+	m.EventName = " llm_usage "
+	m.Aggregation = Aggregation{Type: types.AggregationSum, Field: " output_tokens"}
+	m.Filters = []Filter{{Key: " model_name ", Values: []string{"gpt-4o"}}}
+
+	m.Normalize()
+
+	if m.EventName != "llm_usage" {
+		t.Fatalf("event name not trimmed: %q", m.EventName)
+	}
+	if m.Aggregation.Field != "output_tokens" {
+		t.Fatalf("aggregation field not trimmed: %q", m.Aggregation.Field)
+	}
+	if m.Filters[0].Key != "model_name" {
+		t.Fatalf("filter key not trimmed: %q", m.Filters[0].Key)
+	}
+	// Filter values are tenant data, not identifiers, and are left untouched.
+	if m.Filters[0].Values[0] != "gpt-4o" {
+		t.Fatalf("filter value changed: %q", m.Filters[0].Values[0])
+	}
+}
+
+func TestMeter_Normalize_WhitespaceOnlyFieldFailsValidation(t *testing.T) {
+	m := validBase()
+	m.Aggregation = Aggregation{Type: types.AggregationSum, Field: "   "}
+
+	m.Normalize()
+
+	err := m.Validate()
+	if err == nil {
+		t.Fatal("expected whitespace-only field to be rejected as missing")
+	}
+	if !ierr.IsValidation(err) {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+}
+
+func TestMeter_Normalize_TrimsExpressionAndGroupBy(t *testing.T) {
+	m := validBase()
+	m.Aggregation = Aggregation{
+		Type:       types.AggregationMax,
+		Expression: "  tokens * 2 ",
+		GroupBy:    " request_id ",
+	}
+
+	m.Normalize()
+
+	if m.Aggregation.Expression != "tokens * 2" {
+		t.Fatalf("expression not trimmed: %q", m.Aggregation.Expression)
+	}
+	if m.Aggregation.GroupBy != "request_id" {
+		t.Fatalf("group_by not trimmed: %q", m.Aggregation.GroupBy)
+	}
+}

--- a/internal/domain/meter/model_test.go
+++ b/internal/domain/meter/model_test.go
@@ -104,13 +104,13 @@ func TestMeter_Validate_FieldOnlyStillWorks(t *testing.T) {
 	}
 }
 
-func TestMeter_Normalize_TrimsLookupKeys(t *testing.T) {
+func TestMeter_Sanitize_TrimsLookupKeys(t *testing.T) {
 	m := validBase()
 	m.EventName = " llm_usage "
 	m.Aggregation = Aggregation{Type: types.AggregationSum, Field: " output_tokens"}
 	m.Filters = []Filter{{Key: " model_name ", Values: []string{"gpt-4o"}}}
 
-	m.Normalize()
+	m.Sanitize()
 
 	if m.EventName != "llm_usage" {
 		t.Fatalf("event name not trimmed: %q", m.EventName)
@@ -127,11 +127,11 @@ func TestMeter_Normalize_TrimsLookupKeys(t *testing.T) {
 	}
 }
 
-func TestMeter_Normalize_WhitespaceOnlyFieldFailsValidation(t *testing.T) {
+func TestMeter_Sanitize_WhitespaceOnlyFieldFailsValidation(t *testing.T) {
 	m := validBase()
 	m.Aggregation = Aggregation{Type: types.AggregationSum, Field: "   "}
 
-	m.Normalize()
+	m.Sanitize()
 
 	err := m.Validate()
 	if err == nil {
@@ -142,7 +142,7 @@ func TestMeter_Normalize_WhitespaceOnlyFieldFailsValidation(t *testing.T) {
 	}
 }
 
-func TestMeter_Normalize_TrimsExpressionAndGroupBy(t *testing.T) {
+func TestMeter_Sanitize_TrimsExpressionAndGroupBy(t *testing.T) {
 	m := validBase()
 	m.Aggregation = Aggregation{
 		Type:       types.AggregationMax,
@@ -150,7 +150,7 @@ func TestMeter_Normalize_TrimsExpressionAndGroupBy(t *testing.T) {
 		GroupBy:    " request_id ",
 	}
 
-	m.Normalize()
+	m.Sanitize()
 
 	if m.Aggregation.Expression != "tokens * 2" {
 		t.Fatalf("expression not trimmed: %q", m.Aggregation.Expression)

--- a/internal/ee/service/streaming_processor.go
+++ b/internal/ee/service/streaming_processor.go
@@ -106,6 +106,14 @@ func (sp *StreamingProcessor) ProcessFileStream(
 		}
 	}
 
+	// Spreadsheet exports routinely carry padding around cells, and csv's
+	// TrimLeadingSpace does not reach inside quoted fields or touch trailing
+	// space. An untrimmed header silently fails to match its case in the
+	// processors' switch, and an untrimmed value becomes a lookup key that never
+	// matches an event property — both fail without an error. Trim once here so
+	// every chunk processor sees clean cells.
+	trimFields(headers)
+
 	sp.Logger.Debug(ctx, "parsed CSV headers", "headers", headers)
 
 	var chunk [][]string
@@ -132,6 +140,7 @@ func (sp *StreamingProcessor) ProcessFileStream(
 			continue
 		}
 
+		trimFields(record)
 		chunk = append(chunk, record)
 
 		if len(chunk) >= config.ChunkSize {
@@ -261,4 +270,11 @@ func (sp *StreamingProcessor) updateTaskProgress(ctx context.Context, t *task.Ta
 		"successful", successful,
 		"failed", failed,
 		"chunk_index", chunkIndex)
+}
+
+// trimFields trims surrounding whitespace from every cell of a CSV row in place.
+func trimFields(row []string) {
+	for i := range row {
+		row[i] = strings.TrimSpace(row[i])
+	}
 }

--- a/internal/ee/service/streaming_processor_trim_test.go
+++ b/internal/ee/service/streaming_processor_trim_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/task"
+	"github.com/flexprice/flexprice/internal/logger"
+)
+
+type captureProcessor struct {
+	headers []string
+	rows    [][]string
+}
+
+func (c *captureProcessor) ProcessChunk(_ context.Context, chunk [][]string, headers []string, _ int) (*ChunkResult, error) {
+	c.headers = headers
+	c.rows = append(c.rows, chunk...)
+	return &ChunkResult{ProcessedRecords: len(chunk), SuccessfulRecords: len(chunk)}, nil
+}
+
+// A spreadsheet export that quotes its cells keeps the padding inside the quotes,
+// which csv.TrimLeadingSpace does not strip. That padding is how a meter ended up
+// aggregating on " output_tokens" and silently billing zero usage.
+func TestProcessFileStream_TrimsHeadersAndCells(t *testing.T) {
+	csvData := "name, aggregation_field \ngemma,\" output_tokens \"\n"
+
+	log, err := logger.NewLogger(&config.Configuration{})
+	if err != nil {
+		t.Fatalf("logger: %v", err)
+	}
+	sp := NewStreamingProcessor(log)
+	proc := &captureProcessor{}
+
+	cfg := DefaultStreamingConfig()
+	cfg.ChunkSize = 1
+
+	if err := sp.ProcessFileStream(context.Background(), &task.Task{}, strings.NewReader(csvData), proc, cfg); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+
+	if proc.headers[1] != "aggregation_field" {
+		t.Fatalf("header not trimmed: %q", proc.headers[1])
+	}
+	if len(proc.rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(proc.rows))
+	}
+	if proc.rows[0][1] != "output_tokens" {
+		t.Fatalf("cell not trimmed: %q", proc.rows[0][1])
+	}
+}

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -37,7 +37,7 @@ func NewMeterRepository(client postgres.IClient, logger *logger.Logger, cache ca
 }
 
 func (r *meterRepository) CreateMeter(ctx context.Context, m *domainMeter.Meter) error {
-	m.Normalize()
+	m.Sanitize()
 
 	client := r.client.Writer(ctx)
 
@@ -364,7 +364,7 @@ func (r *meterRepository) UpdateMeter(ctx context.Context, id string, filters []
 	)
 
 	m := &domainMeter.Meter{Filters: filters}
-	m.Normalize()
+	m.Sanitize()
 	_, err := client.Meter.Update().
 		Where(
 			meter.ID(id),

--- a/internal/repository/ent/meter.go
+++ b/internal/repository/ent/meter.go
@@ -37,7 +37,7 @@ func NewMeterRepository(client postgres.IClient, logger *logger.Logger, cache ca
 }
 
 func (r *meterRepository) CreateMeter(ctx context.Context, m *domainMeter.Meter) error {
-	m.EventName = strings.TrimSpace(m.EventName)
+	m.Normalize()
 
 	client := r.client.Writer(ctx)
 
@@ -364,6 +364,7 @@ func (r *meterRepository) UpdateMeter(ctx context.Context, id string, filters []
 	)
 
 	m := &domainMeter.Meter{Filters: filters}
+	m.Normalize()
 	_, err := client.Meter.Update().
 		Where(
 			meter.ID(id),


### PR DESCRIPTION
## Problem

The meter `Gemma-4-31B-Fast-llm-usage-output-tokens` was configured with a leading space in its aggregation field:

```json
"aggregation": { "type": "SUM", "field": " output_tokens" }
```

Property lookup is by exact key, so [`extractQuantity`](internal/ee/service/meter_usage_tracking.go) misses and returns `decimal.Zero` — **no error, no log**. Usage materializes as 0 and billing under-charges silently.

## Why the earlier fix didn't hold

The August change trimmed only `CreateMeterRequest.ToMeter`, i.e. the create path. That left:

- meters written **before** the fix keeping their padding (nothing trimmed on read) — this meter included
- the CSV importer doing **no trimming at all**, which is where the padding originated
- filter keys and the feature-clone path never covered

`csv.TrimLeadingSpace` is enabled but does not reach inside quoted cells or strip trailing space, so a spreadsheet cell exported as `" output_tokens"` arrives padded.

## Changes

| Layer | Change |
|---|---|
| `meter.Normalize()` | Trims `event_name`, `aggregation.field` / `.expression` / `.group_by`, filter keys |
| Read (`FromEnt`) | **Heals existing bad meters with no data migration** |
| `ToMeter` | Runs before `Validate()`, so a whitespace-only field is rejected as missing rather than persisted |
| Repository write | Single boundary covering API, CSV import, onboarding seed and feature-clone paths |
| `events.NormalizeProperties()` | Trims property keys at ingest so both sides of the lookup stay consistent; a padded key never clobbers a clean one |
| CSV importer | Trims headers and cells centrally — the root cause |

## Deliberately unchanged

- **Filter values** — matched against tenant event data, not identifiers. Trimming at read could change matching behaviour for someone.
- **Customer `external_id`** — untrimmed on *both* the customer and event side today, so they are consistent. Trimming one side only would break pairs that currently match. Flagged for a separate decision.

## Testing

New tests cover trimming, the whitespace-only-field validation path, the key-clash rule, and the quoted-CSV-cell case. `go build ./internal/... ./cmd/...` and the meter / events / service / dto / repository suites pass.

## Follow-up (not in this PR)

Read-time normalization fixes the lookup on deploy, but already-materialized usage rows stay at 0. After deploy: reprocess via `POST /v1/events/raw/reprocess/all` for the affected event names, then recompute the affected draft invoices.

Worth running first to size the blast radius:

```sql
SELECT id, event_name, aggregation->>'field' FROM meters WHERE aggregation->>'field' <> trim(aggregation->>'field');
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of extra whitespace in meter names, aggregation fields, grouping fields, and filter keys.
  - Filter values remain unchanged while surrounding whitespace is removed from field identifiers.
  - Event property names are sanitized consistently, including deterministic handling of duplicate keys.
  - CSV streaming now trims whitespace from headers and cell values before processing.
  - Meter validation now correctly rejects fields that become empty after sanitization.
  - Derived event metrics are calculated using cleaned property names, preventing mismatches and incorrect values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->