### PR TITLE
fix(paddle,e2e,integrations): Rzp customer create idempotent + paddle 5xx on not found + Tax e2e probe fixes

### DIFF
--- a/internal/api/v1/webhook.go
+++ b/internal/api/v1/webhook.go
@@ -1219,10 +1219,15 @@ func (h *WebhookHandler) HandlePaddleWebhook(c *gin.Context) {
 	ctx = types.SetEnvironmentID(ctx, environmentID)
 	c.Request = c.Request.WithContext(ctx)
 
-	// Get Paddle integration
 	paddleIntegration, err := h.integrationFactory.GetPaddleIntegration(ctx)
 	if err != nil {
-		h.logger.Error(context.Background(), "failed to get Paddle integration", "error", err)
+		if ierr.IsNotFound(err) {
+			h.logger.Info(ctx, "Paddle connection not configured, ignoring webhook",
+				"tenant_id", tenantID,
+				"environment_id", environmentID)
+			return
+		}
+		h.logger.Error(ctx, "failed to get Paddle integration", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid configuration"})
 		handled = true
 		return

--- a/internal/api/v1/webhook_paddle_test.go
+++ b/internal/api/v1/webhook_paddle_test.go
@@ -1,0 +1,119 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/domain/connection"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/integration"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/security"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type connectionRepoGetByProviderErr struct {
+	*testutil.InMemoryConnectionStore
+	err error
+}
+
+func (s *connectionRepoGetByProviderErr) GetByProvider(_ context.Context, _ types.SecretProvider) (*connection.Connection, error) {
+	return nil, s.err
+}
+
+func setupPaddleWebhookHandler(t *testing.T, connRepo connection.Repository) *WebhookHandler {
+	t.Helper()
+
+	cfg := &config.Configuration{
+		Logging: config.LoggingConfig{Level: types.LogLevelInfo},
+		Secrets: config.SecretsConfig{EncryptionKey: testutil.NewEncryptionKey()},
+	}
+	log, err := logger.NewLogger(cfg)
+	require.NoError(t, err)
+
+	encryptionSvc, err := security.NewEncryptionService(cfg, log)
+	require.NoError(t, err)
+
+	if connRepo == nil {
+		connRepo = testutil.NewInMemoryConnectionStore()
+	}
+
+	factory := integration.NewFactory(
+		cfg,
+		log,
+		connRepo,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		encryptionSvc,
+		nil,
+		testutil.NewInMemoryRedisLocker(nil),
+	)
+
+	return NewWebhookHandler(
+		cfg,
+		nil,
+		log,
+		factory,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func paddleWebhookRequest(t *testing.T, handler *WebhookHandler) *httptest.ResponseRecorder {
+	t.Helper()
+
+	router := gin.New()
+	router.POST("/v1/webhooks/paddle/:tenant_id/:environment_id", handler.HandlePaddleWebhook)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/paddle/tenant_test/env_test",
+		strings.NewReader(`{"event_type":"transaction.completed"}`))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandlePaddleWebhook_NoConnection_ReturnsOK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	w := paddleWebhookRequest(t, setupPaddleWebhookHandler(t, nil))
+
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHandlePaddleWebhook_ConnectionLookupFailure_Returns500(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := &connectionRepoGetByProviderErr{
+		InMemoryConnectionStore: testutil.NewInMemoryConnectionStore(),
+		err: ierr.NewError("connection to database lost").
+			WithHint("Transient database failure").
+			Mark(ierr.ErrDatabase),
+	}
+
+	w := paddleWebhookRequest(t, setupPaddleWebhookHandler(t, repo))
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/ee/e2eprobe/checks/fakeclient_test.go
+++ b/internal/ee/e2eprobe/checks/fakeclient_test.go
@@ -603,6 +603,8 @@ type fakeInvoices struct {
 	queries    int
 	queryErr   error
 	invoices   []types.InvoiceResponse
+	getByID    map[string]types.InvoiceResponse
+	getErr     error
 	lastFilter types.InvoiceFilter
 	// Preview support
 	previewResp   *dtos.GetInvoicePreviewResponse // default response
@@ -626,7 +628,24 @@ func (f *fakeInvoices) Query(_ context.Context, filter types.InvoiceFilter) (*dt
 		ListInvoicesResponse: &types.ListInvoicesResponse{Items: f.invoices},
 	}, nil
 }
-func (f *fakeInvoices) Get(_ context.Context, _ string) (*dtos.GetInvoiceResponse, error) {
+func (f *fakeInvoices) Get(_ context.Context, id string) (*dtos.GetInvoiceResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.getByID != nil {
+		if inv, ok := f.getByID[id]; ok {
+			cp := inv
+			return &dtos.GetInvoiceResponse{InvoiceResponse: &cp}, nil
+		}
+	}
+	for i := range f.invoices {
+		if f.invoices[i].ID != nil && *f.invoices[i].ID == id {
+			inv := f.invoices[i]
+			return &dtos.GetInvoiceResponse{InvoiceResponse: &inv}, nil
+		}
+	}
 	return &dtos.GetInvoiceResponse{}, nil
 }
 func (f *fakeInvoices) GetPreview(_ context.Context, req types.GetPreviewInvoiceRequest) (*dtos.GetInvoicePreviewResponse, error) {

--- a/internal/ee/e2eprobe/checks/persistent_billing_invariants_probe.go
+++ b/internal/ee/e2eprobe/checks/persistent_billing_invariants_probe.go
@@ -47,7 +47,7 @@ func (p *persistentBillingInvariantsProbe) Run(ctx context.Context) error {
 		cust0 := seeds.PersistentCustomerIDs[0]
 		inv, err := p.latestInvoice(ctx, cust0)
 		if err != nil {
-			return e2eprobe.Errorf(map[string]string{"step": "query_invoice_cust0", "external_customer_id": cust0}, "query invoice: %w", err)
+			return e2eprobe.Errorf(map[string]string{"step": "load_invoice_cust0", "external_customer_id": cust0}, "load invoice: %w", err)
 		}
 		if inv != nil {
 			if !invoiceHasTaxRate(inv, seeds.SharedTaxRateID, seeds.SharedTaxRateCode) {
@@ -61,7 +61,7 @@ func (p *persistentBillingInvariantsProbe) Run(ctx context.Context) error {
 		cust1 := seeds.PersistentCustomerIDs[1]
 		inv, err := p.latestInvoice(ctx, cust1)
 		if err != nil {
-			return e2eprobe.Errorf(map[string]string{"step": "query_invoice_cust1", "external_customer_id": cust1}, "query invoice: %w", err)
+			return e2eprobe.Errorf(map[string]string{"step": "load_invoice_cust1", "external_customer_id": cust1}, "load invoice: %w", err)
 		}
 		if inv != nil {
 			if !invoiceHasCoupon(inv, seeds.SharedCouponID) {
@@ -74,8 +74,10 @@ func (p *persistentBillingInvariantsProbe) Run(ctx context.Context) error {
 
 func (p *persistentBillingInvariantsProbe) latestInvoice(ctx context.Context, extID string) (*types.InvoiceResponse, error) {
 	limit := int64(1)
+	invType := types.InvoiceTypeSubscription
 	resp, err := p.client.Invoices().Query(ctx, types.InvoiceFilter{
 		ExternalCustomerID: &extID,
+		InvoiceType:        &invType,
 		Limit:              &limit,
 	})
 	if err != nil {
@@ -84,8 +86,20 @@ func (p *persistentBillingInvariantsProbe) latestInvoice(ctx context.Context, ex
 	if resp.ListInvoicesResponse == nil || len(resp.ListInvoicesResponse.Items) == 0 {
 		return nil, nil // no invoice yet — soft skip at caller
 	}
-	inv := resp.ListInvoicesResponse.Items[0]
-	return &inv, nil
+	listed := resp.ListInvoicesResponse.Items[0]
+	if listed.ID == nil || *listed.ID == "" {
+		return nil, nil
+	}
+
+	// Search/list never expands tax_applied; only GET attaches Taxes.
+	got, err := p.client.Invoices().Get(ctx, *listed.ID)
+	if err != nil {
+		return nil, err
+	}
+	if got == nil || got.InvoiceResponse == nil {
+		return nil, nil
+	}
+	return got.InvoiceResponse, nil
 }
 
 func invoiceHasTaxRate(inv *types.InvoiceResponse, taxRateID, taxRateCode string) bool {

--- a/internal/ee/e2eprobe/checks/persistent_billing_invariants_probe_test.go
+++ b/internal/ee/e2eprobe/checks/persistent_billing_invariants_probe_test.go
@@ -21,6 +21,35 @@ func pbiSeeds() e2eprobe.Seeds {
 	}
 }
 
+func TestPersistentBillingInvariantsProbe_ListOmitsTaxesUsesGet(t *testing.T) {
+	fc := newFakeClient()
+	reg := e2eprobe.NewRegistry()
+	reg.LoadSeeds(pbiSeeds())
+	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
+
+	// Production shape: POST /invoices/search does not expand tax_applied, so
+	// the list row has an ID and empty Taxes. GET /invoices/{id} loads them.
+	invID := "inv_tax_1"
+	trID := "taxrate_1"
+	couponID := "coupon_1"
+	fc.invoices.invoices = []sdktypes.InvoiceResponse{{ID: &invID}}
+	fc.invoices.getByID = map[string]sdktypes.InvoiceResponse{
+		invID: {
+			ID:                 &invID,
+			Taxes:              []sdktypes.TaxAppliedResponse{{TaxRateID: &trID}},
+			CouponApplications: []sdktypes.CouponApplicationResponse{{CouponID: &couponID}},
+		},
+	}
+
+	p := NewPersistentBillingInvariantsProbe(fc, reg, "test-run", lg)
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("list-without-taxes + get-with-taxes must pass; got %v", err)
+	}
+	if fc.invoices.lastFilter.InvoiceType == nil || *fc.invoices.lastFilter.InvoiceType != sdktypes.InvoiceTypeSubscription {
+		t.Fatalf("Query must filter InvoiceType=SUBSCRIPTION so wallet ONE_OFF invoices are ignored")
+	}
+}
+
 func TestPersistentBillingInvariantsProbe_HappyPath(t *testing.T) {
 	fc := newFakeClient()
 	reg := e2eprobe.NewRegistry()
@@ -28,10 +57,11 @@ func TestPersistentBillingInvariantsProbe_HappyPath(t *testing.T) {
 	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
 
 	// Both custs have an invoice: cust #0 has the tax, cust #1 has the coupon.
+	invID := "inv_1"
 	trID := "taxrate_1"
 	couponID := "coupon_1"
 	fc.invoices.invoices = []sdktypes.InvoiceResponse{
-		{Taxes: []sdktypes.TaxAppliedResponse{{TaxRateID: &trID}}, CouponApplications: []sdktypes.CouponApplicationResponse{{CouponID: &couponID}}},
+		{ID: &invID, Taxes: []sdktypes.TaxAppliedResponse{{TaxRateID: &trID}}, CouponApplications: []sdktypes.CouponApplicationResponse{{CouponID: &couponID}}},
 	}
 
 	p := NewPersistentBillingInvariantsProbe(fc, reg, "test-run", lg)
@@ -60,9 +90,10 @@ func TestPersistentBillingInvariantsProbe_MissingTaxFails(t *testing.T) {
 	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
 
 	// Invoice has coupon but NOT the tax — expected step=assert_tax_present_cust0.
+	invID := "inv_1"
 	couponID := "coupon_1"
 	fc.invoices.invoices = []sdktypes.InvoiceResponse{
-		{CouponApplications: []sdktypes.CouponApplicationResponse{{CouponID: &couponID}}},
+		{ID: &invID, CouponApplications: []sdktypes.CouponApplicationResponse{{CouponID: &couponID}}},
 	}
 
 	p := NewPersistentBillingInvariantsProbe(fc, reg, "test-run", lg)
@@ -78,9 +109,10 @@ func TestPersistentBillingInvariantsProbe_MissingCouponFails(t *testing.T) {
 	lg, _ := logger.NewLogger(&config.Configuration{Logging: config.LoggingConfig{Level: itypes.LogLevelInfo}})
 
 	// Invoice has tax but NOT the coupon — expected step=assert_coupon_present_cust1.
+	invID := "inv_1"
 	trID := "taxrate_1"
 	fc.invoices.invoices = []sdktypes.InvoiceResponse{
-		{Taxes: []sdktypes.TaxAppliedResponse{{TaxRateID: &trID}}},
+		{ID: &invID, Taxes: []sdktypes.TaxAppliedResponse{{TaxRateID: &trID}}},
 	}
 
 	p := NewPersistentBillingInvariantsProbe(fc, reg, "test-run", lg)

--- a/internal/integration/razorpay/client.go
+++ b/internal/integration/razorpay/client.go
@@ -252,10 +252,15 @@ func (c *Client) CreateCustomer(ctx context.Context, customerData map[string]int
 			Mark(ierr.ErrInternal)
 	}
 
+	if customerData == nil {
+		customerData = map[string]interface{}{}
+	}
+	customerData["fail_existing"] = "0"
+
 	razorpayCustomer, err := razorpayClient.Customer.Create(customerData, nil)
 	if err != nil {
 		c.logger.Error(ctx, "failed to create customer in Razorpay", "error", err)
-		return nil, ierr.NewError("failed to create customer in Razorpay").
+		return nil, ierr.WithError(err).
 			WithHint("Unable to create customer in Razorpay").
 			WithReportableDetails(map[string]interface{}{
 				"error": err.Error(),

--- a/internal/integration/razorpay/client.go
+++ b/internal/integration/razorpay/client.go
@@ -242,6 +242,15 @@ func (c *Client) GetConnection(ctx context.Context) (*connection.Connection, err
 	return conn, nil
 }
 
+func applyCustomerCreateIdempotency(customerData map[string]interface{}) map[string]interface{} {
+	if customerData == nil {
+		customerData = map[string]interface{}{}
+	}
+	
+	customerData["fail_existing"] = "0"
+	return customerData
+}
+
 // CreateCustomer creates a customer in Razorpay
 func (c *Client) CreateCustomer(ctx context.Context, customerData map[string]interface{}) (map[string]interface{}, error) {
 	razorpayClient, _, err := c.GetRazorpaySDKClient(ctx)
@@ -252,10 +261,7 @@ func (c *Client) CreateCustomer(ctx context.Context, customerData map[string]int
 			Mark(ierr.ErrInternal)
 	}
 
-	if customerData == nil {
-		customerData = map[string]interface{}{}
-	}
-	customerData["fail_existing"] = "0"
+	customerData = applyCustomerCreateIdempotency(customerData)
 
 	razorpayCustomer, err := razorpayClient.Customer.Create(customerData, nil)
 	if err != nil {

--- a/internal/integration/razorpay/customer.go
+++ b/internal/integration/razorpay/customer.go
@@ -186,7 +186,6 @@ func (s *CustomerService) SyncCustomerToRazorpay(ctx context.Context, flexpriceC
 	s.logger.Info(ctx, "creating customer in Razorpay",
 		"customer_id", flexpriceCustomer.ID)
 
-	// Create customer in Razorpay using wrapper function
 	razorpayCustomer, err := s.client.CreateCustomer(ctx, customerData)
 	if err != nil {
 		s.logger.Error(ctx, "failed to create customer in Razorpay",

--- a/internal/integration/razorpay/customer_sync_test.go
+++ b/internal/integration/razorpay/customer_sync_test.go
@@ -1,0 +1,103 @@
+package razorpay
+
+import (
+	"context"
+	"testing"
+
+	domainCustomer "github.com/flexprice/flexprice/internal/domain/customer"
+	"github.com/flexprice/flexprice/internal/domain/entityintegrationmapping"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubCustomerClient struct {
+	RazorpayClient
+	createErr    error
+	createResult map[string]interface{}
+}
+
+func (c *stubCustomerClient) CreateCustomer(_ context.Context, _ map[string]interface{}) (map[string]interface{}, error) {
+	return c.createResult, c.createErr
+}
+
+type inlineMappingStore struct {
+	created []*entityintegrationmapping.EntityIntegrationMapping
+}
+
+func (s *inlineMappingStore) Create(_ context.Context, m *entityintegrationmapping.EntityIntegrationMapping) error {
+	s.created = append(s.created, m)
+	return nil
+}
+func (s *inlineMappingStore) Get(_ context.Context, _ string) (*entityintegrationmapping.EntityIntegrationMapping, error) {
+	return nil, ierr.NewError("not found").Mark(ierr.ErrNotFound)
+}
+func (s *inlineMappingStore) List(_ context.Context, _ *types.EntityIntegrationMappingFilter) ([]*entityintegrationmapping.EntityIntegrationMapping, error) {
+	return nil, nil
+}
+func (s *inlineMappingStore) Count(_ context.Context, _ *types.EntityIntegrationMappingFilter) (int, error) {
+	return 0, nil
+}
+func (s *inlineMappingStore) Update(_ context.Context, _ *entityintegrationmapping.EntityIntegrationMapping) error {
+	return nil
+}
+func (s *inlineMappingStore) Delete(_ context.Context, _ *entityintegrationmapping.EntityIntegrationMapping) error {
+	return nil
+}
+
+func newSyncService(client RazorpayClient, store entityintegrationmapping.Repository) *CustomerService {
+	return &CustomerService{
+		client:                       client,
+		entityIntegrationMappingRepo: store,
+		logger:                       logger.NewNoopLogger(),
+	}
+}
+
+func TestApplyCustomerCreateIdempotency(t *testing.T) {
+	got := applyCustomerCreateIdempotency(map[string]interface{}{"email": "ada@example.com"})
+	assert.Equal(t, "0", got["fail_existing"])
+	assert.Equal(t, "ada@example.com", got["email"])
+
+	got = applyCustomerCreateIdempotency(nil)
+	require.NotNil(t, got)
+	assert.Equal(t, "0", got["fail_existing"])
+}
+
+func TestSyncCustomerToRazorpay_StoresMappingFromCreateResponse(t *testing.T) {
+	ctx := context.Background()
+	client := &stubCustomerClient{
+		createResult: map[string]interface{}{"id": "cust_existing_rp"},
+	}
+	store := &inlineMappingStore{}
+	svc := newSyncService(client, store)
+
+	id, err := svc.SyncCustomerToRazorpay(ctx, &domainCustomer.Customer{
+		ID:    "cust_flex",
+		Name:  "Ada",
+		Email: "ada@example.com",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cust_existing_rp", id)
+	require.Len(t, store.created, 1)
+	assert.Equal(t, "cust_existing_rp", store.created[0].ProviderEntityID)
+}
+
+func TestSyncCustomerToRazorpay_PropagatesCreateError(t *testing.T) {
+	ctx := context.Background()
+	client := &stubCustomerClient{
+		createErr: ierr.NewError("failed to create customer in Razorpay").Mark(ierr.ErrInternal),
+	}
+	svc := newSyncService(client, &inlineMappingStore{})
+
+	_, err := svc.SyncCustomerToRazorpay(ctx, &domainCustomer.Customer{
+		ID:    "cust_flex",
+		Name:  "Ada",
+		Email: "ada@example.com",
+	})
+
+	require.Error(t, err)
+	assert.True(t, ierr.IsInternal(err))
+}


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Paddle webhooks now receive a successful response when no Paddle connection is configured.
  * Paddle integration errors continue to return an appropriate configuration error.
  * Razorpay customer creation handles missing customer data safely and preserves provider error details.
  * Billing checks now retrieve complete invoice details when list results omit tax information.

* **Tests**
  * Added coverage for Paddle webhook handling, Razorpay customer synchronization, and invoice tax retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->