### PR TITLE
fix(export): resolve scheduled export destination from job_config

### DIFF
--- a/internal/ee/service/sync/export/base.go
+++ b/internal/ee/service/sync/export/base.go
@@ -182,7 +182,14 @@ func (s *ExportService) uploadToStorage(ctx context.Context, request *dto.Export
 			Mark(ierr.ErrValidation)
 	}
 
-	store, err := s.storageResolver.ForConnection(ctx, request.ConnectionID)
+	store, err := s.storageResolver.ForConnectionExport(
+		ctx,
+		request.ConnectionID,
+		request.JobConfig.Bucket,
+		request.JobConfig.Region,
+		string(request.JobConfig.Encryption),
+		request.JobConfig.Compression == types.S3CompressionTypeGzip,
+	)
 	if err != nil {
 		return nil, ierr.WithError(err).
 			WithHint("Failed to get storage provider from factory").

--- a/internal/ee/service/task_test.go
+++ b/internal/ee/service/task_test.go
@@ -527,6 +527,9 @@ func (r *fakeImportResolver) ForPlatform(_ context.Context, purpose storage.Purp
 func (r *fakeImportResolver) ForConnection(context.Context, string) (storagetypes.Storage, error) {
 	return nil, nil
 }
+func (r *fakeImportResolver) ForConnectionExport(context.Context, string, string, string, string, bool) (storagetypes.Storage, error) {
+	return nil, nil
+}
 func (r *fakeImportResolver) Provider() storage.Provider { return storage.ProviderS3 }
 func (r *fakeImportResolver) BucketConfigFor(purpose storage.Purpose) (config.BucketConfig, error) {
 	if purpose != storage.PurposeImport {

--- a/internal/integration/factory.go
+++ b/internal/integration/factory.go
@@ -1363,6 +1363,41 @@ func (f *Factory) GetStorageProvider(ctx context.Context, connectionID string) (
 	return f.GetStorageProviderForConnection(ctx, conn)
 }
 
+// exportDestination carries the per-run destination from a scheduled task's
+// job_config. When set, it overrides the connection row's sync_config for
+// bucket/region/encryption — the connection then contributes only credentials
+// and the is_flexprice_managed flag. nil means resolve everything from the
+// connection (the ValidateConnection path).
+type exportDestination struct {
+	bucket     string
+	region     string
+	encryption string
+	gzip       bool
+}
+
+// GetStorageProviderExport builds storage for a scheduled export: credentials
+// and the managed flag from the connection, destination from the run's job_config.
+func (f *Factory) GetStorageProviderExport(ctx context.Context, connectionID, bucket, region, encryption string, gzip bool) (storage.Storage, error) {
+	if connectionID == "" {
+		return nil, ierr.NewError("connection ID is required for storage").Mark(ierr.ErrValidation)
+	}
+	conn, err := f.connectionRepo.Get(ctx, connectionID)
+	if err != nil {
+		return nil, err
+	}
+	dst := &exportDestination{bucket: bucket, region: region, encryption: encryption, gzip: gzip}
+	switch conn.ProviderType {
+	case types.SecretProviderS3:
+		return f.buildS3Storage(ctx, conn, dst)
+	case types.SecretProviderGCS:
+		return f.buildGCSStorage(ctx, conn, dst)
+	default:
+		return nil, ierr.NewErrorf("unsupported storage provider type: %s", conn.ProviderType).
+			WithHint("Supported storage provider types: s3, gcs").
+			Mark(ierr.ErrValidation)
+	}
+}
+
 // Validates config before persisting.
 func (f *Factory) GetStorageProviderForConnection(ctx context.Context, conn *connection.Connection) (storage.Storage, error) {
 	if conn == nil {
@@ -1372,9 +1407,9 @@ func (f *Factory) GetStorageProviderForConnection(ctx context.Context, conn *con
 
 	switch conn.ProviderType {
 	case types.SecretProviderS3:
-		return f.buildS3Storage(ctx, conn)
+		return f.buildS3Storage(ctx, conn, nil)
 	case types.SecretProviderGCS:
-		return f.buildGCSStorage(ctx, conn)
+		return f.buildGCSStorage(ctx, conn, nil)
 	default:
 		return nil, ierr.NewErrorf("unsupported storage provider type: %s", conn.ProviderType).
 			WithHint("Supported storage provider types: s3, gcs").
@@ -1382,7 +1417,7 @@ func (f *Factory) GetStorageProviderForConnection(ctx context.Context, conn *con
 	}
 }
 
-func (f *Factory) buildS3Storage(ctx context.Context, conn *connection.Connection) (storage.Storage, error) {
+func (f *Factory) buildS3Storage(ctx context.Context, conn *connection.Connection, dst *exportDestination) (storage.Storage, error) {
 	jobConfig := conn.GetSyncConfig().Storage
 	if jobConfig == nil {
 		return nil, ierr.NewError("no storage job configuration on connection").Mark(ierr.ErrValidation)
@@ -1452,18 +1487,35 @@ func (f *Factory) buildS3Storage(ctx context.Context, conn *connection.Connectio
 		}
 	}
 
+	// Destination comes from the run's job_config (dst) when this is an export;
+	// the ValidateConnection path passes nil and falls back to the connection row.
+	// A BYOB connection runs many scheduled tasks with different region/prefix, so
+	// the per-run job_config is authoritative — the connection carries only keys.
+	bucket, region := jobConfig.Bucket, jobConfig.Region
+	encryption := string(jobConfig.Encryption)
+	gzip := jobConfig.Compression == types.S3CompressionTypeGzip
+	if dst != nil {
+		bucket, region, encryption, gzip = dst.bucket, dst.region, dst.encryption, dst.gzip
+	}
+
+	if bucket == "" || region == "" {
+		return nil, ierr.NewError("S3 export is missing bucket or region").
+			WithHintf("connection %s: job_config (or sync_config.s3) must set bucket and region", conn.ID).
+			Mark(ierr.ErrValidation)
+	}
+
 	return s3backend.New(ctx, &s3backend.Config{
-		Bucket:             jobConfig.Bucket,
-		Region:             jobConfig.Region,
-		CompressionGzip:    jobConfig.Compression == types.S3CompressionTypeGzip,
-		ServerSideEncrypt:  string(jobConfig.Encryption),
+		Bucket:             bucket,
+		Region:             region,
+		CompressionGzip:    gzip,
+		ServerSideEncrypt:  encryption,
 		AWSAccessKeyID:     accessKey,
 		AWSSecretAccessKey: secretKey,
 		AWSSessionToken:    sessionToken,
 	}, f.logger)
 }
 
-func (f *Factory) buildGCSStorage(ctx context.Context, conn *connection.Connection) (storage.Storage, error) {
+func (f *Factory) buildGCSStorage(ctx context.Context, conn *connection.Connection, _ *exportDestination) (storage.Storage, error) {
 	jobConfig := conn.GetSyncConfig().Storage
 	if jobConfig == nil {
 		return nil, ierr.NewError("no storage job configuration on connection").Mark(ierr.ErrValidation)

--- a/internal/integration/factory_test.go
+++ b/internal/integration/factory_test.go
@@ -653,6 +653,77 @@ func TestFactory_GetStorageProvider_RepositoryFailure_PreservesOriginalErrorKind
 	require.ErrorIs(t, err, dbErr)
 }
 
+// GetStorageProviderExport must resolve a BYOB connection's DESTINATION from the
+// per-run job_config passed in, not the connection's sync_config row. The seeded
+// connection records bucket "test-bucket"/us-east-1; the export run targets a
+// different bucket/region, which must win.
+func TestFactory_GetStorageProviderExport_BYOB_UsesJobConfigDestination(t *testing.T) {
+	ctx := buildFactoryTestContext()
+	connRepo := testutil.NewInMemoryConnectionStore()
+	factory, encSvc := buildStorageTestFactory(connRepo)
+
+	conn := seedS3Connection(ctx, t, connRepo, encSvc) // sync_config bucket=test-bucket region=us-east-1
+
+	got, err := factory.GetStorageProviderExport(ctx, conn.ID, "run-bucket", "ap-south-1", "AES256", false)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, storage.ProviderS3, got.Provider())
+	require.Contains(t, got.FileURL("k.csv"), "run-bucket",
+		"BYOB export must write to the job_config bucket, not the connection sync_config bucket")
+	require.NotContains(t, got.FileURL("k.csv"), "test-bucket")
+}
+
+// A BYOB export whose job_config carries an empty bucket or region must fail loud
+// at construction rather than reaching the S3 SDK as "A region must be set".
+func TestFactory_GetStorageProviderExport_BYOB_EmptyDestination_ReturnsValidationError(t *testing.T) {
+	ctx := buildFactoryTestContext()
+	connRepo := testutil.NewInMemoryConnectionStore()
+	factory, encSvc := buildStorageTestFactory(connRepo)
+
+	conn := seedS3Connection(ctx, t, connRepo, encSvc)
+
+	_, err := factory.GetStorageProviderExport(ctx, conn.ID, "run-bucket", "", "AES256", false)
+	require.Error(t, err)
+	require.True(t, ierr.IsValidation(err), "expected validation error, got: %v", err)
+}
+
+// Managed exports must ignore the per-run job_config destination and force the
+// platform/connection bucket — the run cannot redirect a managed export elsewhere.
+func TestFactory_GetStorageProviderExport_Managed_IgnoresJobConfigDestination(t *testing.T) {
+	ctx := buildFactoryTestContext()
+	connRepo := testutil.NewInMemoryConnectionStore()
+
+	cfg := &config.Configuration{
+		Secrets: config.SecretsConfig{EncryptionKey: "test-encryption-key-for-unit-tests-only"},
+	}
+	cfg.FlexpriceS3Exports.Bucket = "platform-config-bucket"
+	cfg.FlexpriceS3Exports.Region = "ap-south-1"
+	cfg.FlexpriceS3Exports.CredentialSource = config.CredentialSourceAmbient
+
+	log := logger.NewNoopLogger()
+	encSvc, err := security.NewEncryptionService(cfg, log)
+	require.NoError(t, err)
+	factory := buildStorageTestFactoryWithRepo(connRepo, cfg, log, encSvc)
+
+	conn := seedFlexpriceManagedS3Connection(ctx, t, connRepo) // no recorded bucket
+
+	got, err := factory.GetStorageProviderExport(ctx, conn.ID, "attacker-bucket", "eu-west-1", "AES256", false)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Contains(t, got.FileURL("k.csv"), "platform-config-bucket",
+		"managed export must ignore job_config destination and use platform config")
+	require.NotContains(t, got.FileURL("k.csv"), "attacker-bucket")
+}
+
+func TestFactory_GetStorageProviderExport_MissingConnectionID_ReturnsValidationError(t *testing.T) {
+	ctx := buildFactoryTestContext()
+	factory, _ := buildStorageTestFactory(testutil.NewInMemoryConnectionStore())
+
+	_, err := factory.GetStorageProviderExport(ctx, "", "b", "r", "AES256", false)
+	require.Error(t, err)
+	require.True(t, ierr.IsValidation(err), "expected validation error, got: %v", err)
+}
+
 func TestFactory_GetRefundProvider(t *testing.T) {
 	ctx := buildFactoryTestContext()
 	factory, _ := buildStorageTestFactory(testutil.NewInMemoryConnectionStore())

--- a/internal/storage/resolver.go
+++ b/internal/storage/resolver.go
@@ -30,6 +30,12 @@ const (
 type Resolver interface {
 	ForPlatform(ctx context.Context, purpose Purpose) (Storage, error)
 	ForConnection(ctx context.Context, connectionID string) (Storage, error)
+	// ForConnectionExport resolves storage for a scheduled export run. The
+	// destination (bucket, region, prefix, encryption) comes from the run's
+	// job_config snapshot, not the connection row; the connection contributes
+	// only credentials. bucket/region are required and validated here so a bad
+	// job_config fails loud instead of reaching the SDK as an opaque endpoint error.
+	ForConnectionExport(ctx context.Context, connectionID, bucket, region, encryption string, gzip bool) (Storage, error)
 	Provider() Provider
 	// BucketConfigFor returns provider-specific bucket settings (prefix, presign
 	// expiry) for a purpose. Reading cfg.S3.* directly is what hardcoded the
@@ -42,6 +48,9 @@ type Resolver interface {
 // (internal/integration already imports this package). cmd/server wires it in.
 type ConnectionStorageProvider interface {
 	GetStorageProvider(ctx context.Context, connectionID string) (Storage, error)
+	// GetStorageProviderExport builds storage for an export run: credentials from
+	// the connection, destination from the passed job_config values.
+	GetStorageProviderExport(ctx context.Context, connectionID, bucket, region, encryption string, gzip bool) (Storage, error)
 }
 
 type resolver struct {
@@ -122,6 +131,20 @@ func (r *resolver) ForConnection(ctx context.Context, connectionID string) (Stor
 			Mark(ierr.ErrSystem)
 	}
 	return r.connSvc.GetStorageProvider(ctx, connectionID)
+}
+
+func (r *resolver) ForConnectionExport(ctx context.Context, connectionID, bucket, region, encryption string, gzip bool) (Storage, error) {
+	if r.connSvc == nil {
+		return nil, ierr.NewError("connection storage is not configured").
+			WithHint("No connection storage provider was wired into the storage resolver").
+			Mark(ierr.ErrSystem)
+	}
+	if bucket == "" || region == "" {
+		return nil, ierr.NewError("export job_config is missing bucket or region").
+			WithHintf("scheduled task for connection %s has no bucket/region in its job_config", connectionID).
+			Mark(ierr.ErrValidation)
+	}
+	return r.connSvc.GetStorageProviderExport(ctx, connectionID, bucket, region, encryption, gzip)
 }
 
 // signerFor returns the GCS signing identity for a purpose (S3 signs with the

--- a/internal/storage/resolver_test.go
+++ b/internal/storage/resolver_test.go
@@ -316,6 +316,68 @@ func TestResolver_Imports_RejectsWhenDisabled(t *testing.T) {
 	assert.Contains(t, hints, "FLEXPRICE_FLEXPRICE_S3_IMPORTS_ENABLED")
 }
 
+type fakeConnStorageProvider struct {
+	export func(ctx context.Context, connectionID, bucket, region, encryption string, gzip bool) (Storage, error)
+}
+
+func (f *fakeConnStorageProvider) GetStorageProvider(context.Context, string) (Storage, error) {
+	return nil, nil
+}
+func (f *fakeConnStorageProvider) GetStorageProviderExport(ctx context.Context, connectionID, bucket, region, encryption string, gzip bool) (Storage, error) {
+	return f.export(ctx, connectionID, bucket, region, encryption, gzip)
+}
+
+func TestResolver_ForConnectionExport(t *testing.T) {
+	t.Run("nil connSvc fails loud", func(t *testing.T) {
+		r := newTestResolver(t, ProviderS3, testConfig()) // connSvc left nil
+		_, err := r.ForConnectionExport(context.Background(), "conn_1", "bucket", "us-east-1", "AES256", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "connection storage is not configured")
+	})
+
+	t.Run("empty bucket fails loud before delegation", func(t *testing.T) {
+		called := false
+		r := newTestResolver(t, ProviderS3, testConfig())
+		r.connSvc = &fakeConnStorageProvider{export: func(context.Context, string, string, string, string, bool) (Storage, error) {
+			called = true
+			return nil, nil
+		}}
+		_, err := r.ForConnectionExport(context.Background(), "conn_1", "", "us-east-1", "AES256", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing bucket or region")
+		assert.False(t, called, "must not delegate when bucket empty")
+	})
+
+	t.Run("empty region fails loud before delegation", func(t *testing.T) {
+		r := newTestResolver(t, ProviderS3, testConfig())
+		r.connSvc = &fakeConnStorageProvider{export: func(context.Context, string, string, string, string, bool) (Storage, error) {
+			return nil, nil
+		}}
+		_, err := r.ForConnectionExport(context.Background(), "conn_1", "bucket", "", "AES256", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing bucket or region")
+	})
+
+	t.Run("delegates job_config destination through to provider", func(t *testing.T) {
+		var got struct {
+			connID, bucket, region, enc string
+			gzip                        bool
+		}
+		r := newTestResolver(t, ProviderS3, testConfig())
+		r.connSvc = &fakeConnStorageProvider{export: func(_ context.Context, connID, bucket, region, enc string, gzip bool) (Storage, error) {
+			got.connID, got.bucket, got.region, got.enc, got.gzip = connID, bucket, region, enc, gzip
+			return nil, nil
+		}}
+		_, err := r.ForConnectionExport(context.Background(), "conn_9", "byob-bucket", "ap-south-1", "AES256", true)
+		require.NoError(t, err)
+		assert.Equal(t, "conn_9", got.connID)
+		assert.Equal(t, "byob-bucket", got.bucket)
+		assert.Equal(t, "ap-south-1", got.region)
+		assert.Equal(t, "AES256", got.enc)
+		assert.True(t, got.gzip)
+	})
+}
+
 func TestResolver_ForPlatform_Caches(t *testing.T) {
 	cfg := testConfig()
 	r := newTestResolver(t, ProviderS3, cfg)


### PR DESCRIPTION
## Problem
Scheduled export uploads resolved the destination bucket/region from the connection's `sync_config` (via `ForConnection` → `buildS3Storage` reading `conn.GetSyncConfig().Storage`), ignoring the per-run `job_config` snapshot carried on the scheduled task.

A single BYOB connection runs multiple scheduled tasks with **different region/prefix** (verified in prod: one connection, two tasks, `us-east-1/revenue` vs `ap-south-1/flexprice-exports`). The connection row cannot express per-run destinations, so exports either landed in the wrong bucket/region or failed with an opaque `A region must be set` SDK error when `sync_config` was empty.

## Fix
Add `ForConnectionExport` on the storage resolver:
- **destination** (bucket, region, encryption, gzip) ← the run's `job_config`
- **credentials** ← connection (BYOB keys) / platform config (managed)
- **managed flag** ← connection `sync_config.s3.is_flexprice_managed`

Managed exports still force the platform bucket/region from `FlexpriceS3Exports` (unchanged behavior). `bucket`/`region` are validated up front so a bad `job_config` fails loud with a clear hint instead of surfacing deep in the AWS SDK.

The `GetStorageProviderForConnection` path (connection validation) is unchanged — it passes a nil destination override and still resolves from the connection row.

## Verification
- `go build ./internal/... ./cmd/...` — pass
- `go test ./internal/storage/... ./internal/integration/... ./internal/ee/service/sync/export/... ./internal/ee/service/` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Scheduled exports can now use per-run storage settings, including bucket, region, encryption, and gzip compression.
  - Export destinations are validated before storage setup, with clear validation for missing bucket or region details.
  - Storage connections continue to use their saved credentials and provider configuration.
  - Managed export destinations retain their configured settings and do not accept per-run destination overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->