### PR TITLE
ci(security): flip Trivy fs dep-CVE scan to hard-fail on HIGH/CRITICAL

### DIFF
--- a/.github/workflows/pr-security-scan.yml
+++ b/.github/workflows/pr-security-scan.yml
@@ -6,11 +6,10 @@ name: PR Security Scan
 #   - trivy fs   -> go.sum dependency CVEs (the shift-left dep-CVE gate)
 #   - trivy config -> Dockerfile / Dockerfile.e2eprobe misconfiguration
 #
-# Phase 1 is soft-fail (exit-code 0): like the Checkov rollout there is likely
-# legacy dep-CVE debt, and a hard gate on day one would block every PR. It
-# reports without failing while the baseline is triaged. Phase 2 flips the
-# `trivy fs` step to exit-code 1 on HIGH/CRITICAL fixable vulns once triage is
-# done; `trivy config` stays soft-fail until the Dockerfile findings are cleared.
+# The dep-CVE baseline is triaged (0 fixable HIGH/CRITICAL on develop), so
+# `trivy fs` is a hard gate: it fails the PR on HIGH/CRITICAL fixable vulns.
+# `trivy config` stays soft-fail until the Dockerfile misconfig findings are
+# cleared, then it flips too.
 
 on:
   pull_request:
@@ -30,7 +29,7 @@ jobs:
       # Dependency CVEs from go.sum. Secret/license scanners are disabled
       # (scanners: vuln) — GitGuardian already owns secret detection, so
       # running Trivy's secret scanner here would only duplicate findings.
-      # Phase 2: flip exit-code to '1' after the CVE baseline is triaged.
+      # Hard gate: baseline triaged to 0 fixable HIGH/CRITICAL (FLE-1232).
       - name: Trivy fs scan (Go dependency CVEs)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -40,7 +39,7 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           format: table
-          exit-code: '0'
+          exit-code: '1'
 
       # Dockerfile / IaC misconfiguration (Dockerfile, Dockerfile.e2eprobe).
       # Stays soft-fail through phase 2 until the findings are cleared.


### PR DESCRIPTION
## What

Flips the `trivy fs` (Go dependency-CVE) scan in `pr-security-scan.yml` from soft-fail (`exit-code: '0'`) to hard-fail (`exit-code: '1'`) on HIGH/CRITICAL **fixable** vulns.

## Why

The dep-CVE baseline is triaged to 0 (PRs #2749–#2759 + subsequent x/crypto & x/mod bumps). Phase 2 of the rollout planned in the workflow header: gate for real once the baseline is clean.

## Verification

```
trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 .
```
→ exit 0, every target (`go.mod`, `api/**`, `lambda/**`, `tools/**`, npm/pip locks) reports `0`. The gate won't false-block existing PRs.

## Scope

- `trivy config` (Dockerfile misconfig) **stays soft-fail** — separate baseline, flips later.
- After merge: add **Trivy dependency & config scan** to `develop`/`main` required status checks in branch protection (repo setting, not code) so the exit code actually blocks merge.

Closes FLE-1232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency security scanning to block builds when fixable HIGH or CRITICAL vulnerabilities are detected.
  - Documented the accepted baseline for currently triaged dependency vulnerabilities.
  - Kept configuration security findings as non-blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->