### PR TITLE
fix(subscriptions): Line item date check for subs cancellation

### DIFF
--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -5631,13 +5631,17 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 		"entity_ids_filter", addonIDList,
 		"line_items_found", len(allLineItems))
 
-	deleteReq := dto.DeleteSubscriptionLineItemRequest{EffectiveFrom: &effectiveDate}
 	terminated := 0
 	for _, lineItem := range allLineItems {
 		if !lineItem.EndDate.IsZero() {
 			continue
 		}
 
+		termFrom := effectiveDate
+		if lineItem.StartDate.After(effectiveDate) {
+			termFrom = lineItem.StartDate
+		}
+		deleteReq := dto.DeleteSubscriptionLineItemRequest{EffectiveFrom: &termFrom}
 		if _, err := s.deleteSubscriptionLineItem(ctx, lineItem.ID, deleteReq); err != nil {
 			logger.Error(ctx, "failed to terminate addon line item",
 				"line_item_id", lineItem.ID,

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -3218,6 +3218,106 @@ func (s *SubscriptionServiceSuite) TestCancelSubscription() {
 		}
 	})
 
+	s.Run("TestCancelSubscriptionWithFutureStartAddon", func() {
+		ctx := s.GetContext()
+		subService := s.service.(*subscriptionService)
+
+		subWithAddon := &subscription.Subscription{
+			ID:                 "sub_cancel_future_start_addon",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
+			CurrentPeriodEnd:   s.testData.now.Add(6 * 24 * time.Hour),
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+			LineItems:          []*subscription.SubscriptionLineItem{},
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, subWithAddon, subWithAddon.LineItems))
+
+		addonID := "addon_cancel_future_start"
+		a := &addon.Addon{
+			ID:        addonID,
+			LookupKey: addonID,
+			Name:      "Future-start addon",
+			BaseModel: types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(subService.AddonRepo.Create(ctx, a))
+		s.NoError(s.GetStores().PriceRepo.Create(ctx, &price.Price{
+			ID:                 "price_addon_cancel_future_start",
+			Amount:             decimal.Zero,
+			Currency:           "usd",
+			EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+			EntityID:           addonID,
+			Type:               types.PRICE_TYPE_USAGE,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+			InvoiceCadence:     types.InvoiceCadenceArrear,
+			MeterID:            s.testData.meters.apiCalls.ID,
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}))
+
+		attachAt := time.Now().UTC()
+		_, err := s.service.AddAddonToSubscription(ctx, &dto.AddAddonRequest{
+			SubscriptionID: subWithAddon.ID,
+			AddAddonToSubscriptionRequest: dto.AddAddonToSubscriptionRequest{
+				AddonID:   addonID,
+				StartDate: &attachAt,
+			},
+		})
+		s.NoError(err)
+
+		// Association is already active; line item start is still in the future
+		// (catalog price start / trial end).
+		liFilterPre := types.NewNoLimitSubscriptionLineItemFilter()
+		liFilterPre.SubscriptionIDs = []string{subWithAddon.ID}
+		liFilterPre.EntityIDs = []string{addonID}
+		liFilterPre.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+		preItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilterPre)
+		s.NoError(err)
+		s.NotEmpty(preItems)
+		futureStart := attachAt.Add(7 * 24 * time.Hour)
+		for _, li := range preItems {
+			li.StartDate = futureStart
+			s.NoError(s.GetStores().SubscriptionLineItemRepo.Update(ctx, li))
+		}
+
+		resp, err := s.service.CancelSubscription(ctx, subWithAddon.ID, &dto.CancelSubscriptionRequest{
+			CancellationType:  types.CancellationTypeImmediate,
+			ProrationBehavior: types.ProrationBehaviorNone,
+			Reason:            "test_cancel_future_start_addon",
+		})
+		s.Require().NoError(err)
+		s.Equal(types.SubscriptionStatusCancelled, resp.Status)
+
+		aaFilter := types.NewNoLimitAddonAssociationFilter()
+		aaFilter.EntityIDs = []string{subWithAddon.ID}
+		aaFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+		associations, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
+		s.NoError(err)
+		s.NotEmpty(associations)
+		for _, aa := range associations {
+			s.Equal(types.AddonStatusCancelled, aa.AddonStatus)
+			s.NotNil(aa.EndDate)
+		}
+
+		liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+		liFilter.SubscriptionIDs = []string{subWithAddon.ID}
+		liFilter.EntityIDs = []string{addonID}
+		liFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+		lineItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+		s.NoError(err)
+		s.NotEmpty(lineItems)
+		for _, li := range lineItems {
+			s.False(li.EndDate.IsZero(), "unstarted addon line item must still be closed")
+			s.False(li.EndDate.Before(li.StartDate), "end_date must not precede start_date")
+		}
+	})
+
 	s.Run("TestCancelAtPeriodEnd", func() {
 		// Create an active subscription for period end cancel test
 		periodEndSub := &subscription.Subscription{

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -370,6 +370,7 @@ func (r *subscriptionLineItemRepository) BulkTerminate(ctx context.Context, subs
 			subscriptionlineitem.TenantID(types.GetTenantID(ctx)),
 			subscriptionlineitem.EnvironmentID(types.GetEnvironmentID(ctx)),
 			subscriptionlineitem.SubscriptionID(subscriptionID),
+			subscriptionlineitem.StartDateLTE(effectiveDate),
 			subscriptionlineitem.Or(
 				subscriptionlineitem.EndDateIsNil(),
 				subscriptionlineitem.EndDateGT(effectiveDate),

--- a/internal/testutil/inmemory_subscription_line_item_store.go
+++ b/internal/testutil/inmemory_subscription_line_item_store.go
@@ -224,6 +224,9 @@ func (s *InMemorySubscriptionLineItemStore) BulkTerminate(ctx context.Context, s
 
 	affected := 0
 	for _, item := range items {
+		if !item.StartDate.IsZero() && item.StartDate.After(effectiveDate) {
+			continue
+		}
 		if !item.EndDate.IsZero() && item.EndDate.Before(effectiveDate) {
 			continue
 		}


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed subscription cancellations involving add-ons scheduled to start in the future.
  - Future-dated add-on line items are no longer terminated before their start date.
  - Ensured cancelled add-ons receive valid termination dates and cancellation completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->