### PR TITLE
chore(clickhouse): deprecate events proj_by_customer_event (640G reclaim, manual apply)

### DIFF
--- a/migrations/baseline/clickhouse_baseline_20260819.sql
+++ b/migrations/baseline/clickhouse_baseline_20260819.sql
@@ -29,18 +29,7 @@ CREATE TABLE IF NOT EXISTS flexprice.events
     CONSTRAINT check_event_name CHECK event_name != '',
     CONSTRAINT check_tenant_id CHECK tenant_id != '',
     CONSTRAINT check_event_id CHECK id != '',
-    CONSTRAINT check_environment_id CHECK environment_id != '',
-    PROJECTION proj_by_customer_event
-    (
-        SELECT *
-        ORDER BY
-            tenant_id,
-            environment_id,
-            external_customer_id,
-            event_name,
-            timestamp,
-            id
-    )
+    CONSTRAINT check_environment_id CHECK environment_id != ''
 )
 ENGINE = ReplacingMergeTree(ingested_at)
 -- DEVIATION FROM PROD: prod partitions this table monthly, toYYYYMM(timestamp).

--- a/migrations/baseline/clickhouse_baseline_replicated_20260819.sql
+++ b/migrations/baseline/clickhouse_baseline_replicated_20260819.sql
@@ -53,18 +53,7 @@ CREATE TABLE IF NOT EXISTS flexprice.events ON CLUSTER '{cluster}'
     CONSTRAINT check_event_name CHECK event_name != '',
     CONSTRAINT check_tenant_id CHECK tenant_id != '',
     CONSTRAINT check_event_id CHECK id != '',
-    CONSTRAINT check_environment_id CHECK environment_id != '',
-    PROJECTION proj_by_customer_event
-    (
-        SELECT *
-        ORDER BY
-            tenant_id,
-            environment_id,
-            external_customer_id,
-            event_name,
-            timestamp,
-            id
-    )
+    CONSTRAINT check_environment_id CHECK environment_id != ''
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/{database}/{table}', '{replica}', ingested_at)
 -- DEVIATION FROM PROD: prod partitions this table monthly, toYYYYMM(timestamp).

--- a/migrations/clickhouse/000008_drop_proj_by_customer_event.sql
+++ b/migrations/clickhouse/000008_drop_proj_by_customer_event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE flexprice.events DROP PROJECTION IF EXISTS proj_by_customer_event;


### PR DESCRIPTION
## What

Deprecates the `proj_by_customer_event` projection on `flexprice.events` in code:
- **New migration** `migrations/clickhouse/000008_drop_proj_by_customer_event.sql`: `ALTER TABLE flexprice.events DROP PROJECTION IF EXISTS proj_by_customer_event;`
- **Removes** the projection clause from both baseline files (`clickhouse_baseline_20260819.sql`, `_replicated_`) so fresh installs stop creating it.

## Why

The projection is a `SELECT *` full second copy of `events` (~640 GiB, ~66% of the base table), re-sorted by (tenant, env, external_customer_id, event_name, timestamp, id). Dropping it reclaims **640 GiB** on prod ClickHouse.

## ⚠️ IMPORTANT — this does NOT reclaim space by itself

ClickHouse migrations are **not** wired into CI/CD (`deploy.yml` has no clickhouse step). The live mechanism is manual: `go run ./cmd/migrate clickhouse` (or a hand-run `ALTER`). **An operator must run the migration/ALTER against each prod cluster by hand to actually drop the projection and free the 640 GiB.** This PR only records the change + fixes fresh installs.

## ⚠️ Performance tradeoff (accepted, deferred)

The projection is USED (~4728 queries/30d). Dropping it slows customer+event-filtered queries — they scan the time-sorted 977 GiB base instead:
- `GET /events` list/count (top query, 3289×/30d)
- usage aggregation / customer usage dashboards
- **billing-critical**: `GetDistinctEventNames` → `GetUsageBySubscription` meter-shortlist (runs on subscription usage/invoice computation)

Nothing errors (CH falls back to the base table). **Recommend perf-testing the top queries before an operator runs the prod ALTER.** The code is staged so the drop is a deliberate, timed op — not automatic.

## Verified
- New migration: one statement, `IF EXISTS`, matches sibling file style
- Both baseline `events` CREATE TABLE remain valid SQL (constraint→`)`→ENGINE, no dangling comma)
- `proj_by_customer_event` now appears only in the new migration + a descriptive line in `migrations/baseline/README.md` (doc, harmless)

## Follow-up (not in this PR)
Same reclaim to run on self AWS ap-south-1 (same schema). And the JSON `properties` blob is why this projection is so large — a narrow projection would need the parked properties→JSON redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the unused `proj_by_customer_event` projection from the events table.
  * Added a migration to safely remove the projection from existing ClickHouse deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->