### PR TITLE
fix(helm): PDB maxUnavailable so single-replica pods can be evicted

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/values.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/values.yaml
@@ -183,7 +183,9 @@ api:
       authenticationRef: {}   # TriggerAuthentication for IRSA (podIdentity: aws) built in infra
   podDisruptionBudget:
     enabled: true
-    minAvailable: 1
+    # maxUnavailable so a single-replica api still permits one eviction.
+    minAvailable: ""
+    maxUnavailable: 1
   # RollingUpdate strategy: maxSurge controls how many extra pods can spin up
   # over `replicaCount`; maxUnavailable how many existing pods can go down.
   # Defaults are HA-safe (one extra up, zero unavailable) so api rollouts
@@ -277,7 +279,10 @@ consumer:
     authenticationRef: {}
   podDisruptionBudget:
     enabled: true
-    minAvailable: 1
+    # maxUnavailable (not minAvailable) so a single-replica consumer still
+    # permits one eviction — minAvailable:1 on 1 replica blocks GKE node drains.
+    minAvailable: ""
+    maxUnavailable: 1
   # Kafka consumer prefers one-at-a-time rollout to minimise consumer-group
   # rebalance churn. maxSurge=0 keeps the partition assignment stable.
   strategy:
@@ -435,7 +440,9 @@ worker:
     authenticationRef: {}   # in-cluster plaintext temporal needs none; set for Temporal Cloud
   podDisruptionBudget:
     enabled: true
-    minAvailable: 1
+    # maxUnavailable so a single-replica worker still permits one eviction.
+    minAvailable: ""
+    maxUnavailable: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
api/consumer/worker PodDisruptionBudgets defaulted `minAvailable: 1`. On a single-replica deployment that permits **0 evictions** → GKE cannot drain the node for maintenance/upgrades.

Surfaced as an Active GKE recommendation on `flexprice-staging-mumbai` ("A pod disruption budget exists that allows for 0 pod evictions"), and it blocks node-pool rolls (e.g. the staging general-pool right-size).

## Fix
All three PDBs → `maxUnavailable: 1`:
- Allows one eviction at any replica count (fixes the 1-replica deadlock).
- Still protects availability when replicas > 1.
- Template prefers `minAvailable` when set, so it is emptied.
- `frontend` PDB is `enabled: false` — left as-is.

## Verified
`helm template` renders `maxUnavailable: 1` for api / consumer / worker. Diff 10+/3-.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated service disruption settings to allow one replica to be evicted during planned or unexpected infrastructure disruptions.
  - Applied consistently to API, consumer, and worker services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->