### PR TITLE
ci: add standalone prod ECS revert workflow

### DIFF
--- a/.github/workflows/revert-ecs.yml
+++ b/.github/workflows/revert-ecs.yml
@@ -24,8 +24,8 @@ concurrency:
   group: revert-ecs
   cancel-in-progress: false
 
+# Least privilege at the top; only the deploy jobs get id-token (OIDC to AWS).
 permissions:
-  id-token: write
   contents: read
 
 env:
@@ -82,6 +82,9 @@ jobs:
           needs.validate.result == 'success' &&
           (inputs.dry_run == true || needs.approval-gate.result == 'success') }}
     runs-on: self-hosted
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         target: ${{ fromJson(needs.validate.outputs.targets) }}
@@ -118,6 +121,9 @@ jobs:
           needs.validate.result == 'success' &&
           (inputs.dry_run == true || needs.approval-gate.result == 'success') }}
     runs-on: self-hosted
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         target: ${{ fromJson(needs.validate.outputs.targets) }}
@@ -154,6 +160,9 @@ jobs:
           needs.validate.result == 'success' &&
           (inputs.dry_run == true || needs.approval-gate.result == 'success') }}
     runs-on: self-hosted
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         target: ${{ fromJson(needs.validate.outputs.targets) }}

--- a/.github/workflows/revert-ecs.yml
+++ b/.github/workflows/revert-ecs.yml
@@ -29,9 +29,13 @@ permissions:
   contents: read
 
 env:
-  ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
-  ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
+  # Self ECS runs GHCR-only (no ECR). The composite matches the app container by
+  # `startswith(ecr_prefix) OR startswith(ghcr_prefix)`, and ecr_repo_prefix is a
+  # required input — so pass a sentinel that matches NO image (never a prefix of a
+  # real ref, and NOT empty: startswith("") is true for every container and would
+  # swap sidecars too). Only ghcr_repo_prefix does the matching.
+  ECR_REPO_PREFIX_UNUSED: "no-ecr::self-is-ghcr-only"
 
 jobs:
   # Fail closed on a malformed pull ref before any target is touched.
@@ -101,7 +105,7 @@ jobs:
           region: ${{ matrix.target.region }}
           service_name: ${{ matrix.target.api_service }}
           image: ${{ inputs.image }}
-          ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ecr_repo_prefix: ${{ env.ECR_REPO_PREFIX_UNUSED }}
           ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
           ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
           dry_run: ${{ inputs.dry_run }}
@@ -137,7 +141,7 @@ jobs:
           region: ${{ matrix.target.region }}
           service_name: ${{ matrix.target.consumer_service }}
           image: ${{ inputs.image }}
-          ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ecr_repo_prefix: ${{ env.ECR_REPO_PREFIX_UNUSED }}
           ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
           ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
           dry_run: ${{ inputs.dry_run }}
@@ -173,7 +177,7 @@ jobs:
           region: ${{ matrix.target.region }}
           service_name: ${{ matrix.target.worker_service }}
           image: ${{ inputs.image }}
-          ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ecr_repo_prefix: ${{ env.ECR_REPO_PREFIX_UNUSED }}
           ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
           ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
           dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/revert-ecs.yml
+++ b/.github/workflows/revert-ecs.yml
@@ -1,0 +1,179 @@
+name: Revert prod ECS (self ap-south-1)
+
+# Standalone, deploy-only prod ECS revert. Redeploys a PRE-BUILT GHCR image
+# (digest-pinned) to every self production ECS target — NO build, NO migration.
+# It reuses ONLY the deploy-ecs-service composite (reads the live task-def, swaps
+# the app container image, re-registers, force-deploys), never `build` or
+# `run-ecs-migration`, so no-build + no-migration is by construction.
+#
+# Triggered manually (workflow_dispatch) or cross-repo from infra revert.yml via a
+# GitHub App token. deploy.yml (the forward pipeline) is intentionally untouched.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Full GHCR pull ref: ghcr.io/flexprice/flexprice@sha256:<64hex>'
+        required: true
+      dry_run:
+        description: 'Dry run — print the task-def plan only, no register/deploy'
+        type: boolean
+        default: true
+
+concurrency:
+  group: revert-ecs
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+  ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+  GHCR_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  # Fail closed on a malformed pull ref before any target is touched.
+  validate:
+    name: Validate image ref
+    runs-on: self-hosted
+    outputs:
+      targets: ${{ steps.config.outputs.targets }}
+    steps:
+      - name: Validate image + resolve targets
+        id: config
+        env:
+          IMAGE: ${{ inputs.image }}
+          PROD_TARGETS: ${{ vars.PROD_DEPLOY_TARGETS }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$IMAGE" | grep -Eq '^ghcr\.io/flexprice/flexprice@sha256:[0-9a-f]{64}$'; then
+            echo "::error::image must match ^ghcr.io/flexprice/flexprice@sha256:[0-9a-f]{64}\$"
+            exit 1
+          fi
+          {
+            echo "targets<<TARGETS_EOF"
+            echo "$PROD_TARGETS"
+            echo "TARGETS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  # Single manual approval gate before any prod ECS rollout. Dry runs bypass it
+  # (nothing is registered/deployed anyway).
+  approval-gate:
+    name: Approve production revert
+    needs: [validate]
+    if: ${{ inputs.dry_run != true }}
+    runs-on: self-hosted
+    environment: prod-approval
+    steps:
+      - name: Production revert approved
+        run: echo "Production ECS revert approved — deploying api, consumer, worker to all targets."
+
+  deploy-api:
+    name: Revert API (${{ strategy.job-index }})
+    needs: [validate, approval-gate]
+    if: >-
+      ${{ always() &&
+          needs.validate.result == 'success' &&
+          (inputs.dry_run == true || needs.approval-gate.result == 'success') }}
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.validate.outputs.targets) }}
+      fail-fast: false
+      max-parallel: 3
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-cicd
+          aws-region: ${{ matrix.target.region }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Deploy ECS API service
+        uses: ./.github/actions/deploy-ecs-service
+        with:
+          cluster: ${{ matrix.target.cluster }}
+          region: ${{ matrix.target.region }}
+          service_name: ${{ matrix.target.api_service }}
+          image: ${{ inputs.image }}
+          ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
+          ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
+          dry_run: ${{ inputs.dry_run }}
+
+  deploy-consumer:
+    name: Revert Consumer (${{ strategy.job-index }})
+    needs: [validate, approval-gate]
+    if: >-
+      ${{ always() &&
+          needs.validate.result == 'success' &&
+          (inputs.dry_run == true || needs.approval-gate.result == 'success') }}
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.validate.outputs.targets) }}
+      fail-fast: false
+      max-parallel: 3
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-cicd
+          aws-region: ${{ matrix.target.region }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Deploy ECS Consumer service
+        uses: ./.github/actions/deploy-ecs-service
+        with:
+          cluster: ${{ matrix.target.cluster }}
+          region: ${{ matrix.target.region }}
+          service_name: ${{ matrix.target.consumer_service }}
+          image: ${{ inputs.image }}
+          ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
+          ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
+          dry_run: ${{ inputs.dry_run }}
+
+  deploy-worker:
+    name: Revert Worker (${{ strategy.job-index }})
+    needs: [validate, approval-gate]
+    if: >-
+      ${{ always() &&
+          needs.validate.result == 'success' &&
+          (inputs.dry_run == true || needs.approval-gate.result == 'success') }}
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.validate.outputs.targets) }}
+      fail-fast: false
+      max-parallel: 3
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-cicd
+          aws-region: ${{ matrix.target.region }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Deploy ECS Worker service
+        uses: ./.github/actions/deploy-ecs-service
+        with:
+          cluster: ${{ matrix.target.cluster }}
+          region: ${{ matrix.target.region }}
+          service_name: ${{ matrix.target.worker_service }}
+          image: ${{ inputs.image }}
+          ecr_repo_prefix: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          ghcr_repo_prefix: ${{ env.GHCR_IMAGE }}
+          ghcr_credentials_arn: ${{ vars.ECS_GHCR_PULL_CREDENTIALS_ARN }}
+          dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
Adds `.github/workflows/revert-ecs.yml` — the ECS half of the prod-revert system (design D6/D7/D10; GKE half already merged in infra #429/#431/#432/#433, #434 open).

## What
A standalone, **deploy-only** prod ECS revert for self production (ap-south-1). It redeploys a **pre-built, digest-pinned** GHCR image to every `PROD_DEPLOY_TARGETS` service.

- Reuses **ONLY** the existing `deploy-ecs-service` composite (reads live task-def, swaps app container image, re-registers, force-deploys). Never `build`, never `run-ecs-migration` — so **no-build + no-migration is by construction**, not by flag.
- `workflow_dispatch` (`image`, `dry_run`) **and** cross-repo dispatchable from infra `revert.yml` via a GitHub App token.
- `image` validated fail-closed against `^ghcr\.io/flexprice/flexprice@sha256:[0-9a-f]{64}$`.
- `environment: prod-approval` gate (same as `deploy.yml`'s prod deploys); dry runs bypass it.
- 3 jobs (api/consumer/worker), `runs-on: self-hosted`, OIDC `role/github-cicd`, matrix over `PROD_DEPLOY_TARGETS` — mirrors `deploy.yml`'s deploy-job wiring.

## Does NOT touch
`deploy.yml` (working forward pipeline) and the `deploy-ecs-service` composite are unchanged.

## Must merge to `main`
Cross-repo `gh workflow run` from infra requires this on the default branch (D10).

## Pre-merge follow-ups (out of scope for this PR, tracked in the design)
- Confirm `role/github-cicd` OIDC trust-policy `sub` admits `revert-ecs.yml` (may be workflow-ref scoped).
- GitHub App (`actions:write`+`contents:read` on flexprice) created + its id/key stored as infra secrets.

## Validation
YAML validated (`yaml.safe_load`). Composite inputs match `action.yml` exactly. **Live ECS execution is UNVERIFIED** (no approval to run prod ECS deploys).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a manually triggered production rollback workflow for API, consumer, and worker services.
  - Supports digest-pinned container images and configurable deployment targets.
  - Includes dry-run validation and production approval safeguards for live rollbacks.
  - Rollbacks can run without rebuilding images or applying database migrations.
  - Ensures only intended container images are selected for rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->