### PR TITLE
feat(integrations): Stripe root price id dedupe for product creation and zoho payment details sync with global fields support

### DIFF
--- a/internal/integration/factory.go
+++ b/internal/integration/factory.go
@@ -146,7 +146,7 @@ func (f *Factory) GetStripeIntegration(ctx context.Context) (*StripeIntegration,
 		f.logger,
 	)
 
-	priceSyncSvc := stripe.NewStripePriceSyncService(stripeClient, f.entityIntegrationMappingRepo, f.logger)
+	priceSyncSvc := stripe.NewStripePriceSyncService(stripeClient, f.entityIntegrationMappingRepo, f.priceRepo, f.logger)
 
 	// Create invoice sync service first
 	invoiceSyncSvc := stripe.NewInvoiceSyncService(
@@ -687,6 +687,7 @@ func (f *Factory) GetZohoBooksIntegration(ctx context.Context) (*ZohoBooksIntegr
 		f.invoiceRepo,
 		f.priceRepo,
 		f.entityIntegrationMappingRepo,
+		f.paymentRepo,
 		f.logger,
 	)
 

--- a/internal/integration/stripe/payment_test.go
+++ b/internal/integration/stripe/payment_test.go
@@ -27,7 +27,7 @@ func TestBuildSyncedLineItems_HappyPath(t *testing.T) {
 	}
 	s := &PaymentService{
 		logger:       logger.NewNoopLogger(),
-		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, logger.NewNoopLogger()),
+		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, nil, logger.NewNoopLogger()),
 	}
 	invoiceResp := &dto.InvoiceResponse{
 		LineItems: []*dto.InvoiceLineItemResponse{
@@ -54,7 +54,7 @@ func TestBuildSyncedLineItems_MissingPriceIDFallsBackForThatItem(t *testing.T) {
 	}
 	s := &PaymentService{
 		logger:       logger.NewNoopLogger(),
-		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, logger.NewNoopLogger()),
+		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, nil, logger.NewNoopLogger()),
 	}
 	invoiceResp := &dto.InvoiceResponse{
 		LineItems: []*dto.InvoiceLineItemResponse{
@@ -76,7 +76,7 @@ func TestBuildSyncedLineItems_MissingPriceIDFallsBackForThatItem(t *testing.T) {
 func TestBuildSyncedLineItems_AllMissingPriceIDReturnsNilForFullFallback(t *testing.T) {
 	s := &PaymentService{
 		logger:       logger.NewNoopLogger(),
-		priceSyncSvc: NewStripePriceSyncService(nil, &syncTestMappingRepo{}, logger.NewNoopLogger()),
+		priceSyncSvc: NewStripePriceSyncService(nil, &syncTestMappingRepo{}, nil, logger.NewNoopLogger()),
 	}
 	invoiceResp := &dto.InvoiceResponse{
 		LineItems: []*dto.InvoiceLineItemResponse{
@@ -98,7 +98,7 @@ func TestBuildSyncedLineItems_DuplicatePriceIDAcrossLineItems(t *testing.T) {
 	}
 	s := &PaymentService{
 		logger:       logger.NewNoopLogger(),
-		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, logger.NewNoopLogger()),
+		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, nil, logger.NewNoopLogger()),
 	}
 	invoiceResp := &dto.InvoiceResponse{
 		LineItems: []*dto.InvoiceLineItemResponse{
@@ -119,7 +119,7 @@ func TestBuildSyncedLineItems_SyncFailurePropagates(t *testing.T) {
 	mappingRepo := &syncTestMappingRepo{listErr: errors.New("db unavailable")}
 	s := &PaymentService{
 		logger:       logger.NewNoopLogger(),
-		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, logger.NewNoopLogger()),
+		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, nil, logger.NewNoopLogger()),
 	}
 	invoiceResp := &dto.InvoiceResponse{
 		LineItems: []*dto.InvoiceLineItemResponse{
@@ -140,7 +140,7 @@ func TestBuildSyncedLineItems_ZeroAmountLineItemsSkipped(t *testing.T) {
 	}
 	s := &PaymentService{
 		logger:       logger.NewNoopLogger(),
-		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, logger.NewNoopLogger()),
+		priceSyncSvc: NewStripePriceSyncService(nil, mappingRepo, nil, logger.NewNoopLogger()),
 	}
 	invoiceResp := &dto.InvoiceResponse{
 		LineItems: []*dto.InvoiceLineItemResponse{

--- a/internal/integration/stripe/price_sync.go
+++ b/internal/integration/stripe/price_sync.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	"github.com/flexprice/flexprice/internal/domain/price"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
@@ -22,6 +23,7 @@ type priceSyncItem struct {
 type stripePriceSyncService struct {
 	client                       *Client
 	entityIntegrationMappingRepo entityintegrationmapping.Repository
+	priceRepo                    price.Repository
 	logger                       *logger.Logger
 }
 
@@ -29,25 +31,34 @@ type stripePriceSyncService struct {
 func NewStripePriceSyncService(
 	client *Client,
 	entityIntegrationMappingRepo entityintegrationmapping.Repository,
+	priceRepo price.Repository,
 	logger *logger.Logger,
 ) *stripePriceSyncService {
 	return &stripePriceSyncService{
 		client:                       client,
 		entityIntegrationMappingRepo: entityIntegrationMappingRepo,
+		priceRepo:                    priceRepo,
 		logger:                       logger,
 	}
 }
 
-// EnsureBulkProductsSynced ensures a Stripe Product exists per price and returns priceID -> stripeProductID.
+// EnsureBulkProductsSynced returns itemPriceID -> stripeProductID. Products are keyed on the
+// root price so every subscription override of a plan price shares one Stripe catalog item
+// instead of minting a duplicate.
 func (s *stripePriceSyncService) EnsureBulkProductsSynced(ctx context.Context, items []priceSyncItem) (map[string]string, error) {
 	if len(items) == 0 {
 		return map[string]string{}, nil
 	}
 
-	priceIDs := lo.Map(items, func(item priceSyncItem, _ int) string { return item.PriceID })
+	itemToRootPriceIdMap, err := s.resolveRootPriceIDs(ctx, items)
+	if err != nil {
+		return nil, err
+	}
+
+	rootPriceIDs := lo.Uniq(lo.Map(items, func(item priceSyncItem, _ int) string { return itemToRootPriceIdMap[item.PriceID] }))
 
 	existing, err := s.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-		EntityIDs:     priceIDs,
+		EntityIDs:     rootPriceIDs,
 		EntityType:    types.IntegrationEntityTypePrice,
 		ProviderTypes: []string{"stripe"},
 		QueryFilter:   types.NewNoLimitQueryFilter(),
@@ -56,12 +67,19 @@ func (s *stripePriceSyncService) EnsureBulkProductsSynced(ctx context.Context, i
 		return nil, ierr.WithError(err).WithHint("Failed to fetch existing Stripe product mappings").Mark(ierr.ErrDatabase)
 	}
 
-	result := lo.SliceToMap(existing, func(m *entityintegrationmapping.EntityIntegrationMapping) (string, string) {
+	rootProductMap := lo.SliceToMap(existing, func(m *entityintegrationmapping.EntityIntegrationMapping) (string, string) {
 		return m.EntityID, m.ProviderEntityID
 	})
 
-	unmapped := lo.Filter(items, func(item priceSyncItem, _ int) bool { return result[item.PriceID] == "" })
-	if len(unmapped) == 0 {
+	result := make(map[string]string, len(items))
+	for _, item := range items {
+		if productID := rootProductMap[itemToRootPriceIdMap[item.PriceID]]; productID != "" {
+			result[item.PriceID] = productID
+		}
+	}
+
+	unmappedItems := lo.Filter(items, func(item priceSyncItem, _ int) bool { return result[item.PriceID] == "" })
+	if len(unmappedItems) == 0 {
 		return result, nil
 	}
 
@@ -71,31 +89,41 @@ func (s *stripePriceSyncService) EnsureBulkProductsSynced(ctx context.Context, i
 		return nil, err
 	}
 
-	for _, item := range unmapped {
-		name := item.DisplayName
+	// Dedupe by root so two overrides of one unmapped parent create a single product.
+	unmappedRoots := lo.Uniq(lo.Map(unmappedItems, func(item priceSyncItem, _ int) string { return itemToRootPriceIdMap[item.PriceID] }))
+	displayByRoot := make(map[string]string, len(unmappedRoots))
+	for _, item := range unmappedItems {
+		rootPriceID := itemToRootPriceIdMap[item.PriceID]
+		if displayByRoot[rootPriceID] == "" && item.DisplayName != "" {
+			displayByRoot[rootPriceID] = item.DisplayName
+		}
+	}
+
+	for _, rootID := range unmappedRoots {
+		name := displayByRoot[rootID]
 		if name == "" {
-			name = item.PriceID
+			name = rootID
 		}
 
 		product, err := stripeClient.V1Products.Create(ctx, &stripe.ProductCreateParams{
 			Name: stripe.String(name),
 			Metadata: map[string]string{
-				"flexprice_price_id": item.PriceID,
+				"flexprice_price_id": rootID,
 				"environment_id":     types.GetEnvironmentID(ctx),
 				"sync_source":        "flexprice",
 			},
 		})
 		if err != nil {
-			s.logger.Error(ctx, "failed to create Stripe product for price", "error", err, "price_id", item.PriceID)
+			s.logger.Error(ctx, "failed to create Stripe product for price", "error", err, "price_id", rootID)
 			return nil, ierr.NewError("failed to create Stripe product").
 				WithHint("Unable to create Stripe product for price. If using a restricted Stripe API key, ensure it has the 'Products: Write' permission.").
-				WithReportableDetails(map[string]interface{}{"price_id": item.PriceID, "error": err.Error()}).
+				WithReportableDetails(map[string]interface{}{"price_id": rootID, "error": err.Error()}).
 				Mark(ierr.ErrSystem)
 		}
 
 		mapping := &entityintegrationmapping.EntityIntegrationMapping{
 			ID:               types.GenerateUUIDWithPrefix(types.UUID_PREFIX_ENTITY_INTEGRATION_MAPPING),
-			EntityID:         item.PriceID,
+			EntityID:         rootID,
 			EntityType:       types.IntegrationEntityTypePrice,
 			ProviderType:     "stripe",
 			ProviderEntityID: product.ID,
@@ -106,6 +134,8 @@ func (s *stripePriceSyncService) EnsureBulkProductsSynced(ctx context.Context, i
 			EnvironmentID: types.GetEnvironmentID(ctx),
 			BaseModel:     types.GetDefaultBaseModel(ctx),
 		}
+
+		productID := product.ID
 		if err := s.entityIntegrationMappingRepo.Create(ctx, mapping); err != nil {
 			if !ierr.IsAlreadyExists(err) {
 				return nil, ierr.WithError(err).WithHint("Failed to persist Stripe product mapping").Mark(ierr.ErrDatabase)
@@ -116,7 +146,7 @@ func (s *stripePriceSyncService) EnsureBulkProductsSynced(ctx context.Context, i
 			// Product we just created above is orphaned (unreferenced, harmless) rather
 			// than retried into a duplicate.
 			winner, findErr := s.entityIntegrationMappingRepo.List(ctx, &types.EntityIntegrationMappingFilter{
-				EntityIDs:     []string{item.PriceID},
+				EntityIDs:     []string{rootID},
 				EntityType:    types.IntegrationEntityTypePrice,
 				ProviderTypes: []string{"stripe"},
 				QueryFilter:   types.NewNoLimitQueryFilter(),
@@ -126,14 +156,73 @@ func (s *stripePriceSyncService) EnsureBulkProductsSynced(ctx context.Context, i
 			}
 
 			s.logger.Info(ctx, "lost product mapping race, adopting concurrently created mapping",
-				"price_id", item.PriceID, "orphaned_stripe_product_id", product.ID, "winning_stripe_product_id", winner[0].ProviderEntityID)
-			result[item.PriceID] = winner[0].ProviderEntityID
-			continue
+				"price_id", rootID, "orphaned_stripe_product_id", product.ID, "winning_stripe_product_id", winner[0].ProviderEntityID)
+			productID = winner[0].ProviderEntityID
+		} else {
+			s.logger.Info(ctx, "created Stripe product for price", "price_id", rootID, "stripe_product_id", product.ID)
 		}
 
-		result[item.PriceID] = product.ID
-		s.logger.Info(ctx, "created Stripe product for price", "price_id", item.PriceID, "stripe_product_id", product.ID)
+		rootProductMap[rootID] = productID
+		for _, item := range unmappedItems {
+			if itemToRootPriceIdMap[item.PriceID] == rootID {
+				result[item.PriceID] = productID
+			}
+		}
 	}
 
 	return result, nil
+}
+
+// An override whose parent row is gone keeps its own ID so it still gets a product.
+func (s *stripePriceSyncService) resolveRootPriceIDs(ctx context.Context, items []priceSyncItem) (map[string]string, error) {
+	itemToRootPriceIdMap := lo.SliceToMap(items, func(item priceSyncItem) (string, string) {
+		return item.PriceID, item.PriceID
+	})
+	if s.priceRepo == nil {
+		return itemToRootPriceIdMap, nil
+	}
+
+	prices, err := s.listPricesByID(ctx, lo.Keys(itemToRootPriceIdMap))
+	if err != nil {
+		return nil, err
+	}
+
+	exists := lo.SliceToMap(prices, func(p *price.Price) (string, bool) { return p.ID, true })
+	parentPriceIdByPriceId := make(map[string]string, len(prices))
+	for _, p := range prices {
+		if root := p.GetRootPriceID(); root != p.ID {
+			parentPriceIdByPriceId[p.ID] = root
+		}
+	}
+	if len(parentPriceIdByPriceId) == 0 {
+		return itemToRootPriceIdMap, nil
+	}
+
+	unknownParentPriceIds := lo.Filter(lo.Uniq(lo.Values(parentPriceIdByPriceId)), func(id string, _ int) bool { return !exists[id] })
+	if len(unknownParentPriceIds) > 0 {
+		unknownParentPrices, err := s.listPricesByID(ctx, unknownParentPriceIds)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range unknownParentPrices {
+			exists[p.ID] = true
+		}
+	}
+
+	for itemID, parentID := range parentPriceIdByPriceId {
+		if exists[parentID] {
+			itemToRootPriceIdMap[itemID] = parentID
+		}
+	}
+	return itemToRootPriceIdMap, nil
+}
+
+// An ended plan price must keep owning the Product its overrides point at, hence expired prices.
+func (s *stripePriceSyncService) listPricesByID(ctx context.Context, ids []string) ([]*price.Price, error) {
+	prices, err := s.priceRepo.ListAll(ctx, types.NewNoLimitPriceFilter().WithPriceIDs(ids).WithAllowExpiredPrices(true))
+	if err != nil {
+		return nil, ierr.WithError(err).WithHint("Failed to load prices for Stripe product sync").Mark(ierr.ErrDatabase)
+	}
+
+	return prices, nil
 }

--- a/internal/integration/stripe/price_sync_test.go
+++ b/internal/integration/stripe/price_sync_test.go
@@ -5,12 +5,37 @@ package stripe
 // Reuses that file's syncTestMappingRepo and testContext() (same package).
 
 import (
+	"context"
 	"testing"
 
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	"github.com/flexprice/flexprice/internal/domain/price"
 	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
 	"github.com/stretchr/testify/require"
 )
+
+type syncTestPriceRepo struct {
+	price.Repository
+	prices []*price.Price
+}
+
+func (r *syncTestPriceRepo) ListAll(_ context.Context, filter *types.PriceFilter) ([]*price.Price, error) {
+	if filter == nil || len(filter.PriceIDs) == 0 {
+		return append([]*price.Price(nil), r.prices...), nil
+	}
+	want := make(map[string]struct{}, len(filter.PriceIDs))
+	for _, id := range filter.PriceIDs {
+		want[id] = struct{}{}
+	}
+	out := make([]*price.Price, 0, len(filter.PriceIDs))
+	for _, p := range r.prices {
+		if _, ok := want[p.ID]; ok {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
 
 func TestEnsureBulkProductsSynced_AllAlreadyMapped(t *testing.T) {
 	mappingRepo := &syncTestMappingRepo{
@@ -19,7 +44,7 @@ func TestEnsureBulkProductsSynced_AllAlreadyMapped(t *testing.T) {
 			{EntityID: "price_2", ProviderEntityID: "prod_2"},
 		},
 	}
-	svc := NewStripePriceSyncService(nil, mappingRepo, logger.NewNoopLogger())
+	svc := NewStripePriceSyncService(nil, mappingRepo, nil, logger.NewNoopLogger())
 
 	result, err := svc.EnsureBulkProductsSynced(testContext(), []priceSyncItem{
 		{PriceID: "price_1", DisplayName: "Seat fee"},
@@ -33,11 +58,104 @@ func TestEnsureBulkProductsSynced_AllAlreadyMapped(t *testing.T) {
 
 func TestEnsureBulkProductsSynced_EmptyInput(t *testing.T) {
 	mappingRepo := &syncTestMappingRepo{}
-	svc := NewStripePriceSyncService(nil, mappingRepo, logger.NewNoopLogger())
+	svc := NewStripePriceSyncService(nil, mappingRepo, nil, logger.NewNoopLogger())
 
 	result, err := svc.EnsureBulkProductsSynced(testContext(), nil)
 
 	require.NoError(t, err)
 	require.Empty(t, result)
 	require.Equal(t, 0, mappingRepo.listCalls)
+}
+
+func TestEnsureBulkProductsSynced_OverrideReusesParentProduct(t *testing.T) {
+	mappingRepo := &syncTestMappingRepo{
+		mappings: []*entityintegrationmapping.EntityIntegrationMapping{
+			{EntityID: "price_plan", ProviderEntityID: "prod_plan"},
+		},
+	}
+	priceRepo := &syncTestPriceRepo{
+		prices: []*price.Price{
+			{ID: "price_override", ParentPriceID: "price_plan"},
+			{ID: "price_plan"},
+		},
+	}
+	svc := NewStripePriceSyncService(nil, mappingRepo, priceRepo, logger.NewNoopLogger())
+
+	result, err := svc.EnsureBulkProductsSynced(testContext(), []priceSyncItem{
+		{PriceID: "price_override", DisplayName: "Attestra Academy Annual"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"price_override": "prod_plan"}, result)
+}
+
+func TestEnsureBulkProductsSynced_TwoOverridesShareParentProduct(t *testing.T) {
+	mappingRepo := &syncTestMappingRepo{
+		mappings: []*entityintegrationmapping.EntityIntegrationMapping{
+			{EntityID: "price_plan", ProviderEntityID: "prod_plan"},
+		},
+	}
+	priceRepo := &syncTestPriceRepo{
+		prices: []*price.Price{
+			{ID: "price_override_a", ParentPriceID: "price_plan"},
+			{ID: "price_override_b", ParentPriceID: "price_plan"},
+			{ID: "price_plan"},
+		},
+	}
+	svc := NewStripePriceSyncService(nil, mappingRepo, priceRepo, logger.NewNoopLogger())
+
+	result, err := svc.EnsureBulkProductsSynced(testContext(), []priceSyncItem{
+		{PriceID: "price_override_a", DisplayName: "Attestra Academy Annual"},
+		{PriceID: "price_override_b", DisplayName: "Attestra Academy Annual"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"price_override_a": "prod_plan",
+		"price_override_b": "prod_plan",
+	}, result)
+}
+
+func TestEnsureBulkProductsSynced_PrefersParentOverLegacyOverrideMapping(t *testing.T) {
+	mappingRepo := &syncTestMappingRepo{
+		mappings: []*entityintegrationmapping.EntityIntegrationMapping{
+			{EntityID: "price_plan", ProviderEntityID: "prod_plan"},
+			{EntityID: "price_override", ProviderEntityID: "prod_orphan"},
+		},
+	}
+	priceRepo := &syncTestPriceRepo{
+		prices: []*price.Price{
+			{ID: "price_override", ParentPriceID: "price_plan"},
+			{ID: "price_plan"},
+		},
+	}
+	svc := NewStripePriceSyncService(nil, mappingRepo, priceRepo, logger.NewNoopLogger())
+
+	result, err := svc.EnsureBulkProductsSynced(testContext(), []priceSyncItem{
+		{PriceID: "price_override", DisplayName: "Attestra Academy Annual"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"price_override": "prod_plan"}, result)
+}
+
+func TestEnsureBulkProductsSynced_MissingParentFallsBackToOwnMapping(t *testing.T) {
+	mappingRepo := &syncTestMappingRepo{
+		mappings: []*entityintegrationmapping.EntityIntegrationMapping{
+			{EntityID: "price_override", ProviderEntityID: "prod_override"},
+		},
+	}
+	priceRepo := &syncTestPriceRepo{
+		prices: []*price.Price{
+			{ID: "price_override", ParentPriceID: "price_gone"},
+		},
+	}
+	svc := NewStripePriceSyncService(nil, mappingRepo, priceRepo, logger.NewNoopLogger())
+
+	result, err := svc.EnsureBulkProductsSynced(testContext(), []priceSyncItem{
+		{PriceID: "price_override", DisplayName: "Attestra Academy Annual"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"price_override": "prod_override"}, result)
 }

--- a/internal/integration/zoho/dto.go
+++ b/internal/integration/zoho/dto.go
@@ -128,6 +128,9 @@ type CustomField struct {
 // customfield_id. Zoho generates these as "cf_<label_slug>".
 const apiNamePrefix = "cf_"
 
+// Zoho caps reference_number at 100 characters.
+const maxZohoReferenceNumberLen = 100
+
 func NewCustomField(ref, value string) CustomField {
 	ref = strings.TrimSpace(ref)
 	if strings.HasPrefix(ref, apiNamePrefix) {
@@ -219,29 +222,46 @@ type customerPaymentInvoiceApplyWire struct {
 	AmountApplied decimal.Decimal `json:"amount_applied"`
 }
 
+// CustomerPaymentCreateParams are the inputs for NewCustomerPaymentCreateRequest.
+type CustomerPaymentCreateParams struct {
+	CustomerID  string
+	PaymentMode string
+	Amount      decimal.Decimal
+	Date        string
+	Invoices    []CustomerPaymentInvoiceApply
+	// AccountID is Zoho's "Deposit To" chart-of-accounts id. Empty omits the field, leaving
+	// Zoho's Undeposited Funds default.
+	AccountID string
+	// ReferenceNumber is the gateway payment id that settled the invoice. Empty omits the field.
+	ReferenceNumber string
+}
+
 // CustomerPaymentCreateRequest is the body for POST /books/v3/customerpayments.
 type CustomerPaymentCreateRequest struct {
-	customerID  string
-	paymentMode string
-	amount      decimal.Decimal
-	date        string
-	invoices    []CustomerPaymentInvoiceApply
+	customerID      string
+	paymentMode     string
+	amount          decimal.Decimal
+	date            string
+	invoices        []CustomerPaymentInvoiceApply
+	accountID       string
+	referenceNumber string
 }
 
 // NewCustomerPaymentCreateRequest builds the request body for recording a Zoho customer payment.
-func NewCustomerPaymentCreateRequest(
-	customerID string,
-	paymentMode string,
-	amount decimal.Decimal,
-	date string,
-	invoices []CustomerPaymentInvoiceApply,
-) *CustomerPaymentCreateRequest {
+func NewCustomerPaymentCreateRequest(params CustomerPaymentCreateParams) *CustomerPaymentCreateRequest {
+	reference := strings.TrimSpace(params.ReferenceNumber)
+	if len(reference) > maxZohoReferenceNumberLen {
+		reference = reference[:maxZohoReferenceNumberLen]
+	}
+
 	return &CustomerPaymentCreateRequest{
-		customerID:  customerID,
-		paymentMode: paymentMode,
-		amount:      amount,
-		date:        date,
-		invoices:    invoices,
+		customerID:      params.CustomerID,
+		paymentMode:     params.PaymentMode,
+		amount:          params.Amount,
+		date:            params.Date,
+		invoices:        params.Invoices,
+		accountID:       strings.TrimSpace(params.AccountID),
+		referenceNumber: reference,
 	}
 }
 
@@ -280,16 +300,32 @@ func (r *CustomerPaymentCreateRequest) Invoices() []CustomerPaymentInvoiceApply 
 	return r.invoices
 }
 
+func (r *CustomerPaymentCreateRequest) AccountID() string {
+	if r == nil {
+		return ""
+	}
+	return r.accountID
+}
+
+func (r *CustomerPaymentCreateRequest) ReferenceNumber() string {
+	if r == nil {
+		return ""
+	}
+	return r.referenceNumber
+}
+
 func (r *CustomerPaymentCreateRequest) MarshalJSON() ([]byte, error) {
 	if r == nil {
 		return []byte("null"), nil
 	}
 	return json.Marshal(customerPaymentCreateRequestWire{
-		CustomerID:  r.customerID,
-		PaymentMode: r.paymentMode,
-		Amount:      r.amount,
-		Date:        r.date,
-		Invoices:    r.invoices,
+		CustomerID:      r.customerID,
+		PaymentMode:     r.paymentMode,
+		Amount:          r.amount,
+		Date:            r.date,
+		Invoices:        r.invoices,
+		AccountID:       r.accountID,
+		ReferenceNumber: r.referenceNumber,
 	})
 }
 
@@ -303,15 +339,19 @@ func (r *CustomerPaymentCreateRequest) UnmarshalJSON(data []byte) error {
 	r.amount = wire.Amount
 	r.date = wire.Date
 	r.invoices = wire.Invoices
+	r.accountID = wire.AccountID
+	r.referenceNumber = wire.ReferenceNumber
 	return nil
 }
 
 type customerPaymentCreateRequestWire struct {
-	CustomerID  string                        `json:"customer_id"`
-	PaymentMode string                        `json:"payment_mode"`
-	Amount      decimal.Decimal               `json:"amount"`
-	Date        string                        `json:"date"`
-	Invoices    []CustomerPaymentInvoiceApply `json:"invoices"`
+	CustomerID      string                        `json:"customer_id"`
+	PaymentMode     string                        `json:"payment_mode"`
+	Amount          decimal.Decimal               `json:"amount"`
+	Date            string                        `json:"date"`
+	Invoices        []CustomerPaymentInvoiceApply `json:"invoices"`
+	AccountID       string                        `json:"account_id,omitempty"`
+	ReferenceNumber string                        `json:"reference_number,omitempty"`
 }
 
 // CustomerPaymentResponse is the response from POST /books/v3/customerpayments.

--- a/internal/integration/zoho/invoice.go
+++ b/internal/integration/zoho/invoice.go
@@ -146,10 +146,11 @@ func (s *InvoiceService) SyncInvoiceToZoho(ctx context.Context, req ZohoInvoiceS
 	}
 
 	reqPayload.PlaceOfSupply = types.TaxMetadataFromMap(flexCustomer.Metadata).PlaceOfSupply()
-	reqPayload.CustomFields = append(
-		servicePeriodCustomFields(settings, flexInvoice.PeriodStart, flexInvoice.PeriodEnd),
-		metadataCustomFields(settings, flexInvoice.Metadata, flexCustomer.Metadata)...,
-	)
+	// Ordered least to most specific: Zoho keeps the last write to a given field.
+	reqPayload.CustomFields = append(globalCustomFields(settings),
+		servicePeriodCustomFields(settings, flexInvoice.PeriodStart, flexInvoice.PeriodEnd)...)
+	reqPayload.CustomFields = append(reqPayload.CustomFields,
+		metadataCustomFields(settings, flexInvoice.Metadata, flexCustomer.Metadata)...)
 
 	curCode, exchRate, err := s.client.ResolveInvoiceCurrency(ctx, flexInvoice.Currency)
 	if err != nil {
@@ -287,15 +288,15 @@ func (s *InvoiceService) MarkInvoicePaidInZoho(ctx context.Context, flexpriceInv
 		"zoho_balance", zohoInv.Balance.String(),
 	)
 
-	_, err = s.client.CreateCustomerPayment(ctx, NewCustomerPaymentCreateRequest(
-		zohoInv.CustomerID,
-		"others",
-		zohoInv.Balance,
-		time.Now().UTC().Format("2006-01-02"),
-		[]CustomerPaymentInvoiceApply{
+	_, err = s.client.CreateCustomerPayment(ctx, NewCustomerPaymentCreateRequest(CustomerPaymentCreateParams{
+		CustomerID:  zohoInv.CustomerID,
+		PaymentMode: types.DefaultZohoPaymentMode,
+		Amount:      zohoInv.Balance,
+		Date:        time.Now().UTC().Format("2006-01-02"),
+		Invoices: []CustomerPaymentInvoiceApply{
 			NewCustomerPaymentInvoiceApply(zohoInvoiceID, zohoInv.Balance),
 		},
-	))
+	}))
 	if err != nil {
 		return err
 	}
@@ -476,6 +477,26 @@ func servicePeriodCustomFields(settings *types.InvoiceSyncSettings, start, end *
 		NewCustomField(settings.ServicePeriodCustomFields.StartFieldID, start.Format(zohoAPIDateFormat)),
 		NewCustomField(settings.ServicePeriodCustomFields.EndFieldID, inclusiveEnd(end).Format(zohoAPIDateFormat)),
 	}
+}
+
+func globalCustomFields(settings *types.InvoiceSyncSettings) []CustomField {
+	if settings == nil || len(settings.GlobalCustomFields) == 0 {
+		return nil
+	}
+
+	out := make([]CustomField, 0, len(settings.GlobalCustomFields))
+	for _, g := range settings.GlobalCustomFields {
+		value := strings.TrimSpace(g.Value)
+		if value == "" {
+			continue
+		}
+		out = append(out, NewCustomField(g.Field, value))
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // metadataCustomFields copies configured metadata values onto Zoho custom fields. A key

--- a/internal/integration/zoho/invoice.go
+++ b/internal/integration/zoho/invoice.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flexprice/flexprice/internal/domain/customer"
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
 	"github.com/flexprice/flexprice/internal/domain/invoice"
+	"github.com/flexprice/flexprice/internal/domain/payment"
 	"github.com/flexprice/flexprice/internal/domain/price"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -36,6 +37,7 @@ type InvoiceService struct {
 	invoiceRepo  invoice.Repository
 	priceRepo    price.Repository
 	mappingRepo  entityintegrationmapping.Repository
+	paymentRepo  payment.Repository
 	logger       *logger.Logger
 }
 
@@ -48,6 +50,7 @@ func NewInvoiceService(
 	invoiceRepo invoice.Repository,
 	priceRepo price.Repository,
 	mappingRepo entityintegrationmapping.Repository,
+	paymentRepo payment.Repository,
 	logger *logger.Logger,
 ) ZohoInvoiceService {
 	return &InvoiceService{
@@ -59,6 +62,7 @@ func NewInvoiceService(
 		invoiceRepo:  invoiceRepo,
 		priceRepo:    priceRepo,
 		mappingRepo:  mappingRepo,
+		paymentRepo:  paymentRepo,
 		logger:       logger,
 	}
 }
@@ -279,6 +283,12 @@ func (s *InvoiceService) MarkInvoicePaidInZoho(ctx context.Context, flexpriceInv
 		return nil
 	}
 
+	settings, err := s.getInvoiceSyncSettings(ctx)
+	if err != nil {
+		return err
+	}
+	referenceNumber := s.settlementReferenceNumber(ctx, flexpriceInvoiceID)
+
 	// Zoho's total is tax-inclusive while Flexprice's is tax-exclusive, so log both sides of the
 	// amount being settled to explain any mismatch between the two systems' figures.
 	s.logger.Info(ctx, "recording Zoho customer payment for synced invoice",
@@ -286,16 +296,21 @@ func (s *InvoiceService) MarkInvoicePaidInZoho(ctx context.Context, flexpriceInv
 		"zoho_invoice_id", zohoInvoiceID,
 		"zoho_customer_id", zohoInv.CustomerID,
 		"zoho_balance", zohoInv.Balance.String(),
+		"payment_mode", settings.ZohoPaymentMode(),
+		"deposit_to_account_id", settings.ZohoDepositToAccountID(),
+		"reference_number", referenceNumber,
 	)
 
 	_, err = s.client.CreateCustomerPayment(ctx, NewCustomerPaymentCreateRequest(CustomerPaymentCreateParams{
 		CustomerID:  zohoInv.CustomerID,
-		PaymentMode: types.DefaultZohoPaymentMode,
+		PaymentMode: settings.ZohoPaymentMode(),
 		Amount:      zohoInv.Balance,
 		Date:        time.Now().UTC().Format("2006-01-02"),
 		Invoices: []CustomerPaymentInvoiceApply{
 			NewCustomerPaymentInvoiceApply(zohoInvoiceID, zohoInv.Balance),
 		},
+		AccountID:       settings.ZohoDepositToAccountID(),
+		ReferenceNumber: referenceNumber,
 	}))
 	if err != nil {
 		return err
@@ -420,6 +435,47 @@ func (s *InvoiceService) totalLineItemDiscount(lineItems []InvoiceLineItem) deci
 	}
 
 	return total
+}
+
+// settlementReferenceNumber returns the gateway payment id that settled the invoice, for
+// Zoho's reference_number. Empty when the invoice was settled without a gateway payment
+// (offline, credits) or when the lookup fails: this runs inside a retried Temporal activity,
+// and failing here would leave the Zoho invoice unpaid over a reconciliation-only field.
+func (s *InvoiceService) settlementReferenceNumber(ctx context.Context, flexpriceInvoiceID string) string {
+	filter := types.NewNoLimitPaymentFilter()
+	filter.QueryFilter.Status = lo.ToPtr(types.StatusPublished)
+	filter.DestinationType = lo.ToPtr(string(types.PaymentDestinationTypeInvoice))
+	filter.DestinationID = lo.ToPtr(flexpriceInvoiceID)
+
+	payments, err := s.paymentRepo.List(ctx, filter)
+	if err != nil {
+		s.logger.Info(ctx, "could not resolve gateway payment id for Zoho reference number",
+			"error", err,
+			"invoice_id", flexpriceInvoiceID)
+		return ""
+	}
+
+	// PaymentFilter carries a single status, so covering both settled states means filtering
+	// here rather than paying for a second round trip.
+	var latest *payment.Payment
+	for _, p := range payments {
+		if p == nil || p.SucceededAt == nil {
+			continue
+		}
+		if p.PaymentStatus != types.PaymentStatusSucceeded && p.PaymentStatus != types.PaymentStatusOverpaid {
+			continue
+		}
+		if p.GatewayPaymentID == nil || strings.TrimSpace(*p.GatewayPaymentID) == "" {
+			continue
+		}
+		if latest == nil || p.SucceededAt.After(*latest.SucceededAt) {
+			latest = p
+		}
+	}
+	if latest == nil {
+		return ""
+	}
+	return strings.TrimSpace(*latest.GatewayPaymentID)
 }
 
 func (s *InvoiceService) getInvoiceSyncSettings(ctx context.Context) (*types.InvoiceSyncSettings, error) {

--- a/internal/integration/zoho/invoice_approval_test.go
+++ b/internal/integration/zoho/invoice_approval_test.go
@@ -12,7 +12,11 @@ import (
 
 func syncConfigWithApproval(enabled bool) *types.SyncConfig {
 	return &types.SyncConfig{
-		InvoiceSyncSettings: &types.InvoiceSyncSettings{SubmitForApproval: enabled},
+		InvoiceSyncSettings: &types.InvoiceSyncSettings{
+			ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+				SubmitForApproval: enabled,
+			},
+		},
 	}
 }
 

--- a/internal/integration/zoho/invoice_header_test.go
+++ b/internal/integration/zoho/invoice_header_test.go
@@ -333,6 +333,26 @@ func TestMetadataCustomFields(t *testing.T) {
 	})
 }
 
+func TestGlobalCustomFields(t *testing.T) {
+	settings := &types.InvoiceSyncSettings{
+		ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+			GlobalCustomFields: []types.GlobalCustomField{
+				{Field: "cf_source", Value: "FlexPrice"},
+				{Field: "4069923000000000009", Value: "IN"},
+				{Field: "cf_blank", Value: "   "},
+			},
+		},
+	}
+
+	assert.Equal(t, []CustomField{
+		{APIName: "cf_source", Value: "FlexPrice"},
+		{CustomFieldID: "4069923000000000009", Value: "IN"},
+	}, globalCustomFields(settings))
+
+	assert.Nil(t, globalCustomFields(nil))
+	assert.Nil(t, globalCustomFields(&types.InvoiceSyncSettings{}))
+}
+
 func TestSyncInvoiceSendsMetadataCustomFieldsAlongsideServicePeriod(t *testing.T) {
 	inv := &invoice.Invoice{
 		ID:          "inv_3",

--- a/internal/integration/zoho/invoice_header_test.go
+++ b/internal/integration/zoho/invoice_header_test.go
@@ -81,9 +81,11 @@ func TestServicePeriodCustomFields(t *testing.T) {
 	start := tPtr("2026-04-01T00:00:00Z")
 	end := tPtr("2026-05-01T00:00:00Z")
 	configured := &types.InvoiceSyncSettings{
-		ServicePeriodCustomFields: &types.ServicePeriodCustomFields{
-			StartFieldID: "4069923000000000001",
-			EndFieldID:   "4069923000000000002",
+		ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+			ServicePeriodCustomFields: &types.ServicePeriodCustomFields{
+				StartFieldID: "4069923000000000001",
+				EndFieldID:   "4069923000000000002",
+			},
 		},
 	}
 
@@ -105,7 +107,9 @@ func TestServicePeriodCustomFields(t *testing.T) {
 
 	t.Run("nil when only one field ID is set", func(t *testing.T) {
 		half := &types.InvoiceSyncSettings{
-			ServicePeriodCustomFields: &types.ServicePeriodCustomFields{StartFieldID: "cf_service_period_start"},
+			ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+				ServicePeriodCustomFields: &types.ServicePeriodCustomFields{StartFieldID: "cf_service_period_start"},
+			},
 		}
 		assert.Nil(t, servicePeriodCustomFields(half, start, end),
 			"a start date with no end date would render a broken header")
@@ -171,9 +175,11 @@ func TestSyncInvoiceSendsGSTHeaderFields(t *testing.T) {
 
 	syncConfig := &types.SyncConfig{
 		InvoiceSyncSettings: &types.InvoiceSyncSettings{
-			ServicePeriodCustomFields: &types.ServicePeriodCustomFields{
-				StartFieldID: "cf_start",
-				EndFieldID:   "cf_end",
+			ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+				ServicePeriodCustomFields: &types.ServicePeriodCustomFields{
+					StartFieldID: "cf_start",
+					EndFieldID:   "cf_end",
+				},
 			},
 		},
 	}
@@ -271,9 +277,11 @@ func TestCustomFieldSerialisesOnlyOneKey(t *testing.T) {
 
 func TestServicePeriodCustomFieldsUsesAPINames(t *testing.T) {
 	settings := &types.InvoiceSyncSettings{
-		ServicePeriodCustomFields: &types.ServicePeriodCustomFields{
-			StartFieldID: "cf_service_period_start",
-			EndFieldID:   "cf_service_period_end",
+		ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+			ServicePeriodCustomFields: &types.ServicePeriodCustomFields{
+				StartFieldID: "cf_service_period_start",
+				EndFieldID:   "cf_service_period_end",
+			},
 		},
 	}
 	got := servicePeriodCustomFields(settings, tPtr("2026-04-01T00:00:00Z"), tPtr("2026-05-01T00:00:00Z"))
@@ -287,10 +295,12 @@ func TestServicePeriodCustomFieldsUsesAPINames(t *testing.T) {
 
 func TestMetadataCustomFields(t *testing.T) {
 	settings := &types.InvoiceSyncSettings{
-		MetadataCustomFields: []types.MetadataCustomField{
-			{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "hubspot_company_id", Field: "cf_hubspot_id"},
-			{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "brand_name", Field: "4069923000000000009"},
-			{Source: types.MetadataCustomFieldSourceInvoice, MetadataKey: "po_number", Field: "cf_po"},
+		ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+			MetadataCustomFields: []types.MetadataCustomField{
+				{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "hubspot_company_id", Field: "cf_hubspot_id"},
+				{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "brand_name", Field: "4069923000000000009"},
+				{Source: types.MetadataCustomFieldSourceInvoice, MetadataKey: "po_number", Field: "cf_po"},
+			},
 		},
 	}
 	customerMeta := map[string]string{"hubspot_company_id": "164213581519", "brand_name": "Mankind Pharma"}
@@ -336,15 +346,17 @@ func TestSyncInvoiceSendsMetadataCustomFieldsAlongsideServicePeriod(t *testing.T
 
 	client := &fakeSyncZohoClient{syncConfig: &types.SyncConfig{
 		InvoiceSyncSettings: &types.InvoiceSyncSettings{
-			ServicePeriodCustomFields: &types.ServicePeriodCustomFields{
-				StartFieldID: "cf_start",
-				EndFieldID:   "cf_end",
-			},
-			MetadataCustomFields: []types.MetadataCustomField{
-				{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "hubspot_company_id", Field: "cf_hubspot_id"},
-				{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "brand_name", Field: "cf_brand_name"},
-				{Source: types.MetadataCustomFieldSourceInvoice, MetadataKey: "po_number", Field: "cf_po"},
-				{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "absent", Field: "cf_absent"},
+			ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+				ServicePeriodCustomFields: &types.ServicePeriodCustomFields{
+					StartFieldID: "cf_start",
+					EndFieldID:   "cf_end",
+				},
+				MetadataCustomFields: []types.MetadataCustomField{
+					{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "hubspot_company_id", Field: "cf_hubspot_id"},
+					{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "brand_name", Field: "cf_brand_name"},
+					{Source: types.MetadataCustomFieldSourceInvoice, MetadataKey: "po_number", Field: "cf_po"},
+					{Source: types.MetadataCustomFieldSourceCustomer, MetadataKey: "absent", Field: "cf_absent"},
+				},
 			},
 		},
 	}}

--- a/internal/integration/zoho/invoice_mark_paid_test.go
+++ b/internal/integration/zoho/invoice_mark_paid_test.go
@@ -2,11 +2,17 @@ package zoho
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	"github.com/flexprice/flexprice/internal/domain/payment"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
+	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +33,20 @@ func (f *fakeMappingRepo) List(_ context.Context, filter *types.EntityIntegratio
 		out = append(out, m)
 	}
 	return out, nil
+}
+
+// fakePaymentRepo is a minimal in-memory payment.Repository for these tests.
+type fakePaymentRepo struct {
+	payment.Repository
+	payments []*payment.Payment
+	err      error
+}
+
+func (f *fakePaymentRepo) List(_ context.Context, _ *types.PaymentFilter) ([]*payment.Payment, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.payments, nil
 }
 
 // fakeZohoClient is a minimal ZohoClient for these tests. Only GetInvoice,
@@ -90,9 +110,14 @@ func (f *fakeZohoClient) CreateCustomerPayment(_ context.Context, req *CustomerP
 }
 
 func newTestInvoiceService(client ZohoClient, mappingRepo entityintegrationmapping.Repository) *InvoiceService {
+	return newTestInvoiceServiceWithPayments(client, mappingRepo, &fakePaymentRepo{})
+}
+
+func newTestInvoiceServiceWithPayments(client ZohoClient, mappingRepo entityintegrationmapping.Repository, paymentRepo payment.Repository) *InvoiceService {
 	return &InvoiceService{
 		client:      client,
 		mappingRepo: mappingRepo,
+		paymentRepo: paymentRepo,
 		logger:      logger.NewNoopLogger(),
 	}
 }
@@ -152,9 +177,109 @@ func TestMarkInvoicePaidInZoho_PositiveBalance_RecordsFullBalance(t *testing.T) 
 	assert.Equal(t, "zoho_cust_1", req.CustomerID())
 	assert.True(t, decimal.NewFromInt(160).Equal(req.Amount()))
 	assert.Equal(t, "others", req.PaymentMode())
+	assert.Empty(t, req.AccountID(), "unset config must leave Zoho on Undeposited Funds")
+	assert.Empty(t, req.ReferenceNumber())
 	require.Len(t, req.Invoices(), 1)
 	assert.Equal(t, "zoho_inv_1", req.Invoices()[0].InvoiceID())
 	assert.True(t, decimal.NewFromInt(160).Equal(req.Invoices()[0].AmountApplied()))
+}
+
+func markPaidFixtures() (*fakeZohoClient, *fakeMappingRepo) {
+	return &fakeZohoClient{
+			getInvoiceResp: &InvoiceResponse{
+				InvoiceID:  "zoho_inv_1",
+				CustomerID: "zoho_cust_1",
+				Balance:    decimal.NewFromInt(160),
+			},
+		}, &fakeMappingRepo{
+			mappings: []*entityintegrationmapping.EntityIntegrationMapping{
+				{EntityID: "inv_1", ProviderEntityID: "zoho_inv_1"},
+			},
+		}
+}
+
+func succeededPayment(id, gatewayID string, succeededAt time.Time) *payment.Payment {
+	return &payment.Payment{
+		ID:               id,
+		PaymentStatus:    types.PaymentStatusSucceeded,
+		GatewayPaymentID: lo.ToPtr(gatewayID),
+		SucceededAt:      lo.ToPtr(succeededAt),
+	}
+}
+
+func TestMarkInvoicePaidInZoho_SendsConfiguredPaymentModeAndDepositAccount(t *testing.T) {
+	client, mappingRepo := markPaidFixtures()
+	client.syncConfig = &types.SyncConfig{
+		InvoiceSyncSettings: &types.InvoiceSyncSettings{
+			ZohoInvoiceSyncSettings: types.ZohoInvoiceSyncSettings{
+				PaymentMode:        "UPI",
+				DepositToAccountID: "460000000000099",
+			},
+		},
+	}
+	svc := newTestInvoiceService(client, mappingRepo)
+
+	require.NoError(t, svc.MarkInvoicePaidInZoho(context.Background(), "inv_1"))
+
+	require.Equal(t, 1, client.createPaymentCalls)
+	assert.Equal(t, "UPI", client.createPaymentReq.PaymentMode())
+	assert.Equal(t, "460000000000099", client.createPaymentReq.AccountID())
+}
+
+func TestMarkInvoicePaidInZoho_ReferenceNumber(t *testing.T) {
+	base := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		payments []*payment.Payment
+		err      error
+		want     string
+	}{
+		{
+			name:     "latest settled gateway payment wins",
+			payments: []*payment.Payment{succeededPayment("pay_1", "pay_older", base), succeededPayment("pay_2", "pay_newer", base.Add(time.Hour))},
+			want:     "pay_newer",
+		},
+		{
+			name: "newer payment without a gateway id does not mask an older one",
+			payments: []*payment.Payment{
+				succeededPayment("pay_1", "pay_card", base),
+				{ID: "pay_2", PaymentStatus: types.PaymentStatusSucceeded, SucceededAt: lo.ToPtr(base.Add(time.Hour))},
+			},
+			want: "pay_card",
+		},
+		{
+			name: "unsettled payments are ignored",
+			payments: []*payment.Payment{
+				{ID: "pay_1", PaymentStatus: types.PaymentStatusFailed, GatewayPaymentID: lo.ToPtr("pay_failed"), SucceededAt: lo.ToPtr(base)},
+				{ID: "pay_2", PaymentStatus: types.PaymentStatusPending, GatewayPaymentID: lo.ToPtr("pay_pending")},
+			},
+			want: "",
+		},
+		{
+			name:     "no payments at all",
+			payments: nil,
+			want:     "",
+		},
+		{
+			name: "lookup failure still records the payment",
+			err:  errors.New("db down"),
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, mappingRepo := markPaidFixtures()
+			svc := newTestInvoiceServiceWithPayments(client, mappingRepo,
+				&fakePaymentRepo{payments: tc.payments, err: tc.err})
+
+			require.NoError(t, svc.MarkInvoicePaidInZoho(context.Background(), "inv_1"))
+
+			require.Equal(t, 1, client.createPaymentCalls, "reference lookup must never block mark-paid")
+			assert.Equal(t, tc.want, client.createPaymentReq.ReferenceNumber())
+		})
+	}
 }
 
 func TestMarkInvoicePaidInZoho_CreatePaymentError_Propagates(t *testing.T) {
@@ -258,4 +383,26 @@ func TestMarkInvoicePaidInZoho_ApprovalEnabled_SentIsPaid(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, client.createPaymentCalls)
 	assert.Equal(t, 0, client.submitCalls)
+}
+
+// account_id and reference_number must vanish from the payload when unset: Zoho reads a
+// present-but-empty account_id as an invalid account rather than as "use the default".
+func TestCustomerPaymentCreateRequestOmitsUnsetOptionalFields(t *testing.T) {
+	body, err := json.Marshal(NewCustomerPaymentCreateRequest(CustomerPaymentCreateParams{
+		CustomerID:  "zoho_cust_1",
+		PaymentMode: types.DefaultZohoPaymentMode,
+		Amount:      decimal.NewFromInt(160),
+		Date:        "2026-09-07",
+		Invoices:    []CustomerPaymentInvoiceApply{NewCustomerPaymentInvoiceApply("zoho_inv_1", decimal.NewFromInt(160))},
+	}))
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "account_id")
+	assert.NotContains(t, string(body), "reference_number")
+}
+
+func TestCustomerPaymentCreateRequestTruncatesReferenceNumber(t *testing.T) {
+	req := NewCustomerPaymentCreateRequest(CustomerPaymentCreateParams{
+		ReferenceNumber: " " + strings.Repeat("x", 120) + " ",
+	})
+	assert.Len(t, req.ReferenceNumber(), 100)
 }

--- a/internal/integration/zoho/invoice_sync_test.go
+++ b/internal/integration/zoho/invoice_sync_test.go
@@ -465,6 +465,7 @@ func TestSyncInvoiceToZoho_MarksPaidWhenFlexpriceAlreadyPaid(t *testing.T) {
 				customerRepo: &fakeSyncCustomerRepo{},
 				invoiceRepo:  &fakeSyncInvoiceRepo{inv: inv},
 				mappingRepo:  mappingRepo,
+				paymentRepo:  &fakePaymentRepo{},
 				logger:       logger.NewNoopLogger(),
 			}
 

--- a/internal/types/sync_config.go
+++ b/internal/types/sync_config.go
@@ -254,10 +254,6 @@ func (s *InvoiceSyncSettings) ValidateCustomFields() error {
 	}
 
 	seen := make(map[string]struct{}, len(s.MetadataCustomFields)+len(s.GlobalCustomFields)+2)
-	if s.ServicePeriodCustomFields.IsConfigured() {
-		seen[s.ServicePeriodCustomFields.StartFieldID] = struct{}{}
-		seen[s.ServicePeriodCustomFields.EndFieldID] = struct{}{}
-	}
 
 	claim := func(field string) error {
 		field = strings.TrimSpace(field)
@@ -268,6 +264,17 @@ func (s *InvoiceSyncSettings) ValidateCustomFields() error {
 		}
 		seen[field] = struct{}{}
 		return nil
+	}
+
+	// Claimed the same way as the other families so a whitespace variant cannot slip past
+	// the duplicate check and silently overwrite the field it collides with.
+	if s.ServicePeriodCustomFields.IsConfigured() {
+		if err := claim(s.ServicePeriodCustomFields.StartFieldID); err != nil {
+			return err
+		}
+		if err := claim(s.ServicePeriodCustomFields.EndFieldID); err != nil {
+			return err
+		}
 	}
 
 	for _, g := range s.GlobalCustomFields {

--- a/internal/types/sync_config.go
+++ b/internal/types/sync_config.go
@@ -78,6 +78,10 @@ type ZohoInvoiceSyncSettings struct {
 	// Copies metadata values onto Zoho invoice custom fields verbatim.
 	MetadataCustomFields []MetadataCustomField `json:"metadata_custom_fields,omitempty"`
 
+	// Fixed values written to Zoho invoice custom fields on every sync, independent of
+	// any metadata source.
+	GlobalCustomFields []GlobalCustomField `json:"global_custom_fields,omitempty"`
+
 	// Zoho rejects payments on draft invoices, and merchants configure a Zoho auto-approval
 	// rule for FlexPrice-sent invoices, so we submit, wait for that rule to fire, then pay.
 	SubmitForApproval bool `json:"submit_for_approval,omitempty"`
@@ -211,37 +215,77 @@ func (m MetadataCustomField) Validate() error {
 	return nil
 }
 
-// Two mappings may not write to the same Zoho field, and neither may claim a field the
-// service period already uses.
-func (s *InvoiceSyncSettings) ValidateMetadataCustomFields() error {
-	if s == nil || len(s.MetadataCustomFields) == 0 {
+type GlobalCustomField struct {
+	Field string `json:"field"`
+	Value string `json:"value"`
+}
+
+func (g GlobalCustomField) Validate() error {
+	field := strings.TrimSpace(g.Field)
+	if field == "" {
+		return ierr.NewError("global custom field target is required").
+			WithHint("Provide the Zoho custom field API name or ID to write to").
+			Mark(ierr.ErrValidation)
+	}
+	if len(field) > maxCustomFieldRefLen {
+		return ierr.NewError("global custom field target is too long").
+			WithHint(fmt.Sprintf("field must be at most %d characters", maxCustomFieldRefLen)).
+			Mark(ierr.ErrValidation)
+	}
+	if strings.TrimSpace(g.Value) == "" {
+		return ierr.NewError("global custom field value is required").
+			WithHint("Provide the value to write, or drop the mapping").
+			Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+
+// All three custom field families write into one Zoho field namespace, where a second write
+// silently overwrites the first, so they are validated together against a shared field set.
+func (s *InvoiceSyncSettings) ValidateCustomFields() error {
+	if s == nil {
 		return nil
 	}
 
-	if len(s.MetadataCustomFields) > MaxMetadataCustomFields {
-		return ierr.NewError("too many metadata custom field mappings").
-			WithHint(fmt.Sprintf("At most %d metadata custom fields may be mapped", MaxMetadataCustomFields)).
+	if len(s.MetadataCustomFields)+len(s.GlobalCustomFields) > MaxMetadataCustomFields {
+		return ierr.NewError("too many custom field mappings").
+			WithHint(fmt.Sprintf("At most %d custom fields may be mapped", MaxMetadataCustomFields)).
 			Mark(ierr.ErrValidation)
 	}
 
-	seen := make(map[string]struct{}, len(s.MetadataCustomFields)+2)
+	seen := make(map[string]struct{}, len(s.MetadataCustomFields)+len(s.GlobalCustomFields)+2)
 	if s.ServicePeriodCustomFields.IsConfigured() {
 		seen[s.ServicePeriodCustomFields.StartFieldID] = struct{}{}
 		seen[s.ServicePeriodCustomFields.EndFieldID] = struct{}{}
 	}
 
-	for _, m := range s.MetadataCustomFields {
-		if err := m.Validate(); err != nil {
-			return err
-		}
-
-		field := strings.TrimSpace(m.Field)
+	claim := func(field string) error {
+		field = strings.TrimSpace(field)
 		if _, dup := seen[field]; dup {
 			return ierr.NewError("duplicate zoho custom field mapping").
 				WithHint(fmt.Sprintf("Zoho custom field %q is mapped more than once", field)).
 				Mark(ierr.ErrValidation)
 		}
 		seen[field] = struct{}{}
+		return nil
+	}
+
+	for _, g := range s.GlobalCustomFields {
+		if err := g.Validate(); err != nil {
+			return err
+		}
+		if err := claim(g.Field); err != nil {
+			return err
+		}
+	}
+
+	for _, m := range s.MetadataCustomFields {
+		if err := m.Validate(); err != nil {
+			return err
+		}
+		if err := claim(m.Field); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -373,7 +417,7 @@ func (s *SyncConfig) Validate() error {
 		if err := s.InvoiceSyncSettings.ServicePeriodCustomFields.Validate(); err != nil {
 			return err
 		}
-		if err := s.InvoiceSyncSettings.ValidateMetadataCustomFields(); err != nil {
+		if err := s.InvoiceSyncSettings.ValidateCustomFields(); err != nil {
 			return err
 		}
 		if err := s.InvoiceSyncSettings.ValidateZohoPaymentSettings(); err != nil {

--- a/internal/types/sync_config.go
+++ b/internal/types/sync_config.go
@@ -57,32 +57,96 @@ type EntitySyncConfig struct {
 	Outbound bool `json:"outbound"` // Outbound from FlexPrice to external provider
 }
 
-// InvoiceSyncSettings controls how invoice line items are transformed during outbound sync.
+// InvoiceSyncSettings controls how invoices are transformed during outbound sync.
 type InvoiceSyncSettings struct {
 	// NormalizeFixedTo re-expresses fixed-charge line items in a smaller billing period.
 	// For example, a quarterly fixed charge of $300 with NormalizeFixedTo=MONTHLY becomes
 	// qty=3, rate=$100. Empty string means no normalization (keep original).
 	NormalizeFixedTo BillingPeriod `json:"normalize_fixed_to,omitempty"`
 
-	// ServicePeriodCustomFields names the Zoho custom fields that receive the
-	// invoice's service start and end dates.
+	// Embedded rather than nested so the provider-specific settings stay inline in the
+	// same JSON object they have always been stored in.
+	ZohoInvoiceSyncSettings
+}
+
+// ZohoInvoiceSyncSettings holds the outbound invoice settings that map onto Zoho Books API
+// concepts rather than to anything generic.
+type ZohoInvoiceSyncSettings struct {
+	// Zoho custom fields that receive the invoice's service start and end dates.
 	ServicePeriodCustomFields *ServicePeriodCustomFields `json:"service_period_custom_fields,omitempty"`
 
-	// MetadataCustomFields copies metadata values onto Zoho invoice custom fields
-	// verbatim.
+	// Copies metadata values onto Zoho invoice custom fields verbatim.
 	MetadataCustomFields []MetadataCustomField `json:"metadata_custom_fields,omitempty"`
 
-	// SubmitForApproval submits the synced invoice into the merchant's Zoho Books approval
-	// flow before recording payment. Zoho rejects payments on draft invoices, and merchants
-	// configure a Zoho auto-approval rule for FlexPrice-sent invoices, so we submit, wait for
-	// that rule to fire, then pay.
+	// Zoho rejects payments on draft invoices, and merchants configure a Zoho auto-approval
+	// rule for FlexPrice-sent invoices, so we submit, wait for that rule to fire, then pay.
 	SubmitForApproval bool `json:"submit_for_approval,omitempty"`
+
+	// Zoho payment modes are merchant-editable free strings with no id, so this is passed
+	// through verbatim. Empty means DefaultZohoPaymentMode.
+	PaymentMode string `json:"payment_mode,omitempty"`
+
+	// Zoho chart-of-accounts id ("Deposit To"). Empty omits account_id, leaving Zoho's
+	// Undeposited Funds default.a
+	DepositToAccountID string `json:"deposit_to_account_id,omitempty"`
 }
 
 // IsSubmitForApprovalEnabled reports whether synced invoices should be submitted into the
 // merchant's Zoho Books approval flow before payment is recorded against them.
 func (s *InvoiceSyncSettings) IsSubmitForApprovalEnabled() bool {
 	return s != nil && s.SubmitForApproval
+}
+
+func (s *InvoiceSyncSettings) ZohoPaymentMode() string {
+	if s == nil {
+		return DefaultZohoPaymentMode
+	}
+	if mode := strings.TrimSpace(s.PaymentMode); mode != "" {
+		return mode
+	}
+	return DefaultZohoPaymentMode
+}
+
+func (s *InvoiceSyncSettings) ZohoDepositToAccountID() string {
+	if s == nil {
+		return ""
+	}
+	return strings.TrimSpace(s.DepositToAccountID)
+}
+
+// The payment mode is deliberately not checked against Zoho's built-in list: merchants edit
+// that list and add their own modes.
+func (s *InvoiceSyncSettings) ValidateZohoPaymentSettings() error {
+	if s == nil {
+		return nil
+	}
+
+	if mode := strings.TrimSpace(s.PaymentMode); len(mode) > maxZohoPaymentModeLen {
+		return ierr.NewError("zoho payment mode is too long").
+			WithHint(fmt.Sprintf("payment_mode must be at most %d characters", maxZohoPaymentModeLen)).
+			Mark(ierr.ErrValidation)
+	}
+
+	// Zoho entity ids are numeric, so rejecting anything else catches the likely
+	// misconfiguration - pasting the account name - at save time instead of during mark-paid.
+	accountID := strings.TrimSpace(s.DepositToAccountID)
+	if accountID == "" {
+		return nil
+	}
+	if len(accountID) > maxZohoAccountIDLen {
+		return ierr.NewError("zoho deposit to account id is too long").
+			WithHint(fmt.Sprintf("deposit_to_account_id must be at most %d characters", maxZohoAccountIDLen)).
+			Mark(ierr.ErrValidation)
+	}
+	for _, r := range accountID {
+		if r < '0' || r > '9' {
+			return ierr.NewError("invalid zoho deposit to account id").
+				WithHint("deposit_to_account_id must be the numeric Zoho chart-of-accounts id, not the account name").
+				Mark(ierr.ErrValidation)
+		}
+	}
+
+	return nil
 }
 
 type MetadataCustomFieldSource string
@@ -92,6 +156,11 @@ const (
 	// custom fields per module than this.
 	MaxMetadataCustomFields = 50
 	maxCustomFieldRefLen    = 255
+
+	// Zoho's built-in catch-all payment mode.
+	DefaultZohoPaymentMode = "others"
+	maxZohoPaymentModeLen  = 100
+	maxZohoAccountIDLen    = 30
 )
 
 const (
@@ -305,6 +374,9 @@ func (s *SyncConfig) Validate() error {
 			return err
 		}
 		if err := s.InvoiceSyncSettings.ValidateMetadataCustomFields(); err != nil {
+			return err
+		}
+		if err := s.InvoiceSyncSettings.ValidateZohoPaymentSettings(); err != nil {
 			return err
 		}
 	}

--- a/internal/types/sync_config_test.go
+++ b/internal/types/sync_config_test.go
@@ -38,7 +38,7 @@ func TestMetadataCustomFieldValidate(t *testing.T) {
 	}
 }
 
-func TestValidateMetadataCustomFields(t *testing.T) {
+func TestValidateCustomFields(t *testing.T) {
 	servicePeriod := &ServicePeriodCustomFields{StartFieldID: "cf_start", EndFieldID: "cf_end"}
 
 	t.Run("distinct fields", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 				},
 			},
 		}
-		assert.NoError(t, s.ValidateMetadataCustomFields())
+		assert.NoError(t, s.ValidateCustomFields())
 	})
 
 	t.Run("duplicate target field", func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 				},
 			},
 		}
-		assert.Error(t, s.ValidateMetadataCustomFields())
+		assert.Error(t, s.ValidateCustomFields())
 	})
 
 	t.Run("collides with service period field", func(t *testing.T) {
@@ -75,7 +75,7 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 				},
 			},
 		}
-		assert.Error(t, s.ValidateMetadataCustomFields())
+		assert.Error(t, s.ValidateCustomFields())
 	})
 
 	t.Run("too many mappings", func(t *testing.T) {
@@ -91,18 +91,62 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
 				MetadataCustomFields: many,
 			},
-		}).ValidateMetadataCustomFields())
+		}).ValidateCustomFields())
 		assert.NoError(t, (&InvoiceSyncSettings{
 			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
 				MetadataCustomFields: many[:MaxMetadataCustomFields],
 			},
-		}).ValidateMetadataCustomFields())
+		}).ValidateCustomFields())
 	})
 
 	t.Run("nil and empty", func(t *testing.T) {
 		var s *InvoiceSyncSettings
-		assert.NoError(t, s.ValidateMetadataCustomFields())
-		assert.NoError(t, (&InvoiceSyncSettings{}).ValidateMetadataCustomFields())
+		assert.NoError(t, s.ValidateCustomFields())
+		assert.NoError(t, (&InvoiceSyncSettings{}).ValidateCustomFields())
+	})
+
+	t.Run("global collides with metadata and service period", func(t *testing.T) {
+		withGlobal := func(field string) *InvoiceSyncSettings {
+			return &InvoiceSyncSettings{
+				ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+					ServicePeriodCustomFields: servicePeriod,
+					GlobalCustomFields:        []GlobalCustomField{{Field: field, Value: "flexprice"}},
+					MetadataCustomFields: []MetadataCustomField{
+						{MetadataCustomFieldSourceInvoice, "brand", "cf_brand"},
+					},
+				},
+			}
+		}
+		assert.NoError(t, withGlobal("cf_source").ValidateCustomFields())
+		assert.Error(t, withGlobal("cf_brand").ValidateCustomFields())
+		assert.Error(t, withGlobal("cf_end").ValidateCustomFields())
+	})
+
+	t.Run("global requires field and value", func(t *testing.T) {
+		withGlobal := func(g GlobalCustomField) *InvoiceSyncSettings {
+			return &InvoiceSyncSettings{
+				ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{GlobalCustomFields: []GlobalCustomField{g}},
+			}
+		}
+		assert.Error(t, withGlobal(GlobalCustomField{Field: "  ", Value: "v"}).ValidateCustomFields())
+		assert.Error(t, withGlobal(GlobalCustomField{Field: "cf_a", Value: "  "}).ValidateCustomFields())
+		assert.NoError(t, withGlobal(GlobalCustomField{Field: "cf_a", Value: "v"}).ValidateCustomFields())
+	})
+
+	t.Run("cap spans both families", func(t *testing.T) {
+		globals := make([]GlobalCustomField, 0, MaxMetadataCustomFields)
+		for i := 0; i < MaxMetadataCustomFields; i++ {
+			globals = append(globals, GlobalCustomField{Field: fmt.Sprintf("cf_g_%d", i), Value: "v"})
+		}
+		s := &InvoiceSyncSettings{
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				GlobalCustomFields: globals,
+				MetadataCustomFields: []MetadataCustomField{
+					{MetadataCustomFieldSourceInvoice, "brand", "cf_brand"},
+				},
+			},
+		}
+		assert.Error(t, s.ValidateCustomFields())
 	})
 }
 

--- a/internal/types/sync_config_test.go
+++ b/internal/types/sync_config_test.go
@@ -122,6 +122,27 @@ func TestValidateCustomFields(t *testing.T) {
 		assert.Error(t, withGlobal("cf_end").ValidateCustomFields())
 	})
 
+	t.Run("whitespace variant still collides with service period", func(t *testing.T) {
+		s := &InvoiceSyncSettings{
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				ServicePeriodCustomFields: &ServicePeriodCustomFields{StartFieldID: " cf_start ", EndFieldID: "cf_end"},
+				MetadataCustomFields: []MetadataCustomField{
+					{MetadataCustomFieldSourceInvoice, "k", "cf_start"},
+				},
+			},
+		}
+		assert.Error(t, s.ValidateCustomFields())
+	})
+
+	t.Run("service period start and end must differ", func(t *testing.T) {
+		s := &InvoiceSyncSettings{
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				ServicePeriodCustomFields: &ServicePeriodCustomFields{StartFieldID: "cf_same", EndFieldID: "cf_same"},
+			},
+		}
+		assert.Error(t, s.ValidateCustomFields())
+	})
+
 	t.Run("global requires field and value", func(t *testing.T) {
 		withGlobal := func(g GlobalCustomField) *InvoiceSyncSettings {
 			return &InvoiceSyncSettings{

--- a/internal/types/sync_config_test.go
+++ b/internal/types/sync_config_test.go
@@ -43,10 +43,12 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 
 	t.Run("distinct fields", func(t *testing.T) {
 		s := &InvoiceSyncSettings{
-			ServicePeriodCustomFields: servicePeriod,
-			MetadataCustomFields: []MetadataCustomField{
-				{MetadataCustomFieldSourceCustomer, "hubspot_company_id", "cf_hubspot_id"},
-				{MetadataCustomFieldSourceCustomer, "brand_name", "cf_brand_name"},
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				ServicePeriodCustomFields: servicePeriod,
+				MetadataCustomFields: []MetadataCustomField{
+					{MetadataCustomFieldSourceCustomer, "hubspot_company_id", "cf_hubspot_id"},
+					{MetadataCustomFieldSourceCustomer, "brand_name", "cf_brand_name"},
+				},
 			},
 		}
 		assert.NoError(t, s.ValidateMetadataCustomFields())
@@ -54,9 +56,11 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 
 	t.Run("duplicate target field", func(t *testing.T) {
 		s := &InvoiceSyncSettings{
-			MetadataCustomFields: []MetadataCustomField{
-				{MetadataCustomFieldSourceCustomer, "brand_name", "cf_brand"},
-				{MetadataCustomFieldSourceInvoice, "brand", "cf_brand"},
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				MetadataCustomFields: []MetadataCustomField{
+					{MetadataCustomFieldSourceCustomer, "brand_name", "cf_brand"},
+					{MetadataCustomFieldSourceInvoice, "brand", "cf_brand"},
+				},
 			},
 		}
 		assert.Error(t, s.ValidateMetadataCustomFields())
@@ -64,9 +68,11 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 
 	t.Run("collides with service period field", func(t *testing.T) {
 		s := &InvoiceSyncSettings{
-			ServicePeriodCustomFields: servicePeriod,
-			MetadataCustomFields: []MetadataCustomField{
-				{MetadataCustomFieldSourceCustomer, "brand_name", "cf_end"},
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				ServicePeriodCustomFields: servicePeriod,
+				MetadataCustomFields: []MetadataCustomField{
+					{MetadataCustomFieldSourceCustomer, "brand_name", "cf_end"},
+				},
 			},
 		}
 		assert.Error(t, s.ValidateMetadataCustomFields())
@@ -81,8 +87,16 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 				fmt.Sprintf("cf_%d", i),
 			})
 		}
-		assert.Error(t, (&InvoiceSyncSettings{MetadataCustomFields: many}).ValidateMetadataCustomFields())
-		assert.NoError(t, (&InvoiceSyncSettings{MetadataCustomFields: many[:MaxMetadataCustomFields]}).ValidateMetadataCustomFields())
+		assert.Error(t, (&InvoiceSyncSettings{
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				MetadataCustomFields: many,
+			},
+		}).ValidateMetadataCustomFields())
+		assert.NoError(t, (&InvoiceSyncSettings{
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				MetadataCustomFields: many[:MaxMetadataCustomFields],
+			},
+		}).ValidateMetadataCustomFields())
 	})
 
 	t.Run("nil and empty", func(t *testing.T) {
@@ -95,8 +109,10 @@ func TestValidateMetadataCustomFields(t *testing.T) {
 func TestSyncConfigValidateRejectsBadMetadataCustomFields(t *testing.T) {
 	cfg := &SyncConfig{
 		InvoiceSyncSettings: &InvoiceSyncSettings{
-			MetadataCustomFields: []MetadataCustomField{
-				{MetadataCustomFieldSourceCustomer, "brand_name", ""},
+			ZohoInvoiceSyncSettings: ZohoInvoiceSyncSettings{
+				MetadataCustomFields: []MetadataCustomField{
+					{MetadataCustomFieldSourceCustomer, "brand_name", ""},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Stripe price synchronization now reuses parent products for override prices, reducing duplicate product mappings.
  - Zoho Books invoice settings now support payment mode, deposit account, payment references, and global custom fields.
  - Zoho payment references are cleaned up and limited to 100 characters.

- **Bug Fixes**
  - Improved handling of missing or expired parent prices and concurrent price mappings.
  - Zoho custom fields now follow consistent ordering and validation, including duplicate detection across field groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->