### PR TITLE
fix(invoice): persist parent_line_item_id in invoice repo bulk line-item creates

### DIFF
--- a/internal/repository/ent/invoice.go
+++ b/internal/repository/ent/invoice.go
@@ -266,6 +266,7 @@ func (r *invoiceRepository) CreateWithLineItems(ctx context.Context, inv *domain
 					SetQuantity(item.Quantity).
 					SetNillableAdjustedEntitlementQuantity(item.AdjustedEntitlementQuantity).
 					SetNillableSubscriptionLineItemID(item.SubscriptionLineItemID).
+					SetNillableParentLineItemID(item.ParentLineItemID).
 					SetCurrency(item.Currency).
 					SetNillablePeriodStart(item.PeriodStart).
 					SetNillablePeriodEnd(item.PeriodEnd).
@@ -351,6 +352,7 @@ func (r *invoiceRepository) AddLineItems(ctx context.Context, invoiceID string, 
 				SetCurrency(item.Currency).
 				SetNillableAdjustedEntitlementQuantity(item.AdjustedEntitlementQuantity).
 				SetNillableSubscriptionLineItemID(item.SubscriptionLineItemID).
+				SetNillableParentLineItemID(item.ParentLineItemID).
 				SetNillablePeriodStart(item.PeriodStart).
 				SetNillablePeriodEnd(item.PeriodEnd).
 				SetMetadata(item.Metadata).


### PR DESCRIPTION
## Bug

Updating or removing an **existing** line item on a **FINALIZED** invoice fails on real Postgres, every time:

```json
{"code":"not_found","message":"line item inv_line_... does not exist on invoice inv_... (or is not the current version)","http_status_code":404}
```

Reproduced on production (`api.cloud.flexprice.io`) via `POST /invoices/:id/modify/execute` with `action: update` against a finalized invoice.

## Root cause

The void-and-recreate **copy step itself always succeeded** — `voidAndRecreateDraftForEdit` copies the finalized invoice's line items with `parent_line_item_id` back-links and persists the draft through `InvoiceRepo.CreateWithLineItems`. But the inline bulk builder in `CreateWithLineItems` never mapped `ParentLineItemID`, so the copies land in Postgres with `parent_line_item_id = NULL` — one silently dropped column.

That column is exactly what `UpdateLineItem` / `RemoveBulkLineItem` use to resolve the caller's (original invoice's) item id against the fresh draft (`li.ID == id || li.ParentLineItemID == id`). With NULL parents the lookup finds nothing, the edit 404s, and the whole single transaction rolls back — original stays finalized, draft discarded. No data corruption, just a guaranteed failure.

### Exact scope on a finalized invoice
| Operation | Needs lineage lookup? | Result |
|---|---|---|
| **Update existing line item** | yes | ❌ 404, full rollback |
| **Remove existing line item** | yes | ❌ 404, full rollback |
| **Add new line item** | no (no existing id referenced) | ✅ worked — draft committed, but copies missing back-links |
| **apply_discount** | no (applies to draft items directly) | ✅ worked — same silent lineage loss |
| **Non-line-item fields** (due date, metadata, …) | n/a — no void/recreate | ✅ unaffected |

Draft invoices were never affected: their edit versioning goes through the single-item `invoiceLineItemRepo.Create`, which maps the field correctly. And the in-memory test store copies the whole struct including the parent — which is why every service test passed while only the ent mapping dropped it.

Note: drafts already created by the successful add/apply_discount paths carry NULL parents permanently; they edit fine by their own item ids, but the original→copy lineage is missing for them. The fix applies to copies made after deploy.

## Fix

Add `SetNillableParentLineItemID(item.ParentLineItemID)` to both inline builders in `internal/repository/ent/invoice.go`:
- `CreateWithLineItems` (the bug that bites the void-and-recreate flow)
- `AddLineItems` (same dropped field; adds carry no parent today, but the mapping should not silently discard it)

Two lines, no behavior change for items without a parent.

## Verification

- Confirmed on prod state: the failing invoice is still FINALIZED with all items published and no `recalculated_invoice_id`, and the draft id named in the error does not exist — i.e. full rollback, matching the diagnosis.
- `go build ./internal/... ./cmd/...` clean; invoice service test suite passes.
