### PR TITLE
fix(subscription): stop generating inverted billing periods for ended subscriptions

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -7428,6 +7428,15 @@ func (s *subscriptionService) CalculateBillingPeriods(ctx context.Context, subsc
 	currentStart := sub.CurrentPeriodStart
 	currentEnd := sub.CurrentPeriodEnd
 
+	// A subscription cancelled mid-period keeps its untruncated CurrentPeriodEnd.
+	if sub.EndDate != nil && sub.EndDate.After(currentStart) && sub.EndDate.Before(currentEnd) {
+		s.Logger.Info(ctx, "truncating open billing period to subscription end date",
+			"subscription_id", sub.ID,
+			"current_period_end", currentEnd,
+			"end_date", *sub.EndDate)
+		currentEnd = *sub.EndDate
+	}
+
 	periods := make([]dto.Period, 0)
 
 	periods = append(periods, dto.Period{
@@ -7450,6 +7459,18 @@ func (s *subscriptionService) CalculateBillingPeriods(ctx context.Context, subsc
 		if err != nil {
 			return nil, err
 		}
+
+		// Backstop for data the truncation above cannot repair, e.g. an end date at or before
+		// CurrentPeriodStart. Never emit a period that runs backwards.
+		if nextEnd.Before(nextStart) {
+			s.Logger.Info(ctx, "stopped period generation - next period end precedes its start",
+				"subscription_id", sub.ID,
+				"next_start", nextStart,
+				"next_end", nextEnd,
+				"end_date", sub.EndDate)
+			break
+		}
+
 		periods = append(periods, dto.Period{
 			Start: nextStart,
 			End:   nextEnd,

--- a/internal/ee/service/subscription_billing_periods_test.go
+++ b/internal/ee/service/subscription_billing_periods_test.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/stretchr/testify/suite"
+)
+
+// SubscriptionBillingPeriodsSuite covers period generation for subscriptions that carry an
+// end date. An end date landing inside the open period used to produce a period running
+// backwards, which every downstream invoice validation rejects — wedging the billing cron
+// before it reached the step that marks the subscription cancelled.
+type SubscriptionBillingPeriodsSuite struct {
+	testutil.BaseServiceTestSuite
+	service SubscriptionService
+}
+
+func TestSubscriptionBillingPeriods(t *testing.T) {
+	suite.Run(t, new(SubscriptionBillingPeriodsSuite))
+}
+
+func (s *SubscriptionBillingPeriodsSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	s.ClearStores()
+	s.service = NewSubscriptionService(ServiceParams{
+		Logger:                   s.GetLogger(),
+		Config:                   s.GetConfig(),
+		DB:                       s.GetDB(),
+		SubRepo:                  s.GetStores().SubscriptionRepo,
+		SubscriptionLineItemRepo: s.GetStores().SubscriptionLineItemRepo,
+		PlanRepo:                 s.GetStores().PlanRepo,
+		PriceRepo:                s.GetStores().PriceRepo,
+		MeterRepo:                s.GetStores().MeterRepo,
+		CustomerRepo:             s.GetStores().CustomerRepo,
+		InvoiceRepo:              s.GetStores().InvoiceRepo,
+		EnvironmentRepo:          s.GetStores().EnvironmentRepo,
+		TenantRepo:               s.GetStores().TenantRepo,
+		EventPublisher:           s.GetPublisher(),
+		WebhookPublisher:         s.GetWebhookPublisher(),
+		ProrationCalculator:      s.GetCalculator(),
+		IntegrationFactory:       s.GetIntegrationFactory(),
+	})
+}
+
+func (s *SubscriptionBillingPeriodsSuite) TearDownTest() {
+	s.BaseServiceTestSuite.TearDownTest()
+	s.BaseServiceTestSuite.ClearStores()
+}
+
+// monthStart returns the first of the month, monthsAgo months before now, in UTC.
+func monthStart(monthsAgo int) time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, -monthsAgo, 0)
+}
+
+func (s *SubscriptionBillingPeriodsSuite) newSubscription(
+	id string,
+	periodStart, periodEnd time.Time,
+	endDate *time.Time,
+) *subscription.Subscription {
+	sub := &subscription.Subscription{
+		ID:                 id,
+		PlanID:             "plan_periods",
+		CustomerID:         "cust_periods",
+		StartDate:          periodStart,
+		CurrentPeriodStart: periodStart,
+		CurrentPeriodEnd:   periodEnd,
+		BillingAnchor:      periodStart,
+		EndDate:            endDate,
+		Currency:           "usd",
+		BillingCycle:       types.BillingCycleCalendar,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		CollectionMethod:   string(types.CollectionMethodChargeAutomatically),
+		PaymentBehavior:    string(types.PaymentBehaviorDefaultActive),
+		SubscriptionType:   types.SubscriptionTypeStandalone,
+		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(s.GetContext(), sub))
+	return sub
+}
+
+// TestEndDateMidPeriod_NoInvertedPeriod reproduces the production wedge: the end date lands
+// inside the still-open period, NextBillingDate clamps the next period end back to the end
+// date, and the generated period runs backwards.
+func (s *SubscriptionBillingPeriodsSuite) TestEndDateMidPeriod_NoInvertedPeriod() {
+	periodStart := monthStart(2)
+	periodEnd := periodStart.AddDate(0, 1, 0)
+	endDate := periodStart.AddDate(0, 0, 9)
+
+	sub := s.newSubscription("sub_mid_period_end", periodStart, periodEnd, &endDate)
+
+	periods, err := s.service.CalculateBillingPeriods(s.GetContext(), sub.ID)
+	s.NoError(err)
+
+	for i, p := range periods {
+		s.Falsef(p.End.Before(p.Start),
+			"period %d runs backwards: start=%s end=%s", i, p.Start, p.End)
+	}
+
+	// The billing workflow only proceeds past CalculatePeriods — and therefore only reaches
+	// the cancellation check — when more than one period is produced.
+	s.Greater(len(periods), 1, "must produce a terminal period so the cancellation check runs")
+
+	last := periods[len(periods)-1]
+	s.True(last.End.Equal(endDate), "final period must land on the end date, got %s", last.End)
+}
+
+// TestEndDateOnPeriodEnd_StillTerminates guards the behaviour CheckCancellationActivity
+// depends on: a zero-length terminal period whose end equals the end date is what triggers
+// cancellation.
+func (s *SubscriptionBillingPeriodsSuite) TestEndDateOnPeriodEnd_StillTerminates() {
+	periodStart := monthStart(2)
+	periodEnd := periodStart.AddDate(0, 1, 0)
+	endDate := periodEnd
+
+	sub := s.newSubscription("sub_end_on_boundary", periodStart, periodEnd, &endDate)
+
+	periods, err := s.service.CalculateBillingPeriods(s.GetContext(), sub.ID)
+	s.NoError(err)
+	s.Len(periods, 2)
+	s.True(periods[0].Start.Equal(periodStart))
+	s.True(periods[0].End.Equal(periodEnd))
+	s.True(periods[1].Start.Equal(endDate))
+	s.True(periods[1].End.Equal(endDate))
+}
+
+// TestNoEndDate_Unchanged guards the ordinary rollover path.
+func (s *SubscriptionBillingPeriodsSuite) TestNoEndDate_Unchanged() {
+	periodStart := monthStart(2)
+	periodEnd := periodStart.AddDate(0, 1, 0)
+
+	sub := s.newSubscription("sub_no_end_date", periodStart, periodEnd, nil)
+
+	periods, err := s.service.CalculateBillingPeriods(s.GetContext(), sub.ID)
+	s.NoError(err)
+	s.Greater(len(periods), 1)
+	for i, p := range periods {
+		s.Falsef(p.End.Before(p.Start), "period %d runs backwards", i)
+	}
+	s.True(periods[len(periods)-1].End.After(time.Now().UTC()),
+		"last period should extend past now")
+}


### PR DESCRIPTION
## Problem

`ProcessSubscriptionBillingWorkflow` fails every run for subscriptions that ended mid-period, with:

```
period_end must be after period_start
```

`CalculateBillingPeriods` seeds the period list with the subscription's untruncated `CurrentPeriodEnd`. When `end_date` falls inside that still-open period, `NextBillingDate` clamps the following period end back to `end_date` (`internal/types/date.go:141,165`), producing a period whose end precedes its start.

Concrete case — `subs_01KK9ETE86R197EGQPMYMJTX9B`, cancelled immediately on 2026-08-10 with the period running 2026-08-01 → 2026-09-01:

| iteration | nextStart | nextEnd (clamped to end_date) |
|---|---|---|
| 1 | 2026-09-01 | **2026-08-10** ← inverted |
| 2 | 2026-08-10 | 2026-08-10 → loop breaks |

Every downstream invoice validation rejects that period (`internal/api/dto/invoice.go:237`), so the workflow dies at `CreateDraftInvoicesActivity` — **before** `CheckCancellationActivity`, which is the step that would mark the subscription `cancelled`. The subscription stays `active`, the billing cron re-selects it on the next run, and it fails identically. Forever.

17 production subscriptions in one tenant are currently in this state.

## Fix

Close the open period at `end_date` when the subscription ended mid-period, so the final partial period is billable and the terminal zero-length period still triggers cancellation. For the case above this yields `[{08-01, 08-10}, {08-10, 08-10}]`: a valid draft invoice for the partial period, then `CheckCancellationActivity` reaches its `Period.End == end_date` branch and cancels properly — with resource termination, inherited-subscription cascade, and the `subscription.cancelled` webhook.

Also adds a `nextEnd.Before(nextStart)` backstop in the loop for data the truncation cannot repair (an `end_date` at or before `CurrentPeriodStart`). That path now stops generation and logs, instead of emitting a bad period.

## Tests

New `internal/ee/service/subscription_billing_periods_test.go`:

- `TestEndDateMidPeriod_NoInvertedPeriod` — the regression. Fails on `develop` with `period 1 runs backwards: start=2026-08-01 end=2026-07-10`.
- `TestEndDateOnPeriodEnd_StillTerminates` — guards the zero-length terminal period that `CheckCancellationActivity` depends on. Passes before and after.
- `TestNoEndDate_Unchanged` — guards the ordinary rollover path. Passes before and after.

`go build ./internal/...`, `go test ./internal/...`, and `make lint-ci` are all clean.

## Notes for review

- **New invoices for the partial period.** Idempotency keys include `period_start`/`period_end` (`internal/ee/service/invoice.go:196-215`), so the truncated period `08-01→08-10` gets a different key than any existing full-period draft `08-01→09-01`. Affected subscriptions will get a new invoice and the old draft is left orphaned. For the 17 known rows every amount is $0, so they compute to SKIPPED, but the orphaned drafts should be voided as part of remediation.
- **Not in this PR:** the payment processor unconditionally forces `subscription_status = active` on a payment result, with no terminal-state check (`attemptPaymentDefaultActive`, `attemptPaymentAllowIncomplete`, and the manual/`send_invoice` branches). That is what resurrected these subscriptions after they were correctly cancelled — confirmed by an invoice finalizing at `2026-08-25 14:06:56.955` and the subscription's `updated_at` landing 126ms later. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1rvELySB7M33muS4Y93g9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Subscription billing periods now end correctly when a subscription ends partway through an open billing period.
  - Prevented invalid backwards-running billing periods for problematic end-date data.
  - Subscriptions ending exactly at a billing period boundary continue to terminate correctly.

- **Tests**
  - Added coverage for mid-period end dates, boundary dates, and subscriptions without end dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->