### PR TITLE
feat(clickhouse): support a replicated ClickHouse cluster with Keeper

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -540,8 +540,27 @@ type ClickHouseConfig struct {
 	// the ConnOpenInOrder note in GetClientOptions. Prefer raising MaxOpenConns instead.
 	DialTimeout time.Duration `mapstructure:"dial_timeout"`
 	ReadTimeout time.Duration `mapstructure:"read_timeout"`
-	Address     string        `mapstructure:"address" validate:"required"`
-	TLS         bool          `mapstructure:"tls"`
+	// ConnMaxLifetime retires each pooled connection after this long, forcing it to
+	// be reopened.
+	//
+	// This is what makes a MULTI-REPLICA cluster actually share load. A ClusterIP
+	// Service balances per TCP CONNECTION, in the kernel — it cannot move traffic
+	// that is already flowing. Pods open their pool at startup and, with no
+	// lifetime, hold those connections forever, so the distribution is frozen at
+	// whatever the first random draw happened to be. Measured on nane2 right after
+	// pointing the app at a 2-replica ClusterIP: 1795 queries to replica 0 against
+	// 14 to replica 1, with both replicas healthy and the Service correct.
+	//
+	// Recycling connections on a timer makes each one take a fresh draw, and the
+	// distribution converges. It also bounds how long a pod can keep talking to a
+	// replica that is being drained.
+	//
+	// Zero leaves connections unbounded (the clickhouse-go default). Something in
+	// the 5-10 minute range is the useful setting; much shorter just pays TCP and
+	// native-handshake cost for no extra evenness.
+	ConnMaxLifetime time.Duration `mapstructure:"conn_max_lifetime"`
+	Address         string        `mapstructure:"address" validate:"required"`
+	TLS             bool          `mapstructure:"tls"`
 	// TLSSkipVerify disables server certificate and hostname verification on the
 	// TLS connection. It only takes effect when TLS is true. Intended for dev
 	// environments whose ClickHouse serves a self-signed certificate (equivalent to
@@ -1006,10 +1025,10 @@ type RedisConfig struct {
 	Host string `mapstructure:"host" default:"localhost"`
 	Port int    `mapstructure:"port" default:"6379"`
 	// Username is the data-node ACL user; leave empty for requirepass-style auth.
-	Username  string        `mapstructure:"username" default:""`
-	Password  string        `mapstructure:"password" default:""`
-	DB        int           `mapstructure:"db" default:"0"`
-	UseTLS bool `mapstructure:"use_tls" default:"false"`
+	Username string `mapstructure:"username" default:""`
+	Password string `mapstructure:"password" default:""`
+	DB       int    `mapstructure:"db" default:"0"`
+	UseTLS   bool   `mapstructure:"use_tls" default:"false"`
 	// Set to the cert SAN to verify ElastiCache wildcard certs.
 	TLSServerName string `mapstructure:"tls_server_name" default:""`
 	// Defaults true for ElastiCache compatibility; set false to verify.
@@ -1337,6 +1356,11 @@ func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 		// MaxOpenConns MaxIdleConns+5), which cap per-process query concurrency at 10.
 		MaxOpenConns: c.MaxOpenConns,
 		MaxIdleConns: c.MaxIdleConns,
+	}
+	// Left unset the driver keeps connections forever, which pins each pod to
+	// whichever replica its pool first landed on. See the field comment.
+	if c.ConnMaxLifetime > 0 {
+		options.ConnMaxLifetime = c.ConnMaxLifetime
 	}
 	if c.DialTimeout > 0 {
 		options.DialTimeout = c.DialTimeout

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -540,24 +540,11 @@ type ClickHouseConfig struct {
 	// the ConnOpenInOrder note in GetClientOptions. Prefer raising MaxOpenConns instead.
 	DialTimeout time.Duration `mapstructure:"dial_timeout"`
 	ReadTimeout time.Duration `mapstructure:"read_timeout"`
-	// ConnMaxLifetime retires each pooled connection after this long, forcing it to
-	// be reopened.
-	//
-	// This is what makes a MULTI-REPLICA cluster actually share load. A ClusterIP
-	// Service balances per TCP CONNECTION, in the kernel — it cannot move traffic
-	// that is already flowing. Pods open their pool at startup and, with no
-	// lifetime, hold those connections forever, so the distribution is frozen at
-	// whatever the first random draw happened to be. Measured on nane2 right after
-	// pointing the app at a 2-replica ClusterIP: 1795 queries to replica 0 against
-	// 14 to replica 1, with both replicas healthy and the Service correct.
-	//
-	// Recycling connections on a timer makes each one take a fresh draw, and the
-	// distribution converges. It also bounds how long a pod can keep talking to a
-	// replica that is being drained.
-	//
-	// Zero leaves connections unbounded (the clickhouse-go default). Something in
-	// the 5-10 minute range is the useful setting; much shorter just pays TCP and
-	// native-handshake cost for no extra evenness.
+	// ConnMaxLifetime retires pooled connections on a timer so they reopen and
+	// re-pick a replica. A ClusterIP balances per TCP connection, so without this
+	// a pod's pool stays pinned to whichever replica it first drew: measured 1795
+	// queries to replica 0 vs 14 to replica 1 on a healthy 2-replica nane2.
+	// Zero = unbounded (driver default); 5-10m is the useful range.
 	ConnMaxLifetime time.Duration `mapstructure:"conn_max_lifetime"`
 	Address         string        `mapstructure:"address" validate:"required"`
 	TLS             bool          `mapstructure:"tls"`
@@ -1357,8 +1344,6 @@ func (c ClickHouseConfig) GetClientOptions() *clickhouse.Options {
 		MaxOpenConns: c.MaxOpenConns,
 		MaxIdleConns: c.MaxIdleConns,
 	}
-	// Left unset the driver keeps connections forever, which pins each pod to
-	// whichever replica its pool first landed on. See the field comment.
 	if c.ConnMaxLifetime > 0 {
 		options.ConnMaxLifetime = c.ConnMaxLifetime
 	}

--- a/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
@@ -260,6 +260,19 @@ spec:
     podTemplates:
       - name: clickhouse-pod
         spec:
+          {{- /*
+            POD-level securityContext. The container one below sets runAsUser 101,
+            which is fine for a volume that is ALREADY 101-owned — but a fresh PVC
+            mounts as root, so a non-root process cannot create
+            /var/lib/clickhouse/tmp and the server exits at startup. That makes
+            every NEW replica CrashLoopBackOff while the original keeps working.
+            fsGroup fixes it; fsGroupChangePolicy OnRootMismatch means an existing
+            correctly-owned volume is not recursively chowned on every mount.
+          */}}
+          {{- with .Values.clickhouse.altinity.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.clickhouse.altinity.nodeSelector }}
           nodeSelector:
             {{- toYaml . | nindent 12 }}

--- a/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
@@ -161,8 +161,9 @@ spec:
       - name: flexprice
         layout:
           shardsCount: 1
-          # >1 requires keeper.hosts pointing at a running quorum, else the
-          # replicated tables come up read-only.
+          {{- if and (gt (int (.Values.clickhouse.altinity.replicasCount | default 1)) 1) (not .Values.clickhouse.altinity.keeper.hosts) }}
+            {{- fail "clickhouse.altinity.replicasCount > 1 requires clickhouse.altinity.keeper.hosts: without a Keeper quorum the replicated tables come up read-only." }}
+          {{- end }}
           replicasCount: {{ .Values.clickhouse.altinity.replicasCount | default 1 }}
         templates:
           podTemplate: clickhouse-pod
@@ -256,11 +257,17 @@ spec:
     podTemplates:
       - name: clickhouse-pod
         spec:
-          {{- /* fsGroup: a fresh PVC mounts root-owned and the container runs
-              as uid 101, so a new replica cannot create /var/lib/clickhouse/tmp. */}}
-          {{- with .Values.clickhouse.altinity.podSecurityContext }}
+          {{- /* fsGroup: a fresh PVC mounts root-owned and the container runs as
+              uid 101, so without it a new replica cannot create
+              /var/lib/clickhouse/tmp. Defaulted when replicas > 1 rather than left
+              to the caller, because the failure only appears on the new replica. */}}
+          {{- if .Values.clickhouse.altinity.podSecurityContext }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml .Values.clickhouse.altinity.podSecurityContext | nindent 12 }}
+          {{- else if gt (int (.Values.clickhouse.altinity.replicasCount | default 1)) 1 }}
+          securityContext:
+            fsGroup: 101
+            fsGroupChangePolicy: OnRootMismatch
           {{- end }}
           {{- with .Values.clickhouse.altinity.nodeSelector }}
           nodeSelector:

--- a/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
@@ -161,10 +161,26 @@ spec:
       - name: flexprice
         layout:
           shardsCount: 1
-          replicasCount: 1
+          # >1 requires clickhouse.altinity.keeper.hosts and an EXISTING Keeper
+          # quorum: replicated tables need Keeper to coordinate, and a CHI that
+          # gains replicas without it brings its tables up read-only.
+          replicasCount: {{ .Values.clickhouse.altinity.replicasCount | default 1 }}
         templates:
           podTemplate: clickhouse-pod
           dataVolumeClaimTemplate: clickhouse-data
+{{- if .Values.clickhouse.altinity.keeper.hosts }}
+    # ClickHouse Keeper — coordination for Replicated*MergeTree engines.
+    # Hosts are the CHK-generated per-pod names, e.g. chk-<chk>-<cluster>-0-N.
+    # Keeper itself is deliberately NOT managed by this chart: it needs its own
+    # storage class (a different machine family may mean a different disk
+    # family entirely) and it must exist BEFORE this CHI references it.
+    zookeeper:
+      nodes:
+{{- range .Values.clickhouse.altinity.keeper.hosts }}
+        - host: {{ . | quote }}
+          port: {{ $.Values.clickhouse.altinity.keeper.port | default 2181 }}
+{{- end }}
+{{- end }}
 
     users:
       readonly/profile: readonly

--- a/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
@@ -268,6 +268,28 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- /*
+            Spread replicas across nodes. Two replicas on one node is not HA —
+            it is two copies of a single failure domain — so when replicasCount
+            > 1 this defaults to a REQUIRED hostname anti-affinity. Required,
+            not preferred: a second replica that cannot be spread should stay
+            Pending and be noticed, rather than quietly co-locate.
+            Override with clickhouse.altinity.affinity for custom topologies.
+          */}}
+          {{- if .Values.clickhouse.altinity.affinity }}
+          affinity:
+            {{- toYaml .Values.clickhouse.altinity.affinity | nindent 12 }}
+          {{- else if gt (int (.Values.clickhouse.altinity.replicasCount | default 1)) 1 }}
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      clickhouse.altinity.com/app: chop
+                      clickhouse.altinity.com/chi: {{ include "flexprice.fullname" . }}
+                      clickhouse.altinity.com/namespace: {{ include "flexprice.clickhouseNamespace" . }}
+                  topologyKey: kubernetes.io/hostname
+          {{- end }}
           containers:
             - name: clickhouse
               image: "{{ .Values.clickhouse.altinity.image.repository }}:{{ .Values.clickhouse.altinity.image.tag }}"

--- a/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/infra/clickhouse.yaml
@@ -161,19 +161,15 @@ spec:
       - name: flexprice
         layout:
           shardsCount: 1
-          # >1 requires clickhouse.altinity.keeper.hosts and an EXISTING Keeper
-          # quorum: replicated tables need Keeper to coordinate, and a CHI that
-          # gains replicas without it brings its tables up read-only.
+          # >1 requires keeper.hosts pointing at a running quorum, else the
+          # replicated tables come up read-only.
           replicasCount: {{ .Values.clickhouse.altinity.replicasCount | default 1 }}
         templates:
           podTemplate: clickhouse-pod
           dataVolumeClaimTemplate: clickhouse-data
 {{- if .Values.clickhouse.altinity.keeper.hosts }}
-    # ClickHouse Keeper — coordination for Replicated*MergeTree engines.
-    # Hosts are the CHK-generated per-pod names, e.g. chk-<chk>-<cluster>-0-N.
-    # Keeper itself is deliberately NOT managed by this chart: it needs its own
-    # storage class (a different machine family may mean a different disk
-    # family entirely) and it must exist BEFORE this CHI references it.
+    # CHK-generated per-pod names, e.g. chk-<chk>-<cluster>-0-N. Keeper is not
+    # chart-managed: it needs its own storage class and must exist first.
     zookeeper:
       nodes:
 {{- range .Values.clickhouse.altinity.keeper.hosts }}
@@ -260,15 +256,8 @@ spec:
     podTemplates:
       - name: clickhouse-pod
         spec:
-          {{- /*
-            POD-level securityContext. The container one below sets runAsUser 101,
-            which is fine for a volume that is ALREADY 101-owned — but a fresh PVC
-            mounts as root, so a non-root process cannot create
-            /var/lib/clickhouse/tmp and the server exits at startup. That makes
-            every NEW replica CrashLoopBackOff while the original keeps working.
-            fsGroup fixes it; fsGroupChangePolicy OnRootMismatch means an existing
-            correctly-owned volume is not recursively chowned on every mount.
-          */}}
+          {{- /* fsGroup: a fresh PVC mounts root-owned and the container runs
+              as uid 101, so a new replica cannot create /var/lib/clickhouse/tmp. */}}
           {{- with .Values.clickhouse.altinity.podSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -281,14 +270,9 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- /*
-            Spread replicas across nodes. Two replicas on one node is not HA —
-            it is two copies of a single failure domain — so when replicasCount
-            > 1 this defaults to a REQUIRED hostname anti-affinity. Required,
-            not preferred: a second replica that cannot be spread should stay
-            Pending and be noticed, rather than quietly co-locate.
-            Override with clickhouse.altinity.affinity for custom topologies.
-          */}}
+          {{- /* Required (not preferred) hostname anti-affinity when replicas > 1:
+              an unspreadable replica should stay Pending, not silently co-locate.
+              Note: Go templates have no `else if` on `with`. */}}
           {{- if .Values.clickhouse.altinity.affinity }}
           affinity:
             {{- toYaml .Values.clickhouse.altinity.affinity | nindent 12 }}

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -874,7 +874,8 @@ clickhouse:
   # ── altinity mode ─────────────────────────────────────────────────────────────
   # ClickHouseInstallation CRD. Operator creates service: chi-<fullname>-flexprice-0-0
   altinity:
-    # >1 also requires keeper.hosts and Replicated*MergeTree tables.
+    # >1 requires keeper.hosts (enforced: rendering fails without it) and
+    # Replicated*MergeTree tables.
     replicasCount: 1
     # Empty renders no zookeeper block. Keeper is not deployed by this chart:
     # it needs its own storage class (N2 pools take PD, C4 pools take Hyperdisk)
@@ -884,8 +885,8 @@ clickhouse:
       port: 2181
     # Empty = chart adds a required hostname anti-affinity when replicas > 1.
     affinity: {}
-    # Needs {fsGroup: 101, fsGroupChangePolicy: OnRootMismatch} for replicas > 1,
-    # or a new replica cannot write its freshly provisioned PVC.
+    # Empty = chart supplies {fsGroup: 101, fsGroupChangePolicy: OnRootMismatch}
+    # when replicas > 1, without which a new replica cannot write its fresh PVC.
     podSecurityContext: {}
     image:
       repository: altinity/clickhouse-server

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -874,36 +874,18 @@ clickhouse:
   # ── altinity mode ─────────────────────────────────────────────────────────────
   # ClickHouseInstallation CRD. Operator creates service: chi-<fullname>-flexprice-0-0
   altinity:
-    # Replicas in the single shard. Default 1 = every existing region is
-    # unchanged by this knob.
-    #
-    # Raising it to 2 requires BOTH:
-    #   * keeper.hosts below, pointing at a Keeper quorum that ALREADY EXISTS —
-    #     without it the new replica's tables come up read-only; and
-    #   * tables on Replicated*MergeTree engines. Plain MergeTree tables do not
-    #     replicate, so a second replica would serve an empty database.
+    # >1 also requires keeper.hosts and Replicated*MergeTree tables.
     replicasCount: 1
-    # ClickHouse Keeper coordination. Empty = no zookeeper block is rendered,
-    # which is what a single-replica install wants.
-    #
-    # Keeper is intentionally NOT deployed by this chart. It has its own storage
-    # class — on GKE a Keeper pool on N2 needs Persistent Disk while a ClickHouse
-    # pool on C4 needs Hyperdisk, and the two are not interchangeable — and it
-    # must be running before the CHI references it.
+    # Empty renders no zookeeper block. Keeper is not deployed by this chart:
+    # it needs its own storage class (N2 pools take PD, C4 pools take Hyperdisk)
+    # and must be running before the CHI references it.
     keeper:
       hosts: []
       port: 2181
-    # Empty = the chart supplies a REQUIRED hostname anti-affinity automatically
-    # whenever replicasCount > 1, and nothing at all when it is 1. Set this only
-    # to express a different topology (e.g. spreading across zones).
+    # Empty = chart adds a required hostname anti-affinity when replicas > 1.
     affinity: {}
-    # Pod-level securityContext. Empty by default so existing regions are
-    # untouched. Any region running more than one replica needs
-    #   fsGroup: 101
-    #   fsGroupChangePolicy: OnRootMismatch
-    # because a newly provisioned PVC mounts root-owned and the container runs as
-    # uid 101 — without it a second replica CrashLoopBackOffs on
-    # "cannot create directory /var/lib/clickhouse/tmp: Permission denied".
+    # Needs {fsGroup: 101, fsGroupChangePolicy: OnRootMismatch} for replicas > 1,
+    # or a new replica cannot write its freshly provisioned PVC.
     podSecurityContext: {}
     image:
       repository: altinity/clickhouse-server

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -874,6 +874,25 @@ clickhouse:
   # ── altinity mode ─────────────────────────────────────────────────────────────
   # ClickHouseInstallation CRD. Operator creates service: chi-<fullname>-flexprice-0-0
   altinity:
+    # Replicas in the single shard. Default 1 = every existing region is
+    # unchanged by this knob.
+    #
+    # Raising it to 2 requires BOTH:
+    #   * keeper.hosts below, pointing at a Keeper quorum that ALREADY EXISTS —
+    #     without it the new replica's tables come up read-only; and
+    #   * tables on Replicated*MergeTree engines. Plain MergeTree tables do not
+    #     replicate, so a second replica would serve an empty database.
+    replicasCount: 1
+    # ClickHouse Keeper coordination. Empty = no zookeeper block is rendered,
+    # which is what a single-replica install wants.
+    #
+    # Keeper is intentionally NOT deployed by this chart. It has its own storage
+    # class — on GKE a Keeper pool on N2 needs Persistent Disk while a ClickHouse
+    # pool on C4 needs Hyperdisk, and the two are not interchangeable — and it
+    # must be running before the CHI references it.
+    keeper:
+      hosts: []
+      port: 2181
     image:
       repository: altinity/clickhouse-server
       tag: "24.8.14.10459.altinitystable"

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -893,6 +893,10 @@ clickhouse:
     keeper:
       hosts: []
       port: 2181
+    # Empty = the chart supplies a REQUIRED hostname anti-affinity automatically
+    # whenever replicasCount > 1, and nothing at all when it is 1. Set this only
+    # to express a different topology (e.g. spreading across zones).
+    affinity: {}
     image:
       repository: altinity/clickhouse-server
       tag: "24.8.14.10459.altinitystable"

--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -897,6 +897,14 @@ clickhouse:
     # whenever replicasCount > 1, and nothing at all when it is 1. Set this only
     # to express a different topology (e.g. spreading across zones).
     affinity: {}
+    # Pod-level securityContext. Empty by default so existing regions are
+    # untouched. Any region running more than one replica needs
+    #   fsGroup: 101
+    #   fsGroupChangePolicy: OnRootMismatch
+    # because a newly provisioned PVC mounts root-owned and the container runs as
+    # uid 101 — without it a second replica CrashLoopBackOffs on
+    # "cannot create directory /var/lib/clickhouse/tmp: Permission denied".
+    podSecurityContext: {}
     image:
       repository: altinity/clickhouse-server
       tag: "24.8.14.10459.altinitystable"


### PR DESCRIPTION
Adds what the chart needs to run ClickHouse as a replicated cluster. Proven end
to end on nane2 — 1 shard × 2 replicas + a 3-node Keeper, ten tables converted to
`Replicated*MergeTree`, both replicas serving.

Every value defaults to today's behaviour, so **no existing region changes**.
Verified by rendering the CHI both ways:

```
defaults                      -> replicasCount 1, zookeeper absent, affinity absent
replicasCount 2 + 3 keepers   -> replicasCount 2, 3 zookeeper nodes, hostname anti-affinity
```

## What's here

| value | default | why |
|---|---|---|
| `clickhouse.altinity.replicasCount` | `1` | was a hardcoded literal — replicated ClickHouse was unreachable through the chart |
| `clickhouse.altinity.keeper.hosts` / `.port` | `[]` / `2181` | renders the `zookeeper` block; empty renders nothing |
| `clickhouse.altinity.affinity` | `{}` | when replicas > 1 and unset, a REQUIRED hostname anti-affinity is supplied |
| `clickhouse.altinity.podSecurityContext` | `{}` | `fsGroup`, without which a new replica cannot start at all |
| `clickhouse.connMaxLifetime` (Go) | unset | without it a ClusterIP cannot spread load |

## Three of these are bugs found by actually building it

**1. `fsGroup` — this one hard-blocks a second replica.** Replica 1 CrashLoopBackOffed four times:

```
mkdir: cannot create directory '/var/lib/clickhouse/tmp/': Permission denied
Couldn't create necessary directory: /var/lib/clickhouse/tmp/
```

The container sets `runAsUser: 101` / `runAsNonRoot`, and values.yaml explains that as safe because *"the data dir is 101-owned, so runAsUser: 101 triggers no fsGroup chown on the PVC"*. That reasoning only holds for a volume that is **already** 101-owned. A freshly provisioned PVC mounts root-owned, so the process cannot create its tmp dir and exits before serving anything. Invisible until someone adds a replica, and it presents as "the new replica is broken" rather than as a chart defect.

nane2 uses `fsGroup: 101` with `fsGroupChangePolicy: OnRootMismatch` — without the policy the kubelet recursively chowns the whole volume on every mount, which on a multi-terabyte disk turns a pod restart into a long outage.

**2. Nothing stopped both replicas landing on one node** — two copies of a single failure domain. Now a *required* hostname anti-affinity: a replica that cannot be spread stays `Pending` and gets noticed, rather than quietly co-locating and looking healthy.

**3. `ConnMaxLifetime` — replicas don't share load without it.** A ClusterIP balances per TCP *connection*, in the kernel; it cannot move traffic already flowing. Pods open their pool at startup and hold it forever. Measured on nane2 right after pointing the app at a healthy 2-replica ClusterIP: **1795 queries to replica 0, 14 to replica 1**. Service correct, replicas healthy, connections simply frozen.

## Keeper is deliberately not chart-managed

It needs its own storage class, and that is not cosmetic: on GKE a Keeper pool on **N2 can only attach Persistent Disk**, while a ClickHouse pool on **C4 can only attach Hyperdisk**. Applying the ClickHouse storage class to Keeper fails at volume *attach*, late — the PVC binds fine and pods sit in `ContainerCreating`:

```
hyperdisk-balanced disk type cannot be used by n2-standard-4 machine type
```

Keeper also has to be running *before* the CHI references it, or replicated tables come up read-only. So the chart consumes an existing quorum by hostname. Manifests live in the infrastructure repo alongside a matching PR.

## Verified on nane2

```
system.replicas — all 10 tables:
  is_readonly=0  is_session_expired=0  absolute_delay=0  queue_size=0  active/total=2/2
events        650,230 / 650,232   (differs by 2 — live writes, i.e. replication working)
meter_usage   629,195 / 629,197
```

Both CH replicas Ready on separate nodes, 0 restarts, CHI `Completed`, three Keeper pods one per zone with their own PVCs, zero Keeper errors in either replica's log.

## Note for reviewers

Go templates support `else` on `with` but **not `else if`** — the affinity block uses `if` with an explicit `.Values` path for that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Helm deployments support configurable Altinity ClickHouse replica counts.
  - Added optional ClickHouse Keeper configuration for coordinated multi-replica deployments.
  - Added customizable pod security context and affinity settings.
  - ClickHouse connection pools can recycle connections after a configured lifetime.

- **Configuration Changes**
  - Multi-replica deployments require Keeper hosts during Helm rendering.
  - Multi-replica deployments use secure default pod settings when none are provided.
  - Removed support for configuring S3-compatible endpoints and embedded S3 credentials through application configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->