### PR TITLE
fix(billing): support one-time subscription periods

### DIFF
--- a/internal/types/date.go
+++ b/internal/types/date.go
@@ -128,8 +128,14 @@ func nextBillingDateCore(currentPeriodStart, billingAnchor time.Time, unit int, 
 			Mark(ierr.ErrValidation)
 	}
 
-	// For daily and weekly periods, we can use simple addition
+	// For one-time, daily, and weekly periods, we can use simple addition.
 	switch period {
+	case BILLING_PERIOD_ONETIME:
+		nextDate := currentPeriodStart.AddDate(0, 0, 1)
+		if subscriptionEndDate != nil && nextDate.After(*subscriptionEndDate) {
+			return *subscriptionEndDate, nil
+		}
+		return nextDate, nil
 	case BILLING_PERIOD_DAILY:
 		// Use the anchor's time component (hour, min, sec) for calendar-aligned billing
 		// For calendar billing, anchor is at 00:00:00, so next date will be at midnight

--- a/internal/types/date_test.go
+++ b/internal/types/date_test.go
@@ -13,6 +13,20 @@ var (
 	jst, _ = time.LoadLocation("Asia/Tokyo")
 )
 
+func TestNextBillingDate_Onetime(t *testing.T) {
+	start := time.Date(2026, time.June, 2, 15, 38, 3, 0, time.UTC)
+
+	got, err := NextBillingDate(&NextBillingDateParams{
+		CurrentPeriodStart: start,
+		BillingAnchor:      start,
+		Unit:               1,
+		Period:             BILLING_PERIOD_ONETIME,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, start.AddDate(0, 0, 1), got)
+}
+
 // Anniversary billing - start date and billing anchor are the same
 // or start date is after the billing anchor but the same day
 func TestNextbillingDate_Monthly_Anniversary(t *testing.T) {


### PR DESCRIPTION
Fixes #1907

## 📝 Description

`ONETIME` is an admitted subscription billing period, but `NextBillingDate` rejected it during subscription creation. I return a one-calendar-day opening period so the subscription and its one-time charge can be created.

## 🔨 Changes Made

- [x] Bug Fix

- Handle `ONETIME` in the shared billing-date helper.
- Add regression coverage for the one-time period boundary.

## ✅ Checklist

- [x] My code follows the project's code style.
- [x] I have added tests where applicable.
- [x] All new and existing tests pass.
- [x] Documentation is not required for this behavior-preserving bug fix.

### Verification

- Before: `go test ./internal/types -run '^TestNextBillingDate_Onetime$' -count=1` returned `invalid billing period type`.
- After: the same test, `go test ./internal/types -count=1`, and `go vet ./internal/types` pass.

## 📷 Screenshots / Demo (if applicable)

Not applicable; the shared billing-date contract is covered by automated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - One-time billing periods now calculate the next billing date correctly.
  - Billing dates are capped at the subscription end date when necessary.

- **Tests**
  - Added coverage to verify one-time billing date calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->