### PR TITLE
fix(customers): include archived when search filters array is empty

### DIFF
--- a/internal/ee/service/customer_test.go
+++ b/internal/ee/service/customer_test.go
@@ -311,6 +311,18 @@ func (s *CustomerServiceSuite) TestGetCustomersStatusFilter() {
 			expectedCount: 1,
 		},
 		{
+			name: "empty_dsl_filters_include_archived",
+			filter: &types.CustomerFilter{
+				QueryFilter: &types.QueryFilter{
+					Limit:  lo.ToPtr(10),
+					Offset: lo.ToPtr(0),
+				},
+				Filters: []*types.FilterCondition{},
+			},
+			expectedIDs:   []string{"cust-published", "cust-archived"},
+			expectedCount: 2,
+		},
+		{
 			name: "dsl_in_published_and_archived_returns_both",
 			filter: &types.CustomerFilter{
 				QueryFilter: &types.QueryFilter{

--- a/internal/repository/ent/customer.go
+++ b/internal/repository/ent/customer.go
@@ -448,10 +448,11 @@ func (o CustomerQueryOptions) ApplyEnvironmentFilter(ctx context.Context, query 
 }
 
 func (o CustomerQueryOptions) ApplyStatusFilter(query CustomerQuery, status string) CustomerQuery {
-	// Empty means skip the default published-only predicate. CustomerFilter.GetStatus
-	// returns "published" when unset, or "" when DSL filters already constrain status.
 	if status == "" {
-		return query
+		return query.Where(customer.StatusIn(
+			string(types.StatusPublished),
+			string(types.StatusArchived),
+		))
 	}
 	return query.Where(customer.Status(status))
 }

--- a/internal/testutil/inmemory_customer_store.go
+++ b/internal/testutil/inmemory_customer_store.go
@@ -191,16 +191,17 @@ func customerFilterFn(ctx context.Context, c *customer.Customer, filter interfac
 	}
 
 	// Mirror CustomerQueryOptions.ApplyStatusFilter: a non-empty GetStatus is an
-	// equality predicate. Empty means skip (DSL owns status, or no default).
-	// Unset customer status is treated as published so test fixtures still match.
+	// equality predicate. Empty means published+archived (search default).
+	cs := string(c.Status)
+	if cs == "" {
+		cs = string(types.StatusPublished)
+	}
 	if status := f.GetStatus(); status != "" {
-		cs := string(c.Status)
-		if cs == "" {
-			cs = string(types.StatusPublished)
-		}
 		if cs != status {
 			return false
 		}
+	} else if cs != string(types.StatusPublished) && cs != string(types.StatusArchived) {
+		return false
 	}
 
 	for _, cond := range f.Filters {

--- a/internal/types/customer.go
+++ b/internal/types/customer.go
@@ -97,9 +97,9 @@ func (f *CustomerFilter) GetOrder() string {
 }
 
 // GetStatus implements BaseFilter interface.
-// An unset query status defaults to published so listings hide archived customers.
-// When DSL filters already constrain status, return empty so the repository skips
-// that default and lets the DSL IN/eq predicate apply (e.g. published+archived).
+// An unset query status defaults to published so internal lists hide archived customers.
+// Search requests send a filters array (possibly empty); return empty then so
+// ApplyStatusFilter includes published+archived and DSL can narrow further.
 func (f *CustomerFilter) GetStatus() string {
 	if f == nil {
 		return string(StatusPublished)
@@ -109,7 +109,7 @@ func (f *CustomerFilter) GetStatus() string {
 			return status
 		}
 	}
-	if HasFieldFilter(f.Filters, "status") {
+	if f.Filters != nil {
 		return ""
 	}
 	return string(StatusPublished)

--- a/internal/types/customer_test.go
+++ b/internal/types/customer_test.go
@@ -1,10 +1,12 @@
 package types
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCustomerFilter_GetStatus(t *testing.T) {
@@ -22,7 +24,7 @@ func TestCustomerFilter_GetStatus(t *testing.T) {
 		assert.Equal(t, string(StatusPublished), f.GetStatus())
 	})
 
-	t.Run("skips default when DSL filters status so archived can be included", func(t *testing.T) {
+	t.Run("skips default when DSL filters are present so archived can be included", func(t *testing.T) {
 		f := NewCustomerFilter()
 		f.Filters = statusInPublishedAndArchived
 		assert.Equal(t, "", f.GetStatus())
@@ -39,5 +41,29 @@ func TestCustomerFilter_GetStatus(t *testing.T) {
 		f := NewCustomerFilter()
 		f.Status = lo.ToPtr(Status(""))
 		assert.Equal(t, string(StatusPublished), f.GetStatus())
+	})
+
+	t.Run("empty filters slice skips published-only default", func(t *testing.T) {
+		f := NewCustomerFilter()
+		f.Filters = []*FilterCondition{}
+		assert.Equal(t, "", f.GetStatus())
+	})
+}
+
+func TestCustomerFilter_UnmarshalFrontendSearchJSON(t *testing.T) {
+	t.Run("empty filters", func(t *testing.T) {
+		var f CustomerFilter
+		err := json.Unmarshal([]byte(`{"limit":10,"offset":0,"sort":[{"field":"updated_at","direction":"desc"}],"filters":[]}`), &f)
+		require.NoError(t, err)
+		assert.NotNil(t, f.Filters)
+		assert.Equal(t, "", f.GetStatus())
+	})
+
+	t.Run("status in published and archived", func(t *testing.T) {
+		var f CustomerFilter
+		err := json.Unmarshal([]byte(`{"limit":10,"offset":0,"sort":[{"field":"updated_at","direction":"desc"}],"filters":[{"field":"status","operator":"in","data_type":"array","value":{"array":["published","archived"]}}]}`), &f)
+		require.NoError(t, err)
+		assert.True(t, HasFieldFilter(f.Filters, "status"))
+		assert.Equal(t, "", f.GetStatus())
 	})
 }


### PR DESCRIPTION
## Summary
- #2779 merged to `main` before the empty-`filters` follow-up landed, so production still treats `{"filters":[]}` as published-only.
- Search always sends a `filters` array. When that array is present (empty or with `status IN`), default to published+archived. Internal lists that omit `filters` stay published-only.

## Why 2779 was not enough
Deployed `main` is `daedd92` (first two commits only). Frontend default payload is `filters: []`, which still called `GetStatus() == "published"`.

## Test plan
- [x] `go test -race ./internal/types -run TestCustomerFilter_`
- [x] `go test -race ./internal/ee/service -run TestCustomerService/TestGetCustomersStatusFilter`
- [ ] After deploy: `POST /customers/search` with `{"limit":10,"offset":0,"sort":[{"field":"updated_at","direction":"desc"}],"filters":[]}` returns archived customers
- [ ] Same with `filters: [{field: status, operator: in, value.array: [published, archived]}]`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Customer searches with an explicitly empty filter now include both published and archived customers.
  * Default customer filtering continues to exclude archived customers.
  * Customer status filtering is now consistent across stored and in-memory customer data.

* **Tests**
  * Added coverage for empty filters, status filters provided in arrays, and JSON filter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->