### PR TITLE
fix(checkout): Invoices for draft subs to be referenced with start

### DIFF
--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -402,6 +402,13 @@ func (s *invoiceService) CreateDraftInvoiceForSubscription(ctx context.Context, 
 	}
 	billingPeriodStr := string(sub.BillingPeriod)
 	invoicingCustomerID := sub.GetInvoicingCustomerID()
+	billingReason := types.InvoiceBillingReasonSubscriptionCycle
+	switch referencePoint {
+	case types.ReferencePointPeriodStart:
+		billingReason = types.InvoiceBillingReasonSubscriptionCreate
+	case types.ReferencePointCancel:
+		billingReason = types.InvoiceBillingReasonProration
+	}
 	req := dto.CreateDraftInvoiceRequest{
 		CustomerID:     invoicingCustomerID,
 		SubscriptionID: lo.ToPtr(sub.ID),
@@ -410,10 +417,7 @@ func (s *invoiceService) CreateDraftInvoiceForSubscription(ctx context.Context, 
 		BillingPeriod:  &billingPeriodStr,
 		PeriodStart:    &periodStart,
 		PeriodEnd:      &periodEnd,
-		BillingReason:  types.InvoiceBillingReasonSubscriptionCycle,
-	}
-	if referencePoint == types.ReferencePointCancel {
-		req.BillingReason = types.InvoiceBillingReasonProration
+		BillingReason:  billingReason,
 	}
 	req.SubscriptionCustomerID = &sub.CustomerID
 	return s.CreateEmptyDraftInvoice(ctx, req)
@@ -1176,6 +1180,11 @@ func (s *invoiceService) IsFinalizationDue(ctx context.Context, invoiceID string
 
 	// Only finalize invoices that have been computed (LastComputedAt set by ComputeInvoice)
 	if inv.LastComputedAt == nil {
+		return false, nil
+	}
+
+	// Opening invoices stay draft until payment (checkout) or ProcessDraftInvoice.
+	if inv.BillingReason == string(types.InvoiceBillingReasonSubscriptionCreate) {
 		return false, nil
 	}
 

--- a/internal/ee/service/invoice_test.go
+++ b/internal/ee/service/invoice_test.go
@@ -2924,3 +2924,160 @@ func (s *InvoiceServiceSuite) TestProjectCustomCurrencyConvertsPrepaidCredits() 
 	s.True(item.CustomCurrency.PrepaidCreditsApplied.Equal(decimal.NewFromInt(30)),
 		"the denomination keeps the original")
 }
+
+func (s *InvoiceServiceSuite) TestCreateDraftInvoiceForSubscription_MapsReferencePointToBillingReason() {
+	ctx := s.GetContext()
+	periodStart := s.testData.subscription.CurrentPeriodStart
+	periodEnd := s.testData.subscription.CurrentPeriodEnd
+
+	tests := []struct {
+		name       string
+		ref        types.InvoiceReferencePoint
+		wantReason types.InvoiceBillingReason
+	}{
+		{"period start is an opening invoice", types.ReferencePointPeriodStart, types.InvoiceBillingReasonSubscriptionCreate},
+		{"period end is a cycle invoice", types.ReferencePointPeriodEnd, types.InvoiceBillingReasonSubscriptionCycle},
+		{"cancel is proration", types.ReferencePointCancel, types.InvoiceBillingReasonProration},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.invoiceRepo.Clear()
+			draft, err := s.service.CreateDraftInvoiceForSubscription(ctx, s.testData.subscription.ID, periodStart, periodEnd, tt.ref)
+			s.Require().NoError(err)
+			s.Equal(string(tt.wantReason), draft.BillingReason)
+		})
+	}
+}
+
+func (s *InvoiceServiceSuite) TestCreateDraftInvoiceForSubscription_PeriodStartComputeUsesCurrentPeriod() {
+	ctx := s.GetContext()
+	s.invoiceRepo.Clear()
+
+	fixedPrice := &price.Price{
+		ID:                 "price_fixed_advance_opening",
+		Amount:             decimal.NewFromInt(4500),
+		Currency:           "usd",
+		EntityType:         types.PRICE_ENTITY_TYPE_PLAN,
+		EntityID:           s.testData.plan.ID,
+		Type:               types.PRICE_TYPE_FIXED,
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+		BillingCadence:     types.BILLING_CADENCE_RECURRING,
+		InvoiceCadence:     types.InvoiceCadenceAdvance,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	s.NoError(s.GetStores().PriceRepo.Create(ctx, fixedPrice))
+
+	sub := &subscription.Subscription{
+		ID:                 "sub_opening_period_start",
+		PlanID:             s.testData.plan.ID,
+		CustomerID:         s.testData.customer.ID,
+		StartDate:          s.testData.now,
+		CurrentPeriodStart: s.testData.now,
+		CurrentPeriodEnd:   s.testData.now.AddDate(0, 1, 0),
+		BillingAnchor:      s.testData.now,
+		Currency:           "usd",
+		BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+		BillingPeriodCount: 1,
+		SubscriptionStatus: types.SubscriptionStatusActive,
+		ProrationBehavior:  types.ProrationBehaviorNone,
+		BaseModel:          types.GetDefaultBaseModel(ctx),
+	}
+	lineItems := []*subscription.SubscriptionLineItem{{
+		ID:              types.GenerateUUIDWithPrefix(types.UUID_PREFIX_SUBSCRIPTION_LINE_ITEM),
+		SubscriptionID:  sub.ID,
+		CustomerID:      sub.CustomerID,
+		EntityID:        s.testData.plan.ID,
+		EntityType:      types.SubscriptionLineItemEntityTypePlan,
+		PlanDisplayName: s.testData.plan.Name,
+		PriceID:         fixedPrice.ID,
+		PriceType:       fixedPrice.Type,
+		DisplayName:     "Lite Standard",
+		Quantity:        decimal.NewFromInt(1),
+		Currency:        sub.Currency,
+		BillingPeriod:   sub.BillingPeriod,
+		InvoiceCadence:  types.InvoiceCadenceAdvance,
+		StartDate:       sub.StartDate,
+		BaseModel:       types.GetDefaultBaseModel(ctx),
+	}}
+	s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, sub, lineItems))
+
+	draft, err := s.service.CreateDraftInvoiceForSubscription(ctx, sub.ID, sub.CurrentPeriodStart, sub.CurrentPeriodEnd, types.ReferencePointPeriodStart)
+	s.Require().NoError(err)
+
+	_, skipped, err := s.service.ComputeInvoice(ctx, draft.ID, nil)
+	s.Require().NoError(err)
+	s.False(skipped, "a fixed advance charge must produce a computed invoice")
+
+	inv, err := s.invoiceRepo.Get(ctx, draft.ID)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(inv.LineItems)
+	s.Require().NotNil(inv.PeriodStart)
+	s.Require().NotNil(inv.PeriodEnd)
+	for _, li := range inv.LineItems {
+		s.Require().NotNil(li.PeriodStart)
+		s.Require().NotNil(li.PeriodEnd)
+		s.True(li.PeriodStart.Equal(*inv.PeriodStart),
+			"opening-invoice line period_start %s must match invoice period_start %s", li.PeriodStart, *inv.PeriodStart)
+		s.True(li.PeriodEnd.Equal(*inv.PeriodEnd),
+			"opening-invoice line period_end %s must match invoice period_end %s", li.PeriodEnd, *inv.PeriodEnd)
+	}
+}
+
+func (s *InvoiceServiceSuite) seedInvoiceConfigDelay(seconds int) {
+	svc := NewSettingsService(s.service.(*invoiceService).ServiceParams).(*settingsService)
+	cfg, err := GetSetting[types.InvoiceConfig](svc, s.GetContext(), types.SettingKeyInvoiceConfig)
+	s.Require().NoError(err)
+	cfg.FinalizationDelaySeconds = seconds
+	s.Require().NoError(UpdateSetting(svc, s.GetContext(), types.SettingKeyInvoiceConfig, cfg))
+}
+
+func (s *InvoiceServiceSuite) TestIsFinalizationDue_SkipsSubscriptionCreateDrafts() {
+	ctx := s.GetContext()
+	s.invoiceRepo.Clear()
+	s.seedInvoiceConfigDelay(0)
+
+	draft, err := s.service.CreateDraftInvoiceForSubscription(
+		ctx,
+		s.testData.subscription.ID,
+		s.testData.subscription.CurrentPeriodStart,
+		s.testData.subscription.CurrentPeriodEnd,
+		types.ReferencePointPeriodStart,
+	)
+	s.Require().NoError(err)
+
+	computedAt := time.Now().UTC().Add(-time.Hour)
+	inv, err := s.invoiceRepo.Get(ctx, draft.ID)
+	s.Require().NoError(err)
+	inv.LastComputedAt = &computedAt
+	s.Require().NoError(s.invoiceRepo.Update(ctx, inv))
+
+	due, err := s.service.IsFinalizationDue(ctx, draft.ID)
+	s.Require().NoError(err)
+	s.False(due, "opening invoices must wait for payment, not the finalize cron")
+}
+
+func (s *InvoiceServiceSuite) TestIsFinalizationDue_CycleDraftAfterPeriodEndIsDue() {
+	ctx := s.GetContext()
+	s.invoiceRepo.Clear()
+	s.seedInvoiceConfigDelay(0)
+
+	periodStart := s.testData.now.Add(-40 * 24 * time.Hour)
+	periodEnd := s.testData.now.Add(-10 * 24 * time.Hour)
+	draft, err := s.service.CreateDraftInvoiceForSubscription(
+		ctx, s.testData.subscription.ID, periodStart, periodEnd, types.ReferencePointPeriodEnd,
+	)
+	s.Require().NoError(err)
+
+	computedAt := periodEnd.Add(time.Hour)
+	inv, err := s.invoiceRepo.Get(ctx, draft.ID)
+	s.Require().NoError(err)
+	inv.LastComputedAt = &computedAt
+	s.Require().NoError(s.invoiceRepo.Update(ctx, inv))
+
+	due, err := s.service.IsFinalizationDue(ctx, draft.ID)
+	s.Require().NoError(err)
+	s.True(due, "a computed cycle draft whose period has ended should finalize")
+}

--- a/internal/ee/service/subscription_create_test.go
+++ b/internal/ee/service/subscription_create_test.go
@@ -1033,6 +1033,21 @@ func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_GroupedChi
 	s.Require().NotNil(inv, "the gated create must have priced a draft invoice before opening a session")
 	s.True(inv.AmountDue.Equal(decimal.NewFromInt(110)),
 		"the locked amount must cover parent (50) + two seats (30 each), got %s", inv.AmountDue)
+
+	full, err := s.GetStores().InvoiceRepo.Get(ctx, inv.ID)
+	s.Require().NoError(err)
+	s.Equal(string(types.InvoiceBillingReasonSubscriptionCreate), full.BillingReason)
+	s.Require().NotNil(full.PeriodStart)
+	s.Require().NotNil(full.PeriodEnd)
+	s.Require().NotEmpty(full.LineItems)
+	for _, li := range full.LineItems {
+		s.Require().NotNil(li.PeriodStart)
+		s.Require().NotNil(li.PeriodEnd)
+		s.True(li.PeriodStart.Equal(*full.PeriodStart),
+			"checkout opening line period_start %s must match invoice %s", li.PeriodStart, *full.PeriodStart)
+		s.True(li.PeriodEnd.Equal(*full.PeriodEnd),
+			"checkout opening line period_end %s must match invoice %s", li.PeriodEnd, *full.PeriodEnd)
+	}
 }
 
 func (s *SubscriptionServiceSuite) TestCreateSubscriptionWithCheckout_GroupedChildrenAreCreatedDraft() {


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Billing**
  - Subscription invoices now reflect the relevant billing event, including creation, recurring cycles, and cancellation-related proration.
  - Advance-charge invoices use the current billing period consistently across the invoice and its line items.

- **Bug Fixes**
  - Subscription-creation invoices remain in draft until payment or explicit processing, rather than being automatically finalized.
  - Completed recurring-cycle invoices can be finalized after their billing period ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->