### PR TITLE
fix(invoice): Merging line items missing fields

### DIFF
--- a/internal/ee/service/billing.go
+++ b/internal/ee/service/billing.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/flexprice/flexprice/internal/api/dto"
@@ -465,21 +464,21 @@ func mergeLineItemsByBillingPeriod(items []dto.CreateInvoiceLineItemRequest) []d
 func mergeIntoLineItem(target, addition dto.CreateInvoiceLineItemRequest) dto.CreateInvoiceLineItemRequest {
 	target.Amount = target.Amount.Add(addition.Amount)
 
-	// A fixed charge repeats the same quantity every window (5 seats each month),
-	// so summing it would report 15 seats for a 5-seat subscription.
-	if isUsageLineItem(target) {
-		target.Quantity = target.Quantity.Add(addition.Quantity)
-		if target.AdjustedEntitlementQuantity != nil || addition.AdjustedEntitlementQuantity != nil {
-			target.AdjustedEntitlementQuantity = lo.ToPtr(
-				lo.FromPtr(target.AdjustedEntitlementQuantity).Add(lo.FromPtr(addition.AdjustedEntitlementQuantity)))
-		}
-	}
+	// Summed for fixed charges too, so amount / quantity stays the unit price:
+	// 5 seats over 3 months is 15 seat-months at $20, not 5 seats at $60.
+	target.Quantity = target.Quantity.Add(addition.Quantity)
+
+	target.AdjustedEntitlementQuantity = types.AddDecimalPtr(target.AdjustedEntitlementQuantity, addition.AdjustedEntitlementQuantity)
 
 	// PriceUnitAmount is the line's total converted into the price unit currency,
 	// not a per-unit rate, so it tracks Amount.
-	if target.PriceUnitAmount != nil || addition.PriceUnitAmount != nil {
-		target.PriceUnitAmount = lo.ToPtr(lo.FromPtr(target.PriceUnitAmount).Add(lo.FromPtr(addition.PriceUnitAmount)))
-	}
+	target.PriceUnitAmount = types.AddDecimalPtr(target.PriceUnitAmount, addition.PriceUnitAmount)
+
+	// Every other per-window money field, or the later windows' values are lost.
+	target.PrepaidCreditsApplied = types.AddDecimalPtr(target.PrepaidCreditsApplied, addition.PrepaidCreditsApplied)
+	target.LineItemDiscount = types.AddDecimalPtr(target.LineItemDiscount, addition.LineItemDiscount)
+	target.InvoiceLevelDiscount = types.AddDecimalPtr(target.InvoiceLevelDiscount, addition.InvoiceLevelDiscount)
+	target.CommitmentInfo = mergeCommitmentInfo(target.CommitmentInfo, addition.CommitmentInfo)
 
 	target.PeriodStart = types.EarliestOfPtr(target.PeriodStart, addition.PeriodStart)
 	target.PeriodEnd = types.LatestOfPtr(target.PeriodEnd, addition.PeriodEnd)
@@ -487,8 +486,23 @@ func mergeIntoLineItem(target, addition dto.CreateInvoiceLineItemRequest) dto.Cr
 	return target
 }
 
-func isUsageLineItem(item dto.CreateInvoiceLineItemRequest) bool {
-	return strings.EqualFold(lo.FromPtr(item.PriceType), string(types.PRICE_TYPE_USAGE))
+// mergeCommitmentInfo sums the computed amounts across windows. The remaining
+// fields are configuration echoed from the subscription line item — identical on
+// every window — so they carry over from the first. Returns a new value: the
+// inputs belong to the caller's line items.
+func mergeCommitmentInfo(target, addition *types.CommitmentInfo) *types.CommitmentInfo {
+	if target == nil {
+		return addition
+	}
+	if addition == nil {
+		return target
+	}
+
+	merged := *target
+	merged.ComputedCommitmentUtilizedAmount = target.ComputedCommitmentUtilizedAmount.Add(addition.ComputedCommitmentUtilizedAmount)
+	merged.ComputedOverageAmount = target.ComputedOverageAmount.Add(addition.ComputedOverageAmount)
+	merged.ComputedTrueUpAmount = target.ComputedTrueUpAmount.Add(addition.ComputedTrueUpAmount)
+	return &merged
 }
 
 // applyLineItemGrouping merges per-charge-period rows when the subscription opts in.

--- a/internal/ee/service/billing_test.go
+++ b/internal/ee/service/billing_test.go
@@ -5736,8 +5736,9 @@ func (s *BillingServiceSuite) TestMergeLineItemsByBillingPeriod_PreservesTotal()
 	s.True(groupingSumAmounts(got).Equal(want), "total after merge = %s, want %s (merge must be presentational)", groupingSumAmounts(got), want)
 }
 
-// A fixed charge repeats the same quantity each window, so summing would report 15 seats.
-func (s *BillingServiceSuite) TestMergeLineItemsByBillingPeriod_FixedKeepsQuantity() {
+// Quantity sums for fixed charges too, so amount / quantity stays the unit price:
+// 5 seats billed for 3 months at $20 is 15 seat-months, not 5 seats at $60.
+func (s *BillingServiceSuite) TestMergeLineItemsByBillingPeriod_FixedSumsQuantity() {
 	in := []dto.CreateInvoiceLineItemRequest{
 		groupingLine("sli_seat", "price_seat", "Seats", types.PRICE_TYPE_FIXED, "100", "5", groupingQ1Start, groupingFebStar),
 		groupingLine("sli_seat", "price_seat", "Seats", types.PRICE_TYPE_FIXED, "100", "5", groupingFebStar, groupingMarStar),
@@ -5748,7 +5749,10 @@ func (s *BillingServiceSuite) TestMergeLineItemsByBillingPeriod_FixedKeepsQuanti
 
 	s.Require().Len(got, 1)
 	s.True(got[0].Amount.Equal(decimal.RequireFromString("300")), "amount = %s, want 300", got[0].Amount)
-	s.True(got[0].Quantity.Equal(decimal.RequireFromString("5")), "quantity = %s, want 5 (fixed quantity must not be summed)", got[0].Quantity)
+	s.True(got[0].Quantity.Equal(decimal.RequireFromString("15")), "quantity = %s, want 15 (3 windows x 5 seats)", got[0].Quantity)
+
+	unitPrice := got[0].Amount.Div(got[0].Quantity)
+	s.True(unitPrice.Equal(decimal.RequireFromString("20")), "amount/quantity = %s, want the $20 unit price", unitPrice)
 }
 
 func (s *BillingServiceSuite) TestMergeLineItemsByBillingPeriod_KeepsOverageSeparate() {
@@ -5836,4 +5840,69 @@ func (s *BillingServiceSuite) TestApplyLineItemGrouping_DoesNotMutateInput() {
 
 	s.Len(result.FixedCharges, 3, "caller's result was mutated")
 	s.Len(result.UsageCharges, 3, "caller's result was mutated")
+}
+
+// Every monetary field on a line item is per-window and must survive the merge.
+// Taking only the first window's values silently drops the rest.
+func (s *BillingServiceSuite) TestMergeLineItemsByBillingPeriod_SumsAllMonetaryFields() {
+	window := func(utilized, overage, trueUp, prepaid, lineDisc, invDisc string) dto.CreateInvoiceLineItemRequest {
+		li := groupingLine("sli_api", "price_api", "API calls", types.PRICE_TYPE_USAGE, "10", "100", groupingQ1Start, groupingFebStar)
+		li.CommitmentInfo = &types.CommitmentInfo{
+			Type:                             types.COMMITMENT_TYPE_AMOUNT,
+			Amount:                           decimal.RequireFromString("500"),
+			OverageFactor:                    lo.ToPtr(decimal.RequireFromString("2")),
+			TrueUpEnabled:                    true,
+			ComputedCommitmentUtilizedAmount: decimal.RequireFromString(utilized),
+			ComputedOverageAmount:            decimal.RequireFromString(overage),
+			ComputedTrueUpAmount:             decimal.RequireFromString(trueUp),
+		}
+		li.PrepaidCreditsApplied = lo.ToPtr(decimal.RequireFromString(prepaid))
+		li.LineItemDiscount = lo.ToPtr(decimal.RequireFromString(lineDisc))
+		li.InvoiceLevelDiscount = lo.ToPtr(decimal.RequireFromString(invDisc))
+		return li
+	}
+
+	in := []dto.CreateInvoiceLineItemRequest{
+		window("100", "10", "1", "3", "0.50", "0.25"),
+		window("200", "20", "2", "4", "1.50", "0.75"),
+	}
+
+	got := mergeLineItemsByBillingPeriod(in)
+	s.Require().Len(got, 1)
+	m := got[0]
+
+	s.Require().NotNil(m.CommitmentInfo)
+	s.True(m.CommitmentInfo.ComputedCommitmentUtilizedAmount.Equal(decimal.RequireFromString("300")),
+		"utilized = %s, want 300", m.CommitmentInfo.ComputedCommitmentUtilizedAmount)
+	s.True(m.CommitmentInfo.ComputedOverageAmount.Equal(decimal.RequireFromString("30")),
+		"overage = %s, want 30", m.CommitmentInfo.ComputedOverageAmount)
+	s.True(m.CommitmentInfo.ComputedTrueUpAmount.Equal(decimal.RequireFromString("3")),
+		"true-up = %s, want 3", m.CommitmentInfo.ComputedTrueUpAmount)
+
+	// Configuration echoed from the subscription line item is identical on every
+	// window, so it carries over rather than accumulating.
+	s.Equal(types.COMMITMENT_TYPE_AMOUNT, m.CommitmentInfo.Type)
+	s.True(m.CommitmentInfo.Amount.Equal(decimal.RequireFromString("500")),
+		"commitment amount = %s, want 500 (config, not summed)", m.CommitmentInfo.Amount)
+	s.True(m.CommitmentInfo.TrueUpEnabled)
+
+	s.True(lo.FromPtr(m.PrepaidCreditsApplied).Equal(decimal.RequireFromString("7")),
+		"prepaid credits = %s, want 7", lo.FromPtr(m.PrepaidCreditsApplied))
+	s.True(lo.FromPtr(m.LineItemDiscount).Equal(decimal.RequireFromString("2")),
+		"line item discount = %s, want 2", lo.FromPtr(m.LineItemDiscount))
+	s.True(lo.FromPtr(m.InvoiceLevelDiscount).Equal(decimal.RequireFromString("1")),
+		"invoice level discount = %s, want 1", lo.FromPtr(m.InvoiceLevelDiscount))
+}
+
+// The merge must not write through the pointer the caller still holds.
+func (s *BillingServiceSuite) TestMergeLineItemsByBillingPeriod_DoesNotMutateSourceCommitmentInfo() {
+	first := groupingLine("sli_api", "price_api", "API calls", types.PRICE_TYPE_USAGE, "10", "100", groupingQ1Start, groupingFebStar)
+	first.CommitmentInfo = &types.CommitmentInfo{ComputedOverageAmount: decimal.RequireFromString("10")}
+	second := groupingLine("sli_api", "price_api", "API calls", types.PRICE_TYPE_USAGE, "10", "100", groupingFebStar, groupingMarStar)
+	second.CommitmentInfo = &types.CommitmentInfo{ComputedOverageAmount: decimal.RequireFromString("20")}
+
+	_ = mergeLineItemsByBillingPeriod([]dto.CreateInvoiceLineItemRequest{first, second})
+
+	s.True(first.CommitmentInfo.ComputedOverageAmount.Equal(decimal.RequireFromString("10")),
+		"source commitment info was mutated: %s", first.CommitmentInfo.ComputedOverageAmount)
 }

--- a/internal/ee/service/subscription_create_test.go
+++ b/internal/ee/service/subscription_create_test.go
@@ -1324,10 +1324,13 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_LineItemGroupingEndToE
 		name          string
 		grouping      types.LineItemGrouping
 		wantLineItems int
+		// Quantity on each emitted row. A merged row carries the sum, so
+		// amount / quantity still reads as the $100 monthly unit price.
+		wantQuantityEach string
 	}{
-		{"per charge period bills each month", types.LineItemGroupingPerChargePeriod, 3},
-		{"per billing period bills the quarter once", types.LineItemGroupingPerBillingPeriod, 1},
-		{"omitted keeps the per charge period default", types.LineItemGrouping(""), 3},
+		{"per charge period bills each month", types.LineItemGroupingPerChargePeriod, 3, "1"},
+		{"per billing period bills the quarter once", types.LineItemGroupingPerBillingPeriod, 1, "3"},
+		{"omitted keeps the per charge period default", types.LineItemGrouping(""), 3, "1"},
 	}
 
 	for i, tt := range tests {
@@ -1354,9 +1357,17 @@ func (s *SubscriptionServiceSuite) TestCreateSubscription_LineItemGroupingEndToE
 			inv, err := s.GetStores().InvoiceRepo.Get(ctx, invoices[0].ID)
 			s.Require().NoError(err)
 
-			s.Len(inv.LineItems, tt.wantLineItems)
+			s.Require().Len(inv.LineItems, tt.wantLineItems)
 			s.True(inv.AmountDue.Equal(decimal.NewFromInt(300)),
 				"invoice total = %s, want 300 under either grouping", inv.AmountDue)
+
+			wantQty := decimal.RequireFromString(tt.wantQuantityEach)
+			for _, li := range inv.LineItems {
+				s.True(li.Quantity.Equal(wantQty), "line item quantity = %s, want %s", li.Quantity, wantQty)
+				unitPrice := li.Amount.Div(li.Quantity)
+				s.True(unitPrice.Equal(decimal.NewFromInt(100)),
+					"amount/quantity = %s, want the 100 monthly unit price", unitPrice)
+			}
 		})
 	}
 }

--- a/internal/types/math.go
+++ b/internal/types/math.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+// AddDecimalPtr sums two optional decimals. A nil side contributes nothing;
+// two nils stay nil so an unset field is not turned into an explicit zero.
+func AddDecimalPtr(a, b *decimal.Decimal) *decimal.Decimal {
+	if a == nil && b == nil {
+		return nil
+	}
+	return lo.ToPtr(lo.FromPtr(a).Add(lo.FromPtr(b)))
+}

--- a/internal/types/math_test.go
+++ b/internal/types/math_test.go
@@ -1,0 +1,36 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/shopspring/decimal"
+)
+
+func TestAddDecimalPtr(t *testing.T) {
+	five := decimal.RequireFromString("5")
+	seven := decimal.RequireFromString("7.25")
+
+	tests := []struct {
+		name string
+		a, b *decimal.Decimal
+		want *decimal.Decimal
+	}{
+		{"both set", &five, &seven, lo.ToPtr(decimal.RequireFromString("12.25"))},
+		{"a nil", nil, &seven, &seven},
+		{"b nil", &five, nil, &five},
+		{"both nil stays nil", nil, nil, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AddDecimalPtr(tt.a, tt.b)
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("AddDecimalPtr nil-ness = %v, want %v", got, tt.want)
+			}
+			if got != nil && !got.Equal(*tt.want) {
+				t.Errorf("AddDecimalPtr = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invoice line items now correctly combine quantities across billing windows, including fixed-charge items.
  - Billing totals more accurately include prepaid credits, line-item discounts, invoice-level discounts, and commitment amounts.
  - Merged invoice lines preserve consistent unit pricing and commitment settings while aggregating applicable amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->