### PR TITLE
fix(integrations): Onetime billing period sync fix for zoho

### DIFF
--- a/internal/integration/zoho/invoice.go
+++ b/internal/integration/zoho/invoice.go
@@ -509,16 +509,21 @@ func formatPeriodDescription(fallback string, start, end *time.Time) string {
 	if start == nil || end == nil {
 		return fallback
 	}
+	last := inclusiveEnd(start, end)
 	if fallback != "" {
-		return fmt.Sprintf("%s\n(%s - %s)", fallback, start.Format("2006-01-02"), inclusiveEnd(end).Format("2006-01-02"))
+		return fmt.Sprintf("%s\n(%s - %s)", fallback, start.Format("2006-01-02"), last.Format("2006-01-02"))
 	}
-	return fmt.Sprintf("(%s - %s)", start.Format("2006-01-02"), inclusiveEnd(end).Format("2006-01-02"))
+	return fmt.Sprintf("(%s - %s)", start.Format("2006-01-02"), last.Format("2006-01-02"))
 }
 
 // inclusiveEnd converts FlexPrice's exclusive period end into the inclusive last
-// day a tax invoice displays: a period ending 2026-05-01T00:00 reads as 30/04/2026.
-func inclusiveEnd(end *time.Time) time.Time {
-	return end.Add(-time.Nanosecond)
+// day a tax invoice displays. A zero-width period (one-time start == end) stays on start.
+func inclusiveEnd(start, end *time.Time) time.Time {
+	last := end.Add(-time.Nanosecond)
+	if start != nil && last.Before(*start) {
+		return *start
+	}
+	return last
 }
 
 func servicePeriodCustomFields(settings *types.InvoiceSyncSettings, start, end *time.Time) []CustomField {
@@ -531,7 +536,7 @@ func servicePeriodCustomFields(settings *types.InvoiceSyncSettings, start, end *
 
 	return []CustomField{
 		NewCustomField(settings.ServicePeriodCustomFields.StartFieldID, start.Format(zohoAPIDateFormat)),
-		NewCustomField(settings.ServicePeriodCustomFields.EndFieldID, inclusiveEnd(end).Format(zohoAPIDateFormat)),
+		NewCustomField(settings.ServicePeriodCustomFields.EndFieldID, inclusiveEnd(start, end).Format(zohoAPIDateFormat)),
 	}
 }
 

--- a/internal/integration/zoho/invoice_header_test.go
+++ b/internal/integration/zoho/invoice_header_test.go
@@ -62,6 +62,13 @@ func TestFormatPeriodDescription(t *testing.T) {
 			end:      nil,
 			want:     "BBNow",
 		},
+		{
+			name:     "zero-width one-time period stays on the billing date",
+			fallback: "Mandate Registration",
+			start:    tPtr("2026-09-17T00:00:00Z"),
+			end:      tPtr("2026-09-17T00:00:00Z"),
+			want:     "Mandate Registration\n(2026-09-17 - 2026-09-17)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -73,8 +80,10 @@ func TestFormatPeriodDescription(t *testing.T) {
 
 // period_end is exclusive in FlexPrice; the invoice must show the inclusive last day.
 func TestInclusiveEnd(t *testing.T) {
-	assert.Equal(t, "2026-04-30", inclusiveEnd(tPtr("2026-05-01T00:00:00Z")).Format(zohoAPIDateFormat))
-	assert.Equal(t, "2026-12-31", inclusiveEnd(tPtr("2027-01-01T00:00:00Z")).Format(zohoAPIDateFormat))
+	assert.Equal(t, "2026-04-30", inclusiveEnd(tPtr("2026-04-01T00:00:00Z"), tPtr("2026-05-01T00:00:00Z")).Format(zohoAPIDateFormat))
+	assert.Equal(t, "2026-12-31", inclusiveEnd(tPtr("2026-12-01T00:00:00Z"), tPtr("2027-01-01T00:00:00Z")).Format(zohoAPIDateFormat))
+	assert.Equal(t, "2026-09-17", inclusiveEnd(tPtr("2026-09-17T00:00:00Z"), tPtr("2026-09-17T00:00:00Z")).Format(zohoAPIDateFormat),
+		"one-time PeriodStart == PeriodEnd must not walk to the previous day")
 }
 
 func TestServicePeriodCustomFields(t *testing.T) {


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected invoice period-end date formatting for one-time periods.
  - Billing dates now display the same date for both period boundaries when the start and end are identical.
  - Service-period custom fields now use consistent inclusive end-date calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->