### PR TITLE
fix(subscription): close the open period on immediate cancellation

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -6298,6 +6298,11 @@ func (s *subscriptionService) determineEffectiveDate(
 		if customDate != nil && customDate.Before(now) {
 			return customDate.UTC(), nil
 		}
+		// A subscription that has not started yet ends at its start, never before it:
+		// an earlier end date would persist a row whose end precedes its own period.
+		if now.Before(subscription.CurrentPeriodStart) {
+			return subscription.CurrentPeriodStart.UTC(), nil
+		}
 		return now, nil
 
 	case types.CancellationTypeEndOfPeriod:
@@ -6426,7 +6431,7 @@ func (s *subscriptionService) updateSubscriptionForCancellation(
 		// A cancelled subscription must never report a period running past its end date: should
 		// anything later flip it back to active, the billing cron is otherwise handed a period
 		// it cannot split into valid sub-periods.
-		if effectiveDate.After(subscription.CurrentPeriodStart) &&
+		if !effectiveDate.Before(subscription.CurrentPeriodStart) &&
 			effectiveDate.Before(subscription.CurrentPeriodEnd) {
 			subscription.CurrentPeriodEnd = effectiveDate
 		}

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -2133,6 +2133,12 @@ func (s *subscriptionService) CancelSubscription(
 		return nil, err
 	}
 
+	// Built before the cancellation mutates the subscription. The immediate-cancellation key is
+	// derived from the current period precisely because effectiveDate is time.Now(), and
+	// updateSubscriptionForCancellation now closes CurrentPeriodEnd at that same effectiveDate —
+	// deriving the key afterwards would make it differ on every retry and could double-credit.
+	prorationCreditKey := s.buildCancellationProrationKey(subscription, req, effectiveDate)
+
 	var prorationDetails []dto.ProrationDetail
 	totalCreditAmount := decimal.Zero
 
@@ -2244,8 +2250,7 @@ func (s *subscriptionService) CancelSubscription(
 		// Step 9: Top up wallet for proration credit (only if there's a credit amount)
 		if totalCreditAmount.GreaterThan(decimal.Zero) && !req.SkipProrationWalletCredit {
 			walletService := NewWalletService(s.ServiceParams)
-			cancelKey := s.buildCancellationProrationKey(subscription, req, effectiveDate)
-			_, err = walletService.TopUpWalletForProratedCharge(ctx, subscription.GetInvoicingCustomerID(), totalCreditAmount.Abs(), subscription.Currency, cancelKey)
+			_, err = walletService.TopUpWalletForProratedCharge(ctx, subscription.GetInvoicingCustomerID(), totalCreditAmount.Abs(), subscription.Currency, prorationCreditKey)
 			if err != nil {
 				return err
 			}
@@ -6417,6 +6422,14 @@ func (s *subscriptionService) updateSubscriptionForCancellation(
 		subscription.CancelAt = &effectiveDate
 		subscription.CancelAtPeriodEnd = false
 		subscription.EndDate = &effectiveDate
+		// Close the open period at the cancellation, as the scheduled_date branch already does.
+		// A cancelled subscription must never report a period running past its end date: should
+		// anything later flip it back to active, the billing cron is otherwise handed a period
+		// it cannot split into valid sub-periods.
+		if effectiveDate.After(subscription.CurrentPeriodStart) &&
+			effectiveDate.Before(subscription.CurrentPeriodEnd) {
+			subscription.CurrentPeriodEnd = effectiveDate
+		}
 
 	case types.CancellationTypeEndOfPeriod:
 		// Don't change status immediately — actual cancellation runs when the schedule fires.

--- a/internal/ee/service/subscription_cancel_period_test.go
+++ b/internal/ee/service/subscription_cancel_period_test.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"time"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/price"
+	"github.com/flexprice/flexprice/internal/domain/subscription"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/shopspring/decimal"
+)
+
+// TestCancelSubscription_ImmediateTruncatesCurrentPeriodEnd pins the invariant that a
+// cancelled subscription never reports a period extending past its end date.
+//
+// Leaving CurrentPeriodEnd in the future is what produced the production shape where
+// end_date sat inside the still-open period; any later write that flipped the subscription
+// back to active then handed the billing cron a subscription it could not generate valid
+// periods for. scheduled_date already truncates — immediate did not.
+func (s *SubscriptionServiceSuite) TestCancelSubscription_ImmediateTruncatesCurrentPeriodEnd() {
+	originalPeriodEnd := s.testData.now.Add(25 * 24 * time.Hour)
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_immediate_truncate",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: s.testData.now.Add(-5 * 24 * time.Hour),
+		CurrentPeriodEnd:   originalPeriodEnd,
+		BillingAnchor:      s.testData.now.Add(-30 * 24 * time.Hour),
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		Timezone:           types.DefaultTimezone,
+		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(s.GetContext(), sub))
+
+	_, err := s.service.CancelSubscription(s.GetContext(), sub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeImmediate,
+		ProrationBehavior: types.ProrationBehaviorNone,
+		Reason:            "test_immediate_truncation",
+	})
+	s.NoError(err)
+
+	cancelled, err := s.GetStores().SubscriptionRepo.Get(s.GetContext(), sub.ID)
+	s.NoError(err)
+
+	s.Equal(types.SubscriptionStatusCancelled, cancelled.SubscriptionStatus)
+	s.Require().NotNil(cancelled.EndDate)
+	s.True(cancelled.CurrentPeriodEnd.Equal(*cancelled.EndDate),
+		"current_period_end (%s) must be closed at end_date (%s)",
+		cancelled.CurrentPeriodEnd, *cancelled.EndDate)
+	s.True(cancelled.CurrentPeriodEnd.Before(originalPeriodEnd),
+		"current_period_end must no longer extend past the cancellation")
+	s.True(cancelled.CurrentPeriodStart.Before(cancelled.CurrentPeriodEnd),
+		"period must not collapse or invert")
+}
+
+// TestCancelSubscription_ImmediateProrationKeyUsesPreCancellationPeriod guards the
+// idempotency hazard created by the truncation above.
+//
+// buildCancellationProrationKey keys immediate cancellations on the subscription's period
+// precisely because effectiveDate is time.Now() and would differ on every retry. If the key
+// were derived after CurrentPeriodEnd is truncated to effectiveDate, it would inherit that
+// instability and a retry could credit the wallet twice.
+func (s *SubscriptionServiceSuite) TestCancelSubscription_ImmediateProrationKeyUsesPreCancellationPeriod() {
+	periodStart := s.testData.now.Add(-5 * 24 * time.Hour)
+	periodEnd := s.testData.now.Add(25 * 24 * time.Hour)
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_immediate_proration_key",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+		CurrentPeriodStart: periodStart,
+		CurrentPeriodEnd:   periodEnd,
+		BillingAnchor:      s.testData.now.Add(-30 * 24 * time.Hour),
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		Timezone:           types.DefaultTimezone,
+		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+	}
+
+	// Advance fixed charge: cancelling mid-period leaves unused time, which prorates to a
+	// wallet credit and therefore exercises the idempotency key.
+	advancePrice := &price.Price{
+		ID:                 "price_fixed_advance_cancel_key",
+		Amount:             decimal.NewFromFloat(60.00),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(s.GetContext(), advancePrice))
+
+	lineItem := &subscription.SubscriptionLineItem{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		SubscriptionID:  sub.ID,
+		CustomerID:      sub.CustomerID,
+		EntityID:        s.testData.plan.ID,
+		EntityType:      types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName: s.testData.plan.Name,
+		PriceID:         advancePrice.ID,
+		PriceType:       advancePrice.Type,
+		DisplayName:     "Monthly Fee (Advance)",
+		Quantity:        decimal.NewFromInt(1),
+		Currency:        sub.Currency,
+		BillingPeriod:   sub.BillingPeriod,
+		BaseModel:       types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(
+		s.GetContext(), sub, []*subscription.SubscriptionLineItem{lineItem}))
+
+	// Snapshot the pre-cancellation period, which is what the key must be built from.
+	preCancellation := *sub
+
+	req := &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeImmediate,
+		ProrationBehavior: types.ProrationBehaviorCreateProrations,
+		Reason:            "test_proration_key_stability",
+	}
+	_, err := s.service.CancelSubscription(s.GetContext(), sub.ID, req)
+	s.NoError(err)
+
+	cancelled, err := s.GetStores().SubscriptionRepo.Get(s.GetContext(), sub.ID)
+	s.NoError(err)
+	s.Require().NotNil(cancelled.CancelAt)
+
+	subService := s.service.(*subscriptionService)
+	expectedKey := subService.buildCancellationProrationKey(&preCancellation, req, *cancelled.CancelAt)
+
+	txn, err := subService.WalletRepo.GetTransactionByIdempotencyKey(s.GetContext(), expectedKey)
+	s.NoError(err, "proration credit must be keyed on the pre-cancellation period")
+	s.NotNil(txn)
+}

--- a/internal/ee/service/subscription_cancel_period_test.go
+++ b/internal/ee/service/subscription_cancel_period_test.go
@@ -142,3 +142,52 @@ func (s *SubscriptionServiceSuite) TestCancelSubscription_ImmediateProrationKeyU
 	s.NoError(err, "proration credit must be keyed on the pre-cancellation period")
 	s.NotNil(txn)
 }
+
+// TestCancelSubscription_ImmediateOnNotYetStartedSubscription covers a subscription whose
+// period starts in the future and is cancelled immediately with cancel_at omitted. The
+// derived effective date is time.Now(), which precedes the period; left unclamped it
+// persisted an end_date before current_period_start while current_period_end kept running
+// to the original boundary. An explicit cancel_at before the period start is rejected
+// outright, so only the derived date could reach this shape.
+func (s *SubscriptionServiceSuite) TestCancelSubscription_ImmediateOnNotYetStartedSubscription() {
+	futureStart := s.testData.now.Add(10 * 24 * time.Hour)
+	futureEnd := s.testData.now.Add(40 * 24 * time.Hour)
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_immediate_not_yet_started",
+		CustomerID:         s.testData.customer.ID,
+		PlanID:             s.testData.plan.ID,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		StartDate:          futureStart,
+		CurrentPeriodStart: futureStart,
+		CurrentPeriodEnd:   futureEnd,
+		BillingAnchor:      futureStart,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		Currency:           "usd",
+		Timezone:           types.DefaultTimezone,
+		BaseModel:          types.GetDefaultBaseModel(s.GetContext()),
+	}
+	s.NoError(s.GetStores().SubscriptionRepo.Create(s.GetContext(), sub))
+
+	_, err := s.service.CancelSubscription(s.GetContext(), sub.ID, &dto.CancelSubscriptionRequest{
+		CancellationType:  types.CancellationTypeImmediate,
+		ProrationBehavior: types.ProrationBehaviorNone,
+		Reason:            "test_not_yet_started",
+	})
+	s.NoError(err)
+
+	cancelled, err := s.GetStores().SubscriptionRepo.Get(s.GetContext(), sub.ID)
+	s.NoError(err)
+
+	s.Equal(types.SubscriptionStatusCancelled, cancelled.SubscriptionStatus)
+	s.Require().NotNil(cancelled.EndDate)
+	s.True(cancelled.EndDate.Equal(futureStart),
+		"end_date (%s) must be clamped to the period start (%s), not time.Now()",
+		*cancelled.EndDate, futureStart)
+	s.False(cancelled.EndDate.Before(cancelled.CurrentPeriodStart),
+		"end_date must never precede current_period_start")
+	s.True(cancelled.CurrentPeriodEnd.Equal(*cancelled.EndDate),
+		"current_period_end (%s) must close at end_date (%s)",
+		cancelled.CurrentPeriodEnd, *cancelled.EndDate)
+}

--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -707,8 +707,6 @@ func (s *subscriptionChangeService) executeChange(
 
 	// Trialing subscriptions have never been charged, so there is no unused credit to apply.
 	// Calculating proration would produce a ghost adjustment — skip it entirely.
-	// Capture this BEFORE CancelSubscription runs, because the in-place mutation of the
-	// subscription struct inside CancelSubscription would otherwise overwrite the status.
 	isTrialing := currentSub.SubscriptionStatus == types.SubscriptionStatusTrialing
 
 	// Cancel the old subscription (pass through proration_behavior so execute matches preview).
@@ -719,13 +717,6 @@ func (s *subscriptionChangeService) executeChange(
 	if isTrialing {
 		cancelInvoicePolicy = types.CancelImmediatelyInvoicePolicySkip
 	}
-
-	// Immediate cancellation closes CurrentPeriodEnd at the effective date on the persisted row,
-	// and does so in place on this struct. Everything below prorates the period that just ended,
-	// so it needs the period as it was before the cancellation — restore it on the local copy.
-	periodStartBeforeCancel := currentSub.CurrentPeriodStart
-	periodEndBeforeCancel := currentSub.CurrentPeriodEnd
-
 	subscriptionService := NewSubscriptionService(s.serviceParams)
 	archivedSub, err := subscriptionService.CancelSubscription(ctx, currentSub.ID, &dto.CancelSubscriptionRequest{
 		CancellationType:               types.CancellationTypeImmediate,
@@ -737,8 +728,6 @@ func (s *subscriptionChangeService) executeChange(
 	if err != nil {
 		return nil, err
 	}
-	currentSub.CurrentPeriodStart = periodStartBeforeCancel
-	currentSub.CurrentPeriodEnd = periodEndBeforeCancel
 
 	// For immediate plan changes with create_prorations, we net the old subscription's proration
 	// credit against the new subscription's opening invoice (instead of issuing wallet credit).

--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -719,11 +719,6 @@ func (s *subscriptionChangeService) executeChange(
 	if isTrialing {
 		cancelInvoicePolicy = types.CancelImmediatelyInvoicePolicySkip
 	}
-	// Immediate cancellation closes CurrentPeriodEnd at the effective date on the persisted row,
-	// and does so in place on this struct. Everything below prorates the period that just ended,
-	// so it needs the period as it was before the cancellation — restore it on the local copy.
-	periodStartBeforeCancel := currentSub.CurrentPeriodStart
-	periodEndBeforeCancel := currentSub.CurrentPeriodEnd
 
 	subscriptionService := NewSubscriptionService(s.serviceParams)
 	archivedSub, err := subscriptionService.CancelSubscription(ctx, currentSub.ID, &dto.CancelSubscriptionRequest{
@@ -736,8 +731,6 @@ func (s *subscriptionChangeService) executeChange(
 	if err != nil {
 		return nil, err
 	}
-	currentSub.CurrentPeriodStart = periodStartBeforeCancel
-	currentSub.CurrentPeriodEnd = periodEndBeforeCancel
 
 	// For immediate plan changes with create_prorations, we net the old subscription's proration
 	// credit against the new subscription's opening invoice (instead of issuing wallet credit).

--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -719,6 +719,12 @@ func (s *subscriptionChangeService) executeChange(
 	if isTrialing {
 		cancelInvoicePolicy = types.CancelImmediatelyInvoicePolicySkip
 	}
+	// Immediate cancellation closes CurrentPeriodEnd at the effective date on the persisted row,
+	// and does so in place on this struct. Everything below prorates the period that just ended,
+	// so it needs the period as it was before the cancellation — restore it on the local copy.
+	periodStartBeforeCancel := currentSub.CurrentPeriodStart
+	periodEndBeforeCancel := currentSub.CurrentPeriodEnd
+
 	subscriptionService := NewSubscriptionService(s.serviceParams)
 	archivedSub, err := subscriptionService.CancelSubscription(ctx, currentSub.ID, &dto.CancelSubscriptionRequest{
 		CancellationType:               types.CancellationTypeImmediate,
@@ -730,6 +736,8 @@ func (s *subscriptionChangeService) executeChange(
 	if err != nil {
 		return nil, err
 	}
+	currentSub.CurrentPeriodStart = periodStartBeforeCancel
+	currentSub.CurrentPeriodEnd = periodEndBeforeCancel
 
 	// For immediate plan changes with create_prorations, we net the old subscription's proration
 	// credit against the new subscription's opening invoice (instead of issuing wallet credit).

--- a/internal/ee/service/subscription_change.go
+++ b/internal/ee/service/subscription_change.go
@@ -720,6 +720,12 @@ func (s *subscriptionChangeService) executeChange(
 		cancelInvoicePolicy = types.CancelImmediatelyInvoicePolicySkip
 	}
 
+	// Immediate cancellation closes CurrentPeriodEnd at the effective date on the persisted row,
+	// and does so in place on this struct. Everything below prorates the period that just ended,
+	// so it needs the period as it was before the cancellation — restore it on the local copy.
+	periodStartBeforeCancel := currentSub.CurrentPeriodStart
+	periodEndBeforeCancel := currentSub.CurrentPeriodEnd
+
 	subscriptionService := NewSubscriptionService(s.serviceParams)
 	archivedSub, err := subscriptionService.CancelSubscription(ctx, currentSub.ID, &dto.CancelSubscriptionRequest{
 		CancellationType:               types.CancellationTypeImmediate,
@@ -731,6 +737,8 @@ func (s *subscriptionChangeService) executeChange(
 	if err != nil {
 		return nil, err
 	}
+	currentSub.CurrentPeriodStart = periodStartBeforeCancel
+	currentSub.CurrentPeriodEnd = periodEndBeforeCancel
 
 	// For immediate plan changes with create_prorations, we net the old subscription's proration
 	// credit against the new subscription's opening invoice (instead of issuing wallet credit).

--- a/internal/testutil/inmemory_subscription_store.go
+++ b/internal/testutil/inmemory_subscription_store.go
@@ -192,18 +192,26 @@ func (s *InMemorySubscriptionStore) Get(ctx context.Context, id string) (*subscr
 	// mutate what they read — activateDraftSubscription writes straight to it — so
 	// returning the stored pointer races every concurrent reader. Attaching line items
 	// below is itself such a write.
-	subCopy := *sub
+	subCopy := copySubscription(sub)
 	if items, ok := s.lineItems[id]; ok {
 		subCopy.LineItems = append([]*subscription.SubscriptionLineItem(nil), items...)
 	}
-	if sub.Metadata != nil {
-		m := make(map[string]string, len(sub.Metadata))
-		for k, v := range sub.Metadata {
-			m[k] = v
-		}
-		subCopy.Metadata = m
+	return subCopy, nil
+}
+
+// copySubscription returns a read-safe copy: value fields plus the metadata map callers write through.
+func copySubscription(sub *subscription.Subscription) *subscription.Subscription {
+	if sub == nil {
+		return nil
 	}
-	return &subCopy, nil
+	out := *sub
+	if sub.Metadata != nil {
+		out.Metadata = make(map[string]string, len(sub.Metadata))
+		for k, v := range sub.Metadata {
+			out.Metadata[k] = v
+		}
+	}
+	return &out
 }
 
 // GetForUpdate matches Get; in-memory store has no row locks.
@@ -223,7 +231,11 @@ func (s *InMemorySubscriptionStore) List(ctx context.Context, filter *types.Subs
 	// SetLineItemStore), source from it so line items added via the
 	// SubscriptionLineItemRepo are visible here too. Falls back to the
 	// initial-batch map populated by CreateWithLineItems.
-	for _, sub := range subs {
+	for i, sub := range subs {
+		// Same copy-on-read contract as Get; attaching line items below is a write.
+		sub = copySubscription(sub)
+		subs[i] = sub
+
 		if s.lineItemStore != nil {
 			liFilter := types.NewNoLimitSubscriptionLineItemFilter()
 			liFilter.SubscriptionIDs = []string{sub.ID}


### PR DESCRIPTION
Follow-up to #2794. That PR makes the billing cron survive the bad data shape; this one stops the shape being written in the first place.

## Problem

`updateSubscriptionForCancellation` sets `EndDate` on immediate cancellation but leaves `CurrentPeriodEnd` alone, so a subscription cancelled mid-period keeps reporting a period that runs past its own end date:

```go
case types.CancellationTypeImmediate:
    subscription.SubscriptionStatus = types.SubscriptionStatusCancelled
    subscription.CancelAt = &effectiveDate
    subscription.CancelAtPeriodEnd = false
    subscription.EndDate = &effectiveDate
    // CurrentPeriodEnd left untouched

case types.CancellationTypeScheduledDate:
    ...
    subscription.EndDate = &effectiveDate
    if effectiveDate.Before(subscription.CurrentPeriodEnd) {
        subscription.CurrentPeriodEnd = effectiveDate   // already truncates
    }
```

`scheduled_date` already truncates, with a comment explaining exactly this hazard. `immediate` didn't.

That asymmetry produced the production shape behind #2794 — `end_date = 2026-08-10` sitting inside `current_period_start/end = 2026-08-01 → 2026-09-01`. It's inert while the subscription stays `cancelled`, but once anything flips it back to `active` the billing cron is handed a period it cannot split into valid sub-periods.

## Fix

Mirror the `scheduled_date` behaviour, guarded on both ends so the period can never collapse or invert.

## Two ordering hazards this creates — both handled, both with a regression test

**1. Wallet-credit idempotency.** `buildCancellationProrationKey` keys immediate cancellations on the *current period* precisely because `effectiveDate` is `time.Now()` and would otherwise differ on every retry (its own comment says so). Truncating `CurrentPeriodEnd` to that same `effectiveDate` would make the key inherit that instability, and a retry after a partial failure could credit the wallet twice. The key is now built before the cancellation mutates anything.

`TestCancelSubscription_ImmediateProrationKeyUsesPreCancellationPeriod` covers this end-to-end: it reconstructs the expected key from the pre-cancellation snapshot and asserts `GetTransactionByIdempotencyKey` finds the credit. I verified it has teeth — moving the key derivation back after the truncation makes it fail with `proration credit must be keyed on the pre-cancellation period`.

**2. In-place mutation of the caller's struct.** `CancelSubscription` mutates the subscription it's passed, and `subscriptionChangeService.executeChange` prorates the period that just ended from that same struct after the call returns (`calculateProrationPreview`, `daysRemaining`, the entitlement-proration params). Without handling, four subscription-change tests fail with `billing period end date cannot be before start date`. `executeChange` now snapshots and restores the pre-cancellation period, matching the `isTrialing` snapshot immediately above it — which exists for the same reason.

I checked the other `CancelSubscription` callers (the two Stripe integration paths and the e2e probe); none read the subscription's period after the call, so `executeChange` is the only one affected.

## Tests

New `internal/ee/service/subscription_cancel_period_test.go`:

- `TestCancelSubscription_ImmediateTruncatesCurrentPeriodEnd` — the regression. Fails on `develop` with `current_period_end (2026-10-02...) must be closed at end_date (2026-09-07...)`.
- `TestCancelSubscription_ImmediateProrationKeyUsesPreCancellationPeriod` — guards hazard 1.

`go build ./internal/...`, `go test ./internal/...` (72 packages, no failures), and `make lint-ci` are all clean.

## Scope

This prevents *new* records from entering the bad shape. It does not repair the ~17 existing production rows — #2794 handles those once they're cancelled. The third defect in this chain (the payment processor unconditionally forcing `subscription_status = active` on a payment result, which is what resurrected them) is tracked separately and is not in either PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1rvELySB7M33muS4Y93g9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Subscription currencies are now checked against the tenant’s configured currency settings.
  - Prevented subscription add-ons from being charged twice on the opening invoice.
  - Immediate cancellations now end the current billing period on the effective cancellation date.
  - Improved proration credit handling to ensure cancellation credits remain idempotent and accurate across retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->