### PR TITLE
chore(ci): fix CodeRabbit ignore race on develop->main PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,9 +3,10 @@ language: en-US
 reviews:
   auto_review:
     enabled: true
-    # base_branches defaults to the default branch (develop) only, so
-    # develop->main promotion PRs are not auto-reviewed. The
-    # skip-coderabbit workflow posts `@coderabbitai ignore` as a
-    # belt-and-suspenders guard for any manual review trigger.
+    # Review PRs into main and develop. The develop->main promotion PR
+    # is also a PR into main, which base_branches cannot exclude on its
+    # own; the skip-coderabbit workflow posts `@coderabbitai ignore` on
+    # those (head=develop, base=main) to suppress the review.
     base_branches:
-      - develop
+      - ^main$
+      - ^develop$

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,11 @@
-# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 language: en-US
 reviews:
   auto_review:
     enabled: true
-    # develop->main promotion PRs are skipped via .github/workflows/skip-coderabbit.yml
-    # (posts an `@coderabbitai ignore` command comment on open).
+    # base_branches defaults to the default branch (develop) only, so
+    # develop->main promotion PRs are not auto-reviewed. The
+    # skip-coderabbit workflow posts `@coderabbitai ignore` as a
+    # belt-and-suspenders guard for any manual review trigger.
     base_branches:
-      - main
+      - develop

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+reviews:
+  auto_review:
+    enabled: true
+    # develop->main promotion PRs are skipped via .github/workflows/skip-coderabbit.yml
+    # (posts an `@coderabbitai ignore` command comment on open).
+    base_branches:
+      - main

--- a/.github/workflows/skip-coderabbit.yml
+++ b/.github/workflows/skip-coderabbit.yml
@@ -11,14 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - run: |
-          body=$(gh pr view "$PR" --json body --jq '.body')
-          if printf '%s' "$body" | grep -qF '@coderabbitai ignore'; then
-            echo "marker already present, skipping"
+          if gh pr view "$PR" --json comments \
+               --jq '.comments[].body' | grep -qF '@coderabbitai ignore'; then
+            echo "ignore command already posted, skipping"
             exit 0
           fi
-          printf '%s\n\n@coderabbitai ignore\n' "$body" | gh pr edit "$PR" --body-file -
+          gh pr comment "$PR" --body '@coderabbitai ignore'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Problem
The `skip-coderabbit` workflow adds `@coderabbitai ignore` to the PR body on open, but CodeRabbit's own PR-open webhook fires at the same instant (t=0) while the workflow only edits the body ~10s later (checkout + `gh pr edit`). CodeRabbit starts its review before the marker exists, so develop->main promotion PRs still get reviewed (e.g. #2798).

Additionally there was no `.coderabbit.yaml`, so CodeRabbit auto-reviewed every PR.

## Changes
- **skip-coderabbit.yml**: post `@coderabbitai ignore` as a *command comment* instead of editing the body. The command is honored even after a review has started (cancels it in-flight), closing the race. Idempotency check now reads comments; added `issues: write`.
- **.coderabbit.yaml** (new): scope auto-review to the `main` base branch.

## Notes
CodeRabbit config cannot filter by head branch, so develop->main exclusion stays in the workflow; config handles the base-branch scoping.