### PR TITLE
fix(export): stop grouping usage analytics by source

### DIFF
--- a/internal/ee/service/sync/export/usage_analytics_export.go
+++ b/internal/ee/service/sync/export/usage_analytics_export.go
@@ -166,12 +166,10 @@ func (e *UsageAnalyticsExporter) PrepareData(ctx context.Context, request *dto.E
 			ExternalCustomerID: c.ExternalID,
 			StartTime:          request.StartTime,
 			EndTime:            request.EndTime,
-			GroupBy:            []string{"source", "feature_id"}, // TODO: remove feature_id from group by, we groupBy meter_id by default
-			// Internal flag: keep commitment / true-up cost on bucketed
-			// commitment line items even when they fan out per source.
-			// Without this the per-source rows would carry only raw usage
-			// cost and the export totals would drift from the analytics API.
-			ForceApplyCommitment: true,
+			// No "source": fanning by source applied the line item's
+			// commitment once per row, multi-counting the true-up.
+			GroupBy: []string{"feature_id"}, // TODO: remove feature_id from group by, we groupBy meter_id by default
+			// ForceApplyCommitment: true,
 		})
 		if err != nil {
 			failedCount++

--- a/internal/ee/service/sync/export/usage_analytics_export_test.go
+++ b/internal/ee/service/sync/export/usage_analytics_export_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 // inMemoryUsageAnalyticsGetter is a test double for UsageAnalyticsGetter.
 type inMemoryUsageAnalyticsGetter struct {
 	responses map[string]*dto.GetUsageAnalyticsResponse
+	requests  []*dto.GetUsageAnalyticsRequest
 }
 
 func newInMemoryUsageAnalyticsGetter() *inMemoryUsageAnalyticsGetter {
@@ -32,6 +34,7 @@ func (m *inMemoryUsageAnalyticsGetter) set(externalCustomerID string, resp *dto.
 }
 
 func (m *inMemoryUsageAnalyticsGetter) GetDetailedUsageAnalytics(_ context.Context, req *dto.GetUsageAnalyticsRequest) (*dto.GetUsageAnalyticsResponse, error) {
+	m.requests = append(m.requests, req)
 	if resp, ok := m.responses[req.ExternalCustomerID]; ok {
 		return resp, nil
 	}
@@ -540,5 +543,32 @@ func TestGetDistinctCustomerIDsWithCommitmentTrueUp_BucketLevel(t *testing.T) {
 				t.Errorf("customer included = %v, want %v (ids=%v)", included, tc.wantInclude, ids)
 			}
 		})
+	}
+}
+
+// TestUsageAnalyticsExport_DoesNotGroupBySource guards the export's cost
+// correctness: analytics skips commitment on source-fanned rows, and forcing it
+// on multi-counts the true-up once per source.
+func TestUsageAnalyticsExport_DoesNotGroupBySource(t *testing.T) {
+	env := newUsageAnalyticsTestEnv(t)
+	c := env.addCustomer(t, "cust-gb", "ext-gb", "GroupBy Corp", nil)
+	env.addCommitmentTrueUpLineItem(t, c.ID)
+
+	if _, _, err := env.exporter.PrepareData(env.ctx, env.req); err != nil {
+		t.Fatalf("PrepareData: %v", err)
+	}
+
+	if len(env.analyticsGetter.requests) == 0 {
+		t.Fatal("expected at least one analytics request")
+	}
+	for _, req := range env.analyticsGetter.requests {
+		if req.ForceApplyCommitment {
+			t.Error("export must not set ForceApplyCommitment")
+		}
+		for _, g := range req.GroupBy {
+			if g == "source" || strings.HasPrefix(g, "properties.") {
+				t.Fatalf("export must not group by %q; group_by=%v", g, req.GroupBy)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Problem

The usage analytics CSV export requested `group_by=["source","feature_id"]` together with `ForceApplyCommitment=true`. That fanned each subscription line item into **one row per source** *and* applied its commitment on every row — so the commitment fired N times for N sources.

Reported on a bucketed `nvidia-h100` line item with a windowed commitment (12h time bucket committing 40 units/min at a slab-tiered price; 8 units/min at the line-item price outside it). All 7 source rows reported the same `total_cost`:

```
720 in-bucket windows  × slab_cost(40) = 720 × 1.95733333312 = 1409.28
720 out-bucket windows × flat_cost(8)  = 720 × 0.384         =  276.48
                                                               ────────
                                                                1685.76
```

That reproduces the observed CSV value to the cent — and contains **zero contribution from actual usage**. It is purely the per-window true-up floor, counted once per source (~$11.8k across 7 rows).

It also **suppressed real overage**: aggregate usage was ~28 units/min, well above the 8 units/min out-of-bucket commitment, but each source's slice individually fell below it, so no row ever registered overage.

### Why the flag existed

`calculateCosts` deliberately skips commitment whenever `group_by` fans rows by `source`/`properties.*`, because a fanned row holds only a slice of the line item's usage. `ForceApplyCommitment` overrode that skip so per-source rows would still carry cost. The trade-off was documented in-code, but it produces materially wrong money on any multi-source line item.

## Fix

Group by feature only and leave `ForceApplyCommitment` unset. Window values stay aggregated across sources, so commitment fires exactly once over the real usage.

Deliberately minimal: **one production file, 4 lines net.** `ForceApplyCommitment` and all its plumbing are untouched — no production caller sets it now, and the existing tests covering it still pass unchanged.

## Trade-off

The CSV `source` column is now empty, and rows collapse from one per (customer × feature × source) to one per (customer × feature). **The column is retained** so existing consumers keep parsing.

Restoring per-source rows without losing cost correctness requires commitment computed once on the aggregate and then allocated across source rows. That is a larger change and is deliberately **not** attempted here.

## Tests

One new test: `TestUsageAnalyticsExport_DoesNotGroupBySource` — fails if either `"source"` in `GroupBy` or `ForceApplyCommitment` is reintroduced in the exporter. Since the flag remains in the codebase, re-enabling it is a one-line mistake away. Verified non-vacuous by reinstating both and confirming both assertions fire.

Full `go test ./internal/...` green; `make lint-ci` clean.

## Note for verification

The corrected export total will **not** be the ~$1,950 the analytics API returned for this customer — that figure was raw uncommitted cost, because that call also used `group_by=source`. Expect roughly the commitment floor plus the out-of-bucket overage the per-source split was hiding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected usage analytics exports so commitment and true-up costs are aggregated accurately across the export period.
  * Prevented duplicate or missing cost calculations caused by grouping analytics by source or other detailed properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->