### PR TITLE
docs(analytics): FLE-1257 analytics platform ERD

### DIFF
--- a/docs/design/2026-09-10-FLE-1257-analytics-platform-erd.md
+++ b/docs/design/2026-09-10-FLE-1257-analytics-platform-erd.md
@@ -61,6 +61,7 @@ A reader who has *not* followed the design discussion. Section 2 gives the backg
 3. **Analytics is downstream-only.** Derived, read-only; the billing/invoicing path never reads it.
 4. **Nothing tenant-authored becomes a database object.** Saved views are JSON in Postgres; tenants never cause DDL or submit SQL.
 5. **Product analytics shows usage; money comes only from the revenue table.** Never approximate money as `usage × rate` in the product-analytics path — it ignores tiers/allowances and is wrong.
+6. **ClickHouse is optional; revenue analytics runs on Postgres alone.** `revenue_facts` and everything it joins to live in Postgres, so a tenant with no metered usage still gets full revenue analytics. ClickHouse is required only for usage/product analytics.
 
 ---
 
@@ -68,46 +69,43 @@ A reader who has *not* followed the design discussion. Section 2 gives the backg
 
 ```mermaid
 flowchart LR
-  subgraph SRC[Sources]
-    PG[(Postgres OLTP<br/>subs, prices, entitlements,<br/>commitments, invoices,<br/>invoice_line_items,<br/>wallet_transactions)]
-    EV[Usage events]
+  subgraph PG[Postgres  •  source of truth + revenue store]
+    SRC[subs, prices, entitlements, commitments,<br/>invoices, invoice_line_items, wallet_transactions]
+    RF[revenue_facts<br/>DERIVED, daily]
   end
 
-  subgraph CHB[ClickHouse-B  •  analytics replica]
+  subgraph CH[ClickHouse  •  OPTIONAL — only with metered usage]
     MU[meter_usage<br/>usage facts]
-    SYN[synced tables raw:<br/>invoice, invoice_line_item,<br/>wallet_transactions, entities]
-    RF[revenue_facts<br/>DERIVED]
   end
 
+  EV[Usage events] --> MU
   ENG[Billing Preview Engine<br/>non-mutating]
   ROLL[Rollup workflow<br/>watermarked]
   SRV[Serving layer<br/>view JSON to SQL + RLS]
 
-  PG -- PeerDB CDC, near real-time --> SYN
-  EV --> MU
-  MU --> ENG
-  SYN --> ENG
+  SRC --> ENG
+  MU -. metered usage only .-> ENG
   ENG --> ROLL
-  MU --> ROLL
+  MU -. usage curve .-> ROLL
   ROLL --> RF
 
-  MU --> SRV
-  SYN --> SRV
   RF --> SRV
+  SRC --> SRV
+  MU -. usage / product analytics .-> SRV
   SRV --> API[Views API + Saved Views]
   SRV --> EXP[Warehouse export]
 ```
 
-- **Postgres → ClickHouse-B (CH-B)** via **PeerDB** CDC, near real-time — copies operational tables (subscriptions, prices, entitlements, commitments, **invoices**, **invoice line items**, **wallet_transactions**) into CH-B **as raw tables**. They serve as structural dimensions, the reconciliation anchor, and ledger sources.
-- **`meter_usage`** — existing aggregated usage facts; the product-analytics substrate.
-- **`revenue_facts`** — the new **derived** table produced by the rollup (§6–7).
-- **Serving layer** — turns a saved view into parameterized SQL, injects tenant isolation, reads whichever table the metric needs, and feeds exports.
+- **`revenue_facts` lives in Postgres.** Revenue exists even for tenants with no usage events or metered features (fixed fees, commitments, one-off invoices), so revenue analytics must **not** depend on ClickHouse. The table is **small by construction** (subscriptions × prices × days), well within Postgres's reach, and it joins natively to the invoice/entity tables that already live in Postgres — no cross-store hop for structural revenue.
+- **ClickHouse is optional.** It holds `meter_usage` (aggregated usage) and powers **product/usage analytics**. Tenants who don't use metered features never need it; a read replica can isolate the analytics read path when it *is* used.
+- **`revenue_facts`** — the new **derived** table produced by the rollup (§6–7), in Postgres.
+- **Serving layer** — turns a saved view into parameterized SQL, injects tenant isolation, and routes by metric: **revenue → Postgres**, **usage → ClickHouse** (when present). Custom-dimension revenue (money × usage share) is the one cross-store case, and it applies only when ClickHouse is in use (§9.2).
 
 Everything is scoped by `tenant_id` + `environment_id`; every query filters on both.
 
 ### 4.1 Data model (ERD)
 
-`revenue_facts` is the one **derived** table; every other entity is a **raw PeerDB-synced** copy of a Postgres table (or the existing `meter_usage`). Relationships below are the join keys the serving/rollup layers use — `revenue_facts` is intentionally denormalized (it stores ids, not FKs) so these are logical joins, not enforced constraints.
+`revenue_facts` (**Postgres**) is the one **derived** table; the entities it joins to — `invoice`, `invoice_line_item`, `subscription`, `price`, `customer`, `wallet_transaction` — are **native Postgres** source tables, and `meter_usage` is the **ClickHouse** usage store (optional). Relationships below are the join keys the serving/rollup layers use — `revenue_facts` is intentionally denormalized (it stores ids, not FKs) so these are logical joins, not enforced constraints.
 
 ```mermaid
 erDiagram
@@ -158,7 +156,7 @@ erDiagram
         string  invoice_id           "draft id, stable through finalize"
         string  invoice_line_item_id
         date    lock_adjusted_day     "recognition day under period lock"
-        uint64  version              "ReplacingMergeTree"
+        bigint  version              "optimistic version (upsert/append)"
     }
 
     METER_USAGE {
@@ -213,7 +211,7 @@ The flexible lens, largely **reusing existing infrastructure**: `meter_usage` pl
 Added on top:
 - **Saved views** (§9) — reusable, shareable slices as JSON.
 - **Runtime "adjusted usage."** "Billable vs. included usage" or "overage units" are computed **at query time** from the *current* entitlement/price config — **never stored**, because that config is versioned and a stored copy would go stale.
-- **Non-usage series.** Wallet transactions, credit grants, and price-change history are PeerDB-synced tables queried through the same view machinery (filtered lists, running totals).
+- **Non-usage series.** Wallet transactions, credit grants, and price-change history are native Postgres tables queried through the same view machinery (filtered lists, running totals) — no ClickHouse required.
 
 **Hard rule:** product-analytics views never render money as `usage × rate`. Money comes from `revenue_facts`.
 
@@ -243,61 +241,72 @@ Two correctness requirements from the engine investigation:
 
 Usage / fixed / true-up come from the billing engine and reconcile to the invoice. **Breakage** — recognizing previously-deferred revenue when prepaid credits expire unused — is derivable from `wallet_transactions` (`type=DEBIT`, `reason=CREDIT_EXPIRED`), is a **recognition-era** concept, and does not tie to any invoice. v1 only needs the `revenue_source` slot so these can be added later without a schema change.
 
-**Why `revenue_source`, and not `price_type`?** For price-derived rows, `revenue_source ∈ {usage, fixed}` carries the same fact as a price's `price_type`, so we keep only `revenue_source` (the "kind of revenue") and drop `price_type` — the underlying price's nature is a join to the synced `price` table if ever needed. The two only *diverge* for true-up: a `commitment_trueup` row sits on a **usage** price but is a different kind of revenue.
+**Why `revenue_source`, and not `price_type`?** For price-derived rows, `revenue_source ∈ {usage, fixed}` carries the same fact as a price's `price_type`, so we keep only `revenue_source` (the "kind of revenue") and drop `price_type` — the underlying price's nature is a join to the `price` table if ever needed. The two only *diverge* for true-up: a `commitment_trueup` row sits on a **usage** price but is a different kind of revenue.
 
 **Why `commitment_trueup` must be its own row (not folded into usage).** A minimum-commitment true-up is revenue *not caused by usage* — it is the floor that applies when usage falls short. If we left it inside the usage line's amount and then daily-decomposed that line (§6.5), the entire true-up would land on the **last day** (that is when the floor engages) and falsely read as "usage earned on day 30." Emitting it as a separate `period_only` row dated at `period_end` keeps every usage day honest and lets finance answer "how much revenue was floor vs. actual usage." So it is required for correctness, not just labeling.
 
 ### 6.3 Schema
 
-One row per **`(tenant, environment, subscription, price, day, revenue_source)`**. Daily grain enables fine-grained exports and future recognition. Money is decomposed into **columns on `usage` rows**; `fixed`/`trueup`/etc. are their own rows carrying just `net_amount`. Usage is measured **gross** (billable + allowance) so the allowance shows as a visible credit. **Tax and prepaid are excluded** (§6.6, §6.7).
+A **Postgres** table (§4 — keeps ClickHouse optional). One row per **`(tenant, environment, subscription, price, day, revenue_source)`**. Daily grain enables fine-grained exports and future recognition. Money is decomposed into **columns on `usage` rows**; `fixed`/`trueup`/etc. are their own rows carrying just `net_amount`. Usage is measured **gross** (billable + allowance) so the allowance shows as a visible credit. **Tax and prepaid are excluded** (§6.6, §6.7).
 
 ```sql
 CREATE TABLE revenue_facts (
-    tenant_id            LowCardinality(String),
-    environment_id       LowCardinality(String),
-    customer_id          String,
-    subscription_id      String,                  -- the LINE ITEM's subscription (child in grouped invoicing)
-    sub_line_item_id     String,
-    price_id             String,                  -- versioned; amendments create new ids
-    meter_id             LowCardinality(String),  -- '' for fixed / non-usage rows
-    aggregation_type     LowCardinality(String),  -- drives decomposability (§6.5); '' for non-usage rows
-    revenue_source       Enum8('usage'=1,'fixed'=2,'commitment_trueup'=3,'credit_breakage'=4,'manual_adjustment'=5),
-    -- NOTE: no price_type column — revenue_source subsumes the usage/fixed split; the
-    -- underlying price's nature is available by joining price_id to the synced price table.
+    id                   TEXT        NOT NULL,        -- surrogate id
+    tenant_id            TEXT        NOT NULL,
+    environment_id       TEXT        NOT NULL,
+    customer_id          TEXT        NOT NULL,
+    subscription_id      TEXT        NOT NULL,        -- the LINE ITEM's subscription (child in grouped invoicing)
+    sub_line_item_id     TEXT,
+    price_id             TEXT,                        -- versioned; amendments create new ids
+    meter_id             TEXT,                        -- NULL for fixed / non-usage rows
+    aggregation_type     TEXT,                        -- drives decomposability (§6.5); NULL for non-usage
+    revenue_source       TEXT        NOT NULL,        -- usage|fixed|commitment_trueup|credit_breakage|manual_adjustment
+    -- NOTE: no price_type column — revenue_source subsumes usage/fixed; join price_id to `price` for its nature.
 
     -- time
-    period_start         Date,
-    period_end           Date,
-    day                  Date,                     -- grain (billing/booking day for non-usage rows)
-    service_start        Date,                     -- recognition-ready: the charge's service window
-    service_end          Date,
-    recognition_method   LowCardinality(String),   -- recognition-ready: 'point_in_time'|'ratable'|'usage' ('' in v1)
+    period_start         DATE        NOT NULL,
+    period_end           DATE        NOT NULL,
+    day                  DATE        NOT NULL,        -- grain + partition key (billing/booking day for non-usage rows)
+    service_start        DATE,                        -- recognition-ready: the charge's service window
+    service_end          DATE,
+    recognition_method   TEXT,                        -- recognition-ready: 'point_in_time'|'ratable'|'usage' (NULL in v1)
 
-    -- decomposition (usage rows only), GROSS basis, EXCLUDES tax & prepaid
-    usage_at_list_rate   Decimal(38,9),  -- (billable_qty + entitlement_qty) x list/effective rate
-    tier_delta           Decimal(38,9),  -- graduated only: engine Amount - gross_qty x tier1_rate; else 0
-    entitlement_credit   Decimal(38,9),  -- entitlement_qty x list rate  (>=0, subtracted)
-    line_discount        Decimal(38,9),  -- coupon on this line           (>=0, subtracted)
-    invoice_discount     Decimal(38,9),  -- invoice-level discount, allocated to line (>=0, subtracted)
-    net_amount           Decimal(38,9),  -- billed revenue for this row (excl tax, excl prepaid)
+    -- decomposition (usage rows), GROSS basis, EXCLUDES tax & prepaid
+    usage_at_list_rate   NUMERIC(38,9) NOT NULL DEFAULT 0,  -- (billable_qty + entitlement_qty) x list/effective rate
+    tier_delta           NUMERIC(38,9) NOT NULL DEFAULT 0,  -- graduated only: engine Amount - gross_qty x tier1_rate
+    entitlement_credit   NUMERIC(38,9) NOT NULL DEFAULT 0,  -- entitlement_qty x list rate (subtracted)
+    line_discount        NUMERIC(38,9) NOT NULL DEFAULT 0,
+    invoice_discount     NUMERIC(38,9) NOT NULL DEFAULT 0,
+    net_amount           NUMERIC(38,9) NOT NULL,            -- billed revenue for this row (excl tax, excl prepaid)
 
-    billable_qty         Decimal(38,9),  -- net of allowance
-    entitlement_qty      Decimal(38,9),
-    decomposition_mode   Enum8('marginal'=1, 'period_only'=2),  -- §6.5
+    billable_qty         NUMERIC(38,9) NOT NULL DEFAULT 0,  -- net of allowance
+    entitlement_qty      NUMERIC(38,9) NOT NULL DEFAULT 0,
+    decomposition_mode   TEXT        NOT NULL,        -- 'marginal' | 'period_only'  (§6.5)
 
     -- lifecycle / audit
-    currency             LowCardinality(String),
-    status               Enum8('PROVISIONAL'=1, 'FINAL'=2, 'REVERTED'=3),
-    is_revert            UInt8,           -- append-only correction model (§8)
-    invoice_id           String,          -- draft id once a draft exists; stable through finalize
-    invoice_line_item_id String,          -- the specific line item, for exact reconciliation
-    lock_adjusted_day    Date,            -- recognition day given accounting-period lock (§8)
-    computed_at          DateTime64(3),
-    version              UInt64
-) ENGINE = ReplacingMergeTree(version)
-PARTITION BY toYYYYMM(day)
-ORDER BY (tenant_id, environment_id, subscription_id, price_id, day, revenue_source, is_revert);
+    currency             TEXT        NOT NULL,
+    status               TEXT        NOT NULL,        -- 'PROVISIONAL' | 'FINAL' | 'REVERTED'  (§8)
+    is_revert            BOOLEAN     NOT NULL DEFAULT false,
+    invoice_id           TEXT,                        -- draft id once a draft exists; stable through finalize
+    invoice_line_item_id TEXT,                        -- the specific line item, for exact reconciliation
+    lock_adjusted_day    DATE,                        -- recognition day given accounting-period lock (§8)
+    computed_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    version              BIGINT      NOT NULL DEFAULT 1,
+    PRIMARY KEY (day, id)                            -- day first: it is the partition key
+) PARTITION BY RANGE (day);
+-- monthly partitions (revenue_facts_2026_09, …) created ahead of time by a maintenance job.
+
+-- Exactly one LIVE provisional row per grain -> ON CONFLICT upsert during open-period churn (§8).
+CREATE UNIQUE INDEX revenue_facts_provisional_grain ON revenue_facts
+    (tenant_id, environment_id, subscription_id, price_id, day, revenue_source)
+    WHERE status = 'PROVISIONAL';
+-- FINAL / REVERTED rows are append-only (no unique constraint) so corrections can be added.
+
+CREATE INDEX revenue_facts_read    ON revenue_facts (tenant_id, environment_id, day, revenue_source);
+CREATE INDEX revenue_facts_invoice ON revenue_facts (tenant_id, environment_id, invoice_id);
 ```
+
+**Small by construction.** Rows ≈ `active subscriptions × prices-per-sub × days-in-open-period × sources`. Closed periods stop churning, monthly partitions keep the hot set bounded, and there are no per-event rows here — so this is a comfortable Postgres workload, not a ClickHouse-scale one.
 
 **Decomposition-field rationale (reviewed):**
 - `usage_at_list_rate` + `tier_delta` — kept as two fields because the `list` policy (efficiency comparison) needs list rate and graduated pricing needs the delta. Collapsing them would lose list-vs-effective visibility that finance uses.
@@ -401,7 +410,7 @@ Explicitly **safe** (not on the list): package/`ceil` (monotonic, only lumpy), a
 
 ### 6.6 Tax is excluded from `revenue_facts`
 
-Tax in Flexprice is computed **at the invoice level** (one `tax_applied` row per tax rate; no per-line-item tax), and under ASC 606 collected tax is a **liability, not revenue**. So `revenue_facts` carries **tax-excluded** revenue and has **no tax column**. Tax lives at invoice grain in the synced `invoice` table (`TotalTax`) and reconciles separately. If a tenant ever wants "tax by dimension," it can only be a **read-time estimated allocation** of invoice tax by line share (flagged estimated) — the system does not compute per-line tax, so we will not fabricate it as authoritative.
+Tax in Flexprice is computed **at the invoice level** (one `tax_applied` row per tax rate; no per-line-item tax), and under ASC 606 collected tax is a **liability, not revenue**. So `revenue_facts` carries **tax-excluded** revenue and has **no tax column**. Tax lives at invoice grain in the Postgres `invoice` table (`TotalTax`) and reconciles separately. If a tenant ever wants "tax by dimension," it can only be a **read-time estimated allocation** of invoice tax by line share (flagged estimated) — the system does not compute per-line tax, so we will not fabricate it as authoritative.
 
 ### 6.7 Prepaid credits are excluded (ASC 606-aligned)
 
@@ -417,7 +426,7 @@ sequenceDiagram
     participant WM as Watermark (Postgres)
     participant RJ as Rollup job (Temporal)
     participant EN as Billing Preview Engine
-    participant RF as revenue_facts (CH-B)
+    participant RF as revenue_facts (Postgres)
 
     WM->>RJ: dirty subscriptions (usage moved / period close / amendment)
     loop each dirty subscription
@@ -427,17 +436,17 @@ sequenceDiagram
         RJ->>RJ: usage rows -> marginal (else period_only);<br/>fixed / true-up -> own rows
         RJ->>RJ: assert per-row + Σ net == line-item / invoice revenue
         alt period still open
-            RJ->>RF: upsert (version++)
+            RJ->>RF: INSERT ... ON CONFLICT (provisional grain) DO UPDATE, version++
         else finalized / accounting-locked
-            RJ->>RF: append REVERTED row(s) + fresh rows
+            RJ->>RF: INSERT REVERTED row(s) + fresh FINAL rows
         end
     end
 ```
 
 - **Dirty-subscription set** — from a usage watermark plus period-close and amendment events; only subscriptions that moved are rebuilt.
-- **Whole-open-period recompute** — tiers/allowances/commitments are period-cumulative; cheap because it reads aggregated `meter_usage`, not raw events.
+- **Whole-open-period recompute** — tiers/allowances/commitments are period-cumulative. For metered charges the engine reads aggregated `meter_usage` from ClickHouse; for fixed/commitment charges no ClickHouse is needed at all.
 - **Cadence** — watermark-driven; a modest default (e.g. hourly) for open periods, tunable. `FINAL` periods are never recomputed, only corrected (§8). A configurable **grace window** (~3 days, à la Orb) keeps a period `PROVISIONAL` while late usage settles.
-- **Isolation** — separate ClickHouse role/quota so a backfill can't starve the tenant read path.
+- **Isolation** — rollup writes go to Postgres; its `meter_usage` reads (when metered) can use a ClickHouse read replica so a backfill can't starve the tenant read path.
 - **Engine dependency to build** — a preview entry point returning cumulative charge as-of an arbitrary in-period date, ideally all day-checkpoints in one pass (Q2).
 
 ---
@@ -449,7 +458,7 @@ Two **independent** locks:
 ```mermaid
 stateDiagram-v2
     [*] --> PROVISIONAL: period opens
-    PROVISIONAL --> PROVISIONAL: rebuild (ReplacingMergeTree, version++)
+    PROVISIONAL --> PROVISIONAL: rebuild (upsert in place, version++)
     PROVISIONAL --> FINAL: invoice finalized + reconcile assert
     FINAL --> REVERTED: correction — append REVERTED (negatives)
     REVERTED --> FINAL: fresh FINAL rows (new version)
@@ -468,9 +477,9 @@ stateDiagram-v2
 1. **Invoice finalization** (per subscription-period): billed amounts become legally fixed. Rows flip `PROVISIONAL → FINAL`, get `invoice_id`/`invoice_line_item_id`, and we assert reconciliation.
 2. **Accounting-period lock** (ASC 606 finance close, per calendar period across all subscriptions): once a month is closed, its recognized numbers are frozen.
 
-**Storage by lock state:**
-- **Open / provisional** → `ReplacingMergeTree(version)`: recompute freely, last version wins, high churn, nobody depends on it yet.
-- **Finalized or accounting-locked** → **append-only, corrected via reverts.** There is **no `AMENDED` state.** A correction appends **`REVERTED`** rows (the exact negatives of what's being corrected, `is_revert=1`) plus fresh `FINAL` rows with a new `version`. Summing all rows is self-correcting (original + its `REVERTED` twin = 0). Closed accounting periods are never mutated in place.
+**Storage by lock state** (Postgres):
+- **Open / provisional** → **upsert in place.** The partial unique index on the grain (`WHERE status='PROVISIONAL'`, §6.3) makes each rebuild an `INSERT … ON CONFLICT … DO UPDATE` that bumps `version` — one live provisional row per grain, high churn, nobody depends on it yet.
+- **Finalized or accounting-locked** → **append-only, corrected via reverts.** These rows carry no unique constraint, so there is **no `AMENDED` state**: a correction `INSERT`s **`REVERTED`** rows (the exact negatives of what's being corrected, `is_revert=true`) plus fresh `FINAL` rows with a new `version`. Summing all rows is self-correcting (original + its `REVERTED` twin = 0). Closed accounting periods are never mutated in place.
 
 **`lock_adjusted_day`** is the day a row is *recognized* given lock posture: it equals `day` when the period is open, and shifts to the **first day of the next open period** when the real period is closed — a "catch-up" so a closed month is never rewritten. Reports key on `lock_adjusted_day`; analytics/attribution key on `day`.
 
@@ -478,7 +487,7 @@ stateDiagram-v2
 
 ## 9. Serving layer (a translator, not a compiler)
 
-A **saved view is a JSON row in Postgres**, immutable and versioned. It creates nothing in ClickHouse.
+A **saved view is a JSON row in Postgres**, immutable and versioned. It creates no schema objects in either store.
 
 ```json
 {
@@ -504,19 +513,20 @@ A **saved view is a JSON row in Postgres**, immutable and versioned. It creates 
 flowchart LR
   V[View JSON + variables] --> T1[resolve & type-check variables]
   T1 --> T2[inject tenant + env RLS]
-  T2 --> T3{metric to table}
-  T3 -- usage --> MU[meter_usage query builder]
-  T3 -- revenue --> RF[revenue_facts SQL<br/>+ allocation join]
-  T3 -- ledger --> SY[synced table SQL]
-  MU --> BIND[bind vars as CH query params]
-  RF --> BIND
-  SY --> BIND
-  BIND --> EX[execute on CH-B] --> SH[shape to columns + rows]
+  T2 --> T3{route by metric}
+  T3 -- revenue --> RF[revenue_facts SQL<br/>Postgres]
+  T3 -- ledger --> SY[Postgres source-table SQL]
+  T3 -- usage --> MU[meter_usage query builder<br/>ClickHouse, optional]
+  RF --> PG[bind params, execute on Postgres]
+  SY --> PG
+  MU --> CH[bind params, execute on ClickHouse]
+  PG --> SH[shape to columns + rows]
+  CH --> SH
 ```
 
 - **Shapes (v1):** `timeseries`, `breakdown`, `single_value`, `drilldown`. (`pivot`, `distribution` later.)
-- **Variables** bind as **ClickHouse query parameters**, never string interpolation. Optional filters with no value are dropped from `WHERE`. Dimension-position variables are allowed only against a per-tenant registered-property allowlist.
-- **Custom dimensions** are aggregated **at read time** (`JSONExtract` over `meter_usage`; an allocation join for revenue).
+- **Variables** bind as **query parameters** on the target store (Postgres for revenue/ledger, ClickHouse for usage), never string interpolation. Optional filters with no value are dropped from `WHERE`. Dimension-position variables are allowed only against a per-tenant registered-property allowlist.
+- **Custom dimensions** are aggregated **at read time**: for usage, `JSONExtract` over `meter_usage` (ClickHouse); for revenue, the money comes from `revenue_facts` (Postgres) allocated by the dimension's usage share from `meter_usage` — the one **cross-store** path, available only when ClickHouse is in use.
 - **Allocation presets** (custom-dimension revenue only): `billed` (default; aggregate-level components as their own rows so every line is defensible) and `amortized` (aggregate effects spread by usage share). Allocate per price, then sum. A third, `list` (usage at list rate only), is an opt-in for efficiency comparisons; it deliberately does **not** reconcile and returns `reconciles_to_invoice: false`.
 - **Authoritative vs. estimated:** a revenue query returns stored authoritative rows (`marginal` + `period_only`). A daily-shape chart over `period_only` items uses read-time `estimated` allocation, labeled and never summed into an authoritative total.
 
@@ -531,9 +541,9 @@ flowchart LR
 | `time` | `range` (often a `{{variable}}`) + `grain` (`day`/`week`/`month`). | `grain` sets the time bucket for `timeseries`. |
 | `sort`, `limit` | Ordering and top-N. | Drives "top 10 customers by revenue". |
 | `allocation_policy` | Only for **custom-dimension revenue** — `billed` / `amortized` / `list` (§9 bullets). | Ignored for usage metrics and structural revenue breakdowns. |
-| `variables` | Typed placeholders (`date_range`, `string`, `string_list`, `number`, `enum`, `boolean`) bound at query time. | Bound as **ClickHouse query parameters**, never string-interpolated. |
+| `variables` | Typed placeholders (`date_range`, `string`, `string_list`, `number`, `enum`, `boolean`) bound at query time. | Bound as **query parameters** on the target store, never string-interpolated. |
 
-**Group-by resolution.** A **structural** dimension resolves by joining `price_id`/`meter_id`/`customer_id` to the PeerDB-synced entity tables in CH-B (e.g. `feature_id` via the meter→feature relation). A **custom** dimension (e.g. `region`) resolves via `JSONExtractString(properties, 'region')` on `meter_usage` **at read time** — no pre-declaration, but it must pass the registered-property allowlist to become a legal group-by.
+**Group-by resolution.** A **structural** dimension resolves by joining `price_id`/`meter_id`/`customer_id`/`plan_id` to the entity tables. For **revenue**, those entity tables are the **native Postgres** tables `revenue_facts` already sits beside — a plain SQL join. For **usage**, a **custom** dimension (e.g. `region`) resolves via `JSONExtractString(properties, 'region')` on `meter_usage` in ClickHouse **at read time** — no pre-declaration, but it must pass the registered-property allowlist to become a legal group-by.
 
 ### 9.2 What powers a view — and where "runtime adjustments" apply
 
@@ -542,18 +552,19 @@ The metric decides the source table. This is the crux of your question, and the 
 | Metric kind | Powered by | Adjustments |
 |---|---|---|
 | **Usage** (`usage_quantity`, `event_count`, `billable_usage`, `overage_units`) | **`meter_usage`** via the existing query builder | "Adjusted" usage (`billable_usage`, `overage_units`) is computed **at runtime** by applying the *current* entitlement/price config to the raw usage — never stored, so it can't go stale. |
-| **Revenue** (`revenue`, `usage_at_list_rate`, `entitlement_credit`, …) | **`revenue_facts`** (pre-computed) | Money is **not** derived from `meter_usage` at read time — tiers/allowances/commitments make `usage × rate` wrong. It is read from `revenue_facts`, which the engine already priced. Custom-dimension revenue additionally does a read-time **allocation join** to `meter_usage` for the dimension's usage share. |
-| **Ledger** (credit top-ups, balance, price-change history) | **synced tables** (`wallet_transactions`, …) | Simple filters/sums; no pricing. |
+| **Revenue** (`revenue`, `usage_at_list_rate`, `entitlement_credit`, …) | **`revenue_facts`** (Postgres, pre-computed) | Money is **not** derived from `meter_usage` at read time — tiers/allowances/commitments make `usage × rate` wrong. It is read from `revenue_facts`, which the engine already priced. Custom-dimension revenue additionally does a read-time **allocation join** to `meter_usage` (ClickHouse) for the dimension's usage share. |
+| **Ledger** (credit top-ups, balance, price-change history) | **native Postgres tables** (`wallet_transactions`, …) | Simple filters/sums; no pricing. |
 
-So: **usage views** *are* powered by `meter_usage` with runtime-computed adjustment fields — exactly as you said. But **revenue views** are powered by `revenue_facts`, precisely because revenue can't be safely recomputed from usage at read time. A view that mixes a usage metric and a revenue metric runs two sub-queries (one per source) and joins the results in the serving layer.
+So: **usage views** are powered by ClickHouse `meter_usage` with runtime-computed adjustment fields — exactly as you said. **Revenue and ledger views** are powered by **Postgres** (`revenue_facts` + native source tables), so they work with **no ClickHouse at all**. A view that mixes a usage metric and a revenue metric runs two sub-queries — one per store — and joins the results in the serving layer; that is also the only place a cross-store hop occurs.
 
 ---
 
 ## 10. Warehouse export
 
 Daily grain makes tenant-side BI viable. Export surface:
-- **Derived:** `revenue_facts` (and, later, the recognition table).
-- **Raw (PeerDB-synced):** `invoice`, `invoice_line_item`, entities, `wallet_transactions` — reconciliation anchor and structural dimensions.
+- **Derived:** `revenue_facts` from Postgres (and, later, the recognition table).
+- **Raw (native Postgres):** `invoice`, `invoice_line_item`, entities, `wallet_transactions` — reconciliation anchor and structural dimensions.
+- **Usage (ClickHouse, when present):** `meter_usage` for tenants doing usage BI.
 
 Export is a fast-follow on `revenue_facts`, hedging the risk that a full in-app builder is more than some tenants need. Mechanism (snapshot vs. incremental by `updated_at`/`version`; destinations) is deferred; the common pattern is a first full snapshot then daily incrementals.
 
@@ -627,7 +638,7 @@ Concretely, this is the billed-vs-recognized split the fixed-charge example make
 
 **Q3 — Multi-period commitment prior-base.** For an annual commitment billed monthly, month N needs cumulative consumption from months 1..N-1; the engine reads it only from *finalized* invoices and degrades silently otherwise. *Why it matters:* the rollup produces provisional numbers before finalization, exactly when the engine's source is incomplete. *Resolved by:* fixing the fields of a rollup-maintained cumulative prior-base (sum of usage-line base; overage lines ÷ overage factor; true-up excluded), where it's stored, and the rule gating true-up to the final period.
 
-**Q4 — PeerDB sync coverage and latency.** The design assumes `invoice`, `invoice_line_item`, `wallet_transactions`, and entities are in CH-B with low lag. *Why it matters:* structural breakdowns and ledger views join these; the reconciliation anchor is the synced invoice. *Resolved by:* confirming which tables PeerDB replicates into CH-B, observed lag, and failure/backfill behavior.
+**Q4 — ClickHouse read isolation and entity enrichment for usage views.** Revenue/ledger run on Postgres, but usage/product analytics reads `meter_usage` in ClickHouse. *Why it matters:* under load, analytical scans shouldn't degrade ingestion or the tenant read path, and structural dimensions for *usage* (feature/plan names) live in Postgres. *Resolved by:* deciding whether usage reads hit a ClickHouse read replica, and whether usage-side entity names are joined in the Go serving layer (as today) or need a lightweight entity copy in ClickHouse.
 
 **Q5 — Allocation basis for `period_only` daily shape.** Rendering a daily shape for a non-decomposable item allocates the period total proportionally, proposed as that day's usage share. *Why it matters:* for volume tiers and `LATEST`/`AVG` meters this is defensible but not unique; even-spread may read better for some. *Resolved by:* picking a default and checking it against real volume-tier and `LATEST` examples; decide if it's per-aggregation-type.
 
@@ -651,7 +662,7 @@ Concretely, this is the billed-vs-recognized split the fixed-charge example make
 - **Billed vs. recognized revenue** — invoiced vs. earned; ASC 606 governs recognition timing.
 - **Deferred revenue** — money received but not yet earned (a liability); prepaid credits are deferred until consumed.
 - **Breakage** — deferred revenue recognized when prepaid credits expire unused.
-- **PeerDB / CH-B** — the CDC pipeline replicating Postgres into the ClickHouse analytics replica this platform reads.
+- **ClickHouse (optional)** — the usage store holding `meter_usage`; required only for usage/product analytics. Revenue analytics runs on Postgres alone.
 
 ## Appendix B — Codebase anchors
 
@@ -664,4 +675,4 @@ Concretely, this is the billed-vs-recognized split the fixed-charge example make
 - Usage engine (build on): `internal/repository/clickhouse/meter_usage_query_builder.go`, `aggregators.go`; table `migrations/clickhouse/000007_create_meter_usage.sql`; ingestion clamp `meter_usage_tracking.go:493`.
 - Price math: `internal/ee/service/price.go:1088-1239`, bucketed max `1065-1084`; `internal/domain/price/model.go:275-360`.
 - Monthly persistence (no analytics precompute exists): `invoice.go:430-618,2112`.
-- Analytics-lake feed (usage → CH-B): `internal/ee/analytics/meter_usage_sink_publisher.go` (`cfg.Analytics`).
+- Analytics-lake feed (usage → ClickHouse): `internal/ee/analytics/meter_usage_sink_publisher.go` (`cfg.Analytics`).

--- a/docs/design/2026-09-10-FLE-1257-analytics-platform-erd.md
+++ b/docs/design/2026-09-10-FLE-1257-analytics-platform-erd.md
@@ -1,0 +1,667 @@
+# FLE-1257 — Analytics Platform: Product & Revenue Analytics (ERD)
+
+- **Ticket:** [FLE-1257](https://linear.app/flexprice/issue/FLE-1257/analytics)
+- **Date:** 2026-09-10
+- **Author:** Ankit Malik
+- **Status:** Proposed
+
+**Scope:** A tenant-facing analytics platform over usage and revenue, plus a warehouse-export path, served from a ClickHouse analytics replica. Built to be revenue-recognition (ASC 606) ready.
+
+---
+
+## 1. What we are building and why
+
+Flexprice tenants (our customers) need to understand their own business through two very different lenses:
+
+1. **Product analytics** — *"how is my product being used?"* Usage patterns, feature adoption, the effect of a pricing experiment, cost-per-API-key, credit top-up behavior, price-change history. This lens is **exploratory and open-ended**: a tenant should be able to slice their data by almost any dimension and save that slice as a reusable view.
+
+2. **Revenue analytics** — *"where is the money coming from?"* Revenue by feature, plan, customer, region; committed vs. overage; the impact of discounts and commitments. Consumed by **finance, leadership, and investors**, so the numbers must be **exact and defensible** — they have to tie to the invoices we actually issued.
+
+These lenses pull in opposite directions. Product analytics wants maximum flexibility and cardinality. Revenue analytics wants correctness above all, and correctness is genuinely hard because pricing is non-linear (tiers, included allowances, minimum commitments, discounts, taxes). One design must serve both without letting the flexibility of one corrupt the correctness of the other.
+
+The guiding idea:
+
+> **Two use cases, two read models, one storage substrate.** Product analytics reads the raw usage store we already have. Revenue analytics reads a new *derived* table produced by **re-running our real billing engine** in a non-mutating mode and recording what it computes. The two meet in a shared serving layer (saved views + a query API) and a shared export path.
+
+### Audience for this document
+A reader who has *not* followed the design discussion. Section 2 gives the background; a glossary is in Appendix A.
+
+---
+
+## 2. Background you need to follow this
+
+**Meters and events.** Tenants send **usage events**. A **meter** turns a stream of events into a billable quantity via an **aggregation** (`SUM`, `COUNT`, `COUNT_UNIQUE`, `MAX`, `LATEST`, `AVG`, `SUM_WITH_MULTIPLIER`, `WEIGHTED_SUM`), an optional filter, and optional dimensions. Aggregated usage lands in a ClickHouse table, `meter_usage`.
+
+**Prices and pricing shapes.** A **price** attaches money to a meter:
+- **Flat / per-unit** — fixed rate per unit.
+- **Graduated tiers** — first N units at rate A, next M at rate B (like tax brackets); each unit charged at its bracket's rate.
+- **Volume tiers** — the reached tier sets **one** rate applied to **all** units; crossing into a cheaper tier can make the whole bill drop.
+- **Package** — "$10 per 1,000 units," in whole packages (rounded up).
+
+**Included allowances (entitlements).** A plan may include an allowance; only overage is charged.
+
+**Commitments and true-up.** A subscription may commit to a minimum spend; a **true-up** covers any shortfall. Commitments can span **multiple billing periods** (annual commitment billed monthly), so one month's true-up depends on earlier months.
+
+**Fixed charges & billing cadence.** Recurring fees are billed **in advance** (at period start) or **in arrear** (at period end), configured per line item. The *service window* (what the fee is for) is recorded separately from *when* it's billed.
+
+**Discounts and taxes.** Coupons discount a line or a whole invoice. **Tax is computed at the invoice level** (not per line item) and collected on behalf of tax authorities.
+
+**Prepaid credits / wallet.** Customers can prepay into a wallet and draw it down; credits can **expire**.
+
+**Why revenue is hard to attribute.** Because of tiers, allowances, and commitments, **a period's charge cannot be computed one day (or one dimension) at a time in isolation** — the 100,000th unit's price depends on the 99,999 before it. "Revenue by region" or "revenue on day 12" is an *attribution* of a non-decomposable total. This one fact shapes the whole revenue design.
+
+**ASC 606 (revenue recognition), briefly.** Accounting distinguishes *billed* revenue (invoiced) from *recognized* revenue (earned by delivering the service). Prepaid money is a **liability (deferred revenue)** until earned. Sales tax collected is a **liability**, not revenue. Finance "closes the books" for a period, after which its numbers must not silently change. "ASC 606 ready" means the data model can support these later without a rebuild.
+
+---
+
+## 3. Principles
+
+1. **Re-run the engine; never reimplement pricing.** All money is computed by the billing engine. The analytics layer records and arranges its output; it does arithmetic (sums, allocation), never pricing. Two pricing implementations would drift, and a dashboard that contradicts the invoice destroys trust.
+2. **Exact reconciliation is a hard invariant.** Any revenue number that claims to reconcile must sum to the finalized invoice, asserted in code with alerts on drift.
+3. **Analytics is downstream-only.** Derived, read-only; the billing/invoicing path never reads it.
+4. **Nothing tenant-authored becomes a database object.** Saved views are JSON in Postgres; tenants never cause DDL or submit SQL.
+5. **Product analytics shows usage; money comes only from the revenue table.** Never approximate money as `usage × rate` in the product-analytics path — it ignores tiers/allowances and is wrong.
+
+---
+
+## 4. Architecture
+
+```mermaid
+flowchart LR
+  subgraph SRC[Sources]
+    PG[(Postgres OLTP<br/>subs, prices, entitlements,<br/>commitments, invoices,<br/>invoice_line_items,<br/>wallet_transactions)]
+    EV[Usage events]
+  end
+
+  subgraph CHB[ClickHouse-B  •  analytics replica]
+    MU[meter_usage<br/>usage facts]
+    SYN[synced tables raw:<br/>invoice, invoice_line_item,<br/>wallet_transactions, entities]
+    RF[revenue_facts<br/>DERIVED]
+  end
+
+  ENG[Billing Preview Engine<br/>non-mutating]
+  ROLL[Rollup workflow<br/>watermarked]
+  SRV[Serving layer<br/>view JSON to SQL + RLS]
+
+  PG -- PeerDB CDC, near real-time --> SYN
+  EV --> MU
+  MU --> ENG
+  SYN --> ENG
+  ENG --> ROLL
+  MU --> ROLL
+  ROLL --> RF
+
+  MU --> SRV
+  SYN --> SRV
+  RF --> SRV
+  SRV --> API[Views API + Saved Views]
+  SRV --> EXP[Warehouse export]
+```
+
+- **Postgres → ClickHouse-B (CH-B)** via **PeerDB** CDC, near real-time — copies operational tables (subscriptions, prices, entitlements, commitments, **invoices**, **invoice line items**, **wallet_transactions**) into CH-B **as raw tables**. They serve as structural dimensions, the reconciliation anchor, and ledger sources.
+- **`meter_usage`** — existing aggregated usage facts; the product-analytics substrate.
+- **`revenue_facts`** — the new **derived** table produced by the rollup (§6–7).
+- **Serving layer** — turns a saved view into parameterized SQL, injects tenant isolation, reads whichever table the metric needs, and feeds exports.
+
+Everything is scoped by `tenant_id` + `environment_id`; every query filters on both.
+
+### 4.1 Data model (ERD)
+
+`revenue_facts` is the one **derived** table; every other entity is a **raw PeerDB-synced** copy of a Postgres table (or the existing `meter_usage`). Relationships below are the join keys the serving/rollup layers use — `revenue_facts` is intentionally denormalized (it stores ids, not FKs) so these are logical joins, not enforced constraints.
+
+```mermaid
+erDiagram
+    CUSTOMER            ||--o{ SUBSCRIPTION       : "owns"
+    SUBSCRIPTION        ||--o{ SUBSCRIPTION_LINE_ITEM : "has"
+    SUBSCRIPTION        ||--o{ INVOICE            : "billed per period"
+    INVOICE             ||--o{ INVOICE_LINE_ITEM  : "contains"
+    PRICE               ||--o{ INVOICE_LINE_ITEM  : "prices"
+    METER               ||--o{ PRICE              : "metered by"
+    METER               ||--o{ METER_USAGE        : "aggregates usage"
+    CUSTOMER            ||--o{ WALLET_TRANSACTION  : "prepaid ledger"
+
+    INVOICE_LINE_ITEM   ||--o{ REVENUE_FACTS      : "reconciles to (invoice_line_item_id)"
+    PRICE               ||--o{ REVENUE_FACTS      : "priced by (price_id)"
+    SUBSCRIPTION        ||--o{ REVENUE_FACTS      : "attributed to (subscription_id)"
+    METER               |o--o{ REVENUE_FACTS      : "usage rows (meter_id)"
+    METER_USAGE         }o--o{ REVENUE_FACTS      : "read-time allocation for custom dims"
+    WALLET_TRANSACTION  |o--o{ REVENUE_FACTS      : "credit_breakage source (Phase 4)"
+
+    REVENUE_FACTS {
+        string  tenant_id            "scope"
+        string  environment_id       "scope"
+        string  customer_id
+        string  subscription_id      "line item's sub (child in grouped invoicing)"
+        string  sub_line_item_id
+        string  price_id
+        string  meter_id             "'' for non-usage rows"
+        string  aggregation_type     "drives decomposability"
+        enum    revenue_source       "usage|fixed|commitment_trueup|credit_breakage|manual_adjustment"
+        date    period_start
+        date    period_end
+        date    day                  "grain"
+        date    service_start        "recognition-ready"
+        date    service_end          "recognition-ready"
+        string  recognition_method   "recognition-ready ('' in v1)"
+        decimal usage_at_list_rate   "usage rows"
+        decimal tier_delta           "graduated only"
+        decimal entitlement_credit   "allowance giveaway"
+        decimal line_discount
+        decimal invoice_discount
+        decimal net_amount           "billed revenue, excl tax & prepaid"
+        decimal billable_qty
+        decimal entitlement_qty
+        enum    decomposition_mode   "marginal|period_only"
+        string  currency
+        enum    status               "PROVISIONAL|FINAL|REVERTED"
+        uint8   is_revert
+        string  invoice_id           "draft id, stable through finalize"
+        string  invoice_line_item_id
+        date    lock_adjusted_day     "recognition day under period lock"
+        uint64  version              "ReplacingMergeTree"
+    }
+
+    METER_USAGE {
+        string  tenant_id
+        string  environment_id
+        string  external_customer_id
+        string  meter_id
+        datetime timestamp
+        decimal qty_total
+        string  properties           "JSON — custom dimensions"
+    }
+
+    INVOICE {
+        string  id PK
+        string  subscription_id
+        date    period_start
+        date    period_end
+        decimal subtotal
+        decimal total_discount
+        decimal total_tax            "tax reconciles here, not in revenue_facts"
+        decimal total
+        string  status               "draft|finalized"
+    }
+
+    INVOICE_LINE_ITEM {
+        string  id PK
+        string  invoice_id FK
+        string  subscription_id      "child sub under grouped invoicing"
+        string  sub_line_item_id
+        string  price_id
+        string  meter_id
+        date    period_start
+        date    period_end
+    }
+
+    WALLET_TRANSACTION {
+        string  id PK
+        string  wallet_id
+        string  type                 "CREDIT|DEBIT"
+        string  transaction_reason   "CREDIT_EXPIRED -> breakage"
+        decimal credit_amount
+        date    expiry_date
+    }
+```
+
+---
+
+## 5. Product analytics
+
+The flexible lens, largely **reusing existing infrastructure**: `meter_usage` plus a hardened, parameterized query builder that already supports filters, allow-listed group-by, windowed aggregation, and custom dimensions (arbitrary event properties via `JSONExtract`).
+
+Added on top:
+- **Saved views** (§9) — reusable, shareable slices as JSON.
+- **Runtime "adjusted usage."** "Billable vs. included usage" or "overage units" are computed **at query time** from the *current* entitlement/price config — **never stored**, because that config is versioned and a stored copy would go stale.
+- **Non-usage series.** Wallet transactions, credit grants, and price-change history are PeerDB-synced tables queried through the same view machinery (filtered lists, running totals).
+
+**Hard rule:** product-analytics views never render money as `usage × rate`. Money comes from `revenue_facts`.
+
+---
+
+## 6. Revenue analytics — the derived `revenue_facts` table
+
+### 6.1 Core idea: re-run the engine, record the decomposition
+
+Flexprice already computes charges through a **non-mutating preview path**: it applies entitlements, tiers, commitments, coupons in memory, and only persists/deducts at finalization. The rollup calls this path and records the output. Because it is literally the code that issues the invoice, the numbers reconcile **by construction** — no second pricing implementation.
+
+Two correctness requirements from the engine investigation:
+- Use the **standard preview reference point** (mirrors real finalization), **not** the "internal preview" path — the latter computes **multi-period commitments incorrectly** (it would true-up to the full annual amount every month).
+- Multi-period commitment state is only correct if prior periods are finalized. The rollup therefore **maintains its own cumulative "prior-base" running total** per commitment window and feeds it in, gating true-up to the final period — so correctness doesn't depend on invoice-finalization ordering.
+
+### 6.2 Revenue has multiple sources
+
+`revenue_facts` is not just "decomposed invoice line items." It is a unified revenue store with several **producers**, distinguished by `revenue_source`:
+
+| `revenue_source` | Producer | Reconciles to invoice? | Phase |
+|---|---|---|---|
+| `usage` | billing preview (usage line items) | yes | v1/v2 |
+| `fixed` | billing preview (fixed/recurring line items) | yes | v1/v2 |
+| `commitment_trueup` | billing preview (period-end shortfall) | yes | v1/v2 |
+| `credit_breakage` | wallet ledger (expired unused credits) | **no** (never invoiced) | Phase 4 |
+| `manual_adjustment` | credit notes / manual corrections | varies | later |
+
+Usage / fixed / true-up come from the billing engine and reconcile to the invoice. **Breakage** — recognizing previously-deferred revenue when prepaid credits expire unused — is derivable from `wallet_transactions` (`type=DEBIT`, `reason=CREDIT_EXPIRED`), is a **recognition-era** concept, and does not tie to any invoice. v1 only needs the `revenue_source` slot so these can be added later without a schema change.
+
+**Why `revenue_source`, and not `price_type`?** For price-derived rows, `revenue_source ∈ {usage, fixed}` carries the same fact as a price's `price_type`, so we keep only `revenue_source` (the "kind of revenue") and drop `price_type` — the underlying price's nature is a join to the synced `price` table if ever needed. The two only *diverge* for true-up: a `commitment_trueup` row sits on a **usage** price but is a different kind of revenue.
+
+**Why `commitment_trueup` must be its own row (not folded into usage).** A minimum-commitment true-up is revenue *not caused by usage* — it is the floor that applies when usage falls short. If we left it inside the usage line's amount and then daily-decomposed that line (§6.5), the entire true-up would land on the **last day** (that is when the floor engages) and falsely read as "usage earned on day 30." Emitting it as a separate `period_only` row dated at `period_end` keeps every usage day honest and lets finance answer "how much revenue was floor vs. actual usage." So it is required for correctness, not just labeling.
+
+### 6.3 Schema
+
+One row per **`(tenant, environment, subscription, price, day, revenue_source)`**. Daily grain enables fine-grained exports and future recognition. Money is decomposed into **columns on `usage` rows**; `fixed`/`trueup`/etc. are their own rows carrying just `net_amount`. Usage is measured **gross** (billable + allowance) so the allowance shows as a visible credit. **Tax and prepaid are excluded** (§6.6, §6.7).
+
+```sql
+CREATE TABLE revenue_facts (
+    tenant_id            LowCardinality(String),
+    environment_id       LowCardinality(String),
+    customer_id          String,
+    subscription_id      String,                  -- the LINE ITEM's subscription (child in grouped invoicing)
+    sub_line_item_id     String,
+    price_id             String,                  -- versioned; amendments create new ids
+    meter_id             LowCardinality(String),  -- '' for fixed / non-usage rows
+    aggregation_type     LowCardinality(String),  -- drives decomposability (§6.5); '' for non-usage rows
+    revenue_source       Enum8('usage'=1,'fixed'=2,'commitment_trueup'=3,'credit_breakage'=4,'manual_adjustment'=5),
+    -- NOTE: no price_type column — revenue_source subsumes the usage/fixed split; the
+    -- underlying price's nature is available by joining price_id to the synced price table.
+
+    -- time
+    period_start         Date,
+    period_end           Date,
+    day                  Date,                     -- grain (billing/booking day for non-usage rows)
+    service_start        Date,                     -- recognition-ready: the charge's service window
+    service_end          Date,
+    recognition_method   LowCardinality(String),   -- recognition-ready: 'point_in_time'|'ratable'|'usage' ('' in v1)
+
+    -- decomposition (usage rows only), GROSS basis, EXCLUDES tax & prepaid
+    usage_at_list_rate   Decimal(38,9),  -- (billable_qty + entitlement_qty) x list/effective rate
+    tier_delta           Decimal(38,9),  -- graduated only: engine Amount - gross_qty x tier1_rate; else 0
+    entitlement_credit   Decimal(38,9),  -- entitlement_qty x list rate  (>=0, subtracted)
+    line_discount        Decimal(38,9),  -- coupon on this line           (>=0, subtracted)
+    invoice_discount     Decimal(38,9),  -- invoice-level discount, allocated to line (>=0, subtracted)
+    net_amount           Decimal(38,9),  -- billed revenue for this row (excl tax, excl prepaid)
+
+    billable_qty         Decimal(38,9),  -- net of allowance
+    entitlement_qty      Decimal(38,9),
+    decomposition_mode   Enum8('marginal'=1, 'period_only'=2),  -- §6.5
+
+    -- lifecycle / audit
+    currency             LowCardinality(String),
+    status               Enum8('PROVISIONAL'=1, 'FINAL'=2, 'REVERTED'=3),
+    is_revert            UInt8,           -- append-only correction model (§8)
+    invoice_id           String,          -- draft id once a draft exists; stable through finalize
+    invoice_line_item_id String,          -- the specific line item, for exact reconciliation
+    lock_adjusted_day    Date,            -- recognition day given accounting-period lock (§8)
+    computed_at          DateTime64(3),
+    version              UInt64
+) ENGINE = ReplacingMergeTree(version)
+PARTITION BY toYYYYMM(day)
+ORDER BY (tenant_id, environment_id, subscription_id, price_id, day, revenue_source, is_revert);
+```
+
+**Decomposition-field rationale (reviewed):**
+- `usage_at_list_rate` + `tier_delta` — kept as two fields because the `list` policy (efficiency comparison) needs list rate and graduated pricing needs the delta. Collapsing them would lose list-vs-effective visibility that finance uses.
+- `entitlement_credit` — contra-revenue (value given away as allowance); finance wants it visible.
+- `line_discount` vs `invoice_discount` — kept separate: different origins, allocated differently (invoice-level is spread across lines). Merging loses "where the discount came from."
+- `fixed_charge` / `commitment_trueup` — **not columns.** They are separate `revenue_source` rows carrying `net_amount`, so a usage row never carries always-zero fixed/trueup columns and non-line-item revenue (breakage) fits the same shape.
+- `tax` — **removed** (invoice-level only in the system; §6.6).
+- `net_amount` — the row's billed revenue, tax- and prepaid-excluded.
+
+**Reconciliation (sanity check, not derivation):**
+- usage rows: `net_amount ≈ usage_at_list_rate + tier_delta − entitlement_credit − line_discount − invoice_discount`.
+- `fixed` / `commitment_trueup` rows: `net_amount` = the engine's amount for that charge.
+- Per line item/period: `Σ net_amount == that invoice_line_item's billed amount (excl tax)`.
+- Per invoice: `Σ net_amount == invoice.Subtotal − invoice.TotalDiscount` (pre-tax, pre-prepaid revenue). Tax is verified **separately** against `invoice.TotalTax` at invoice grain. Any gap → alert, never plugged.
+
+**Tiers:** graduated → `usage_at_list_rate = gross_qty × tier1_rate`, `tier_delta = engine Amount − gross_qty × tier1_rate` (one delta, no engine refactor). Volume/package/flat → single resolved rate on all units, `tier_delta = 0`.
+
+### 6.4 Linking `invoice_id`
+
+- Join key is the **line item's** identity: `invoice_line_item.subscription_id + price_id + period` (and `sub_line_item_id`). **Not** `invoice.subscription_id` — under **grouped invoicing** a parent invoice merges children and each merged line item is stamped with the *child* `subscription_id`, so the invoice's own subscription differs from the line item's.
+- A **draft invoice id exists before finalization** (the flow is draft → compute → finalize). So once a draft exists for a period, `revenue_facts.invoice_id` (and `invoice_line_item_id`) are stamped and stay stable through finalization. Mid-period provisional rows, before any draft exists, carry empty ids.
+- At finalization we match rows to the finalized line items and assert reconciliation.
+
+### 6.5 Daily decomposition — what one row means, and how it is computed
+
+**A row is the revenue *earned on that day*, not "revenue up to that day."** This is the single most important thing to understand about the table. The billing engine gives us a *cumulative* number (the charge for everything through day D), but what we **store** is the **marginal difference** — day D's slice alone:
+
+> for a `usage` row, `component(day D) = charge(cumulative usage through D) − charge(cumulative usage through D−1)`,
+> applied to `usage_at_list_rate`, `tier_delta`, and `entitlement_credit` (allowance consumed earliest-first).
+
+So `SUM(net_amount)` over days 1..D gives the cumulative-through-D; a single row is one day's incremental revenue. You reconstruct any "as of day X" snapshot by summing rows up to X — you never store cumulative values.
+
+The marginal-cumulative difference applies **only to the usage-rate components** of a `usage` row (the part with a cumulative-usage curve). Everything else is layered on per its own rule.
+
+Everything else is layered per its own rule — **this is the part the earlier draft glossed over:**
+- **Discounts**: a percentage discount scales the day's usage amount; a fixed discount is allocated by day share.
+- **Fixed charges** (`revenue_source='fixed'`): **not** usage-curve-driven. In v1 (billed) they book as a single row on the **billing-cadence day** (advance → `period_start`, arrear → `period_end`), `decomposition_mode='period_only'`. (The $1/day straight-line spread is the *recognized* view — §11, Phase 4 — using `service_start/end`.)
+- **Commitment true-up** (`revenue_source='commitment_trueup'`): a period-end shortfall → one `period_only` row dated at `period_end`.
+- **Tax**: not in `revenue_facts` (§6.6).
+
+So a usage row's `net_amount(D)` is assembled from the day's marginal usage components plus daily-proportional discount — **not** a single cumulative subtraction over the whole invoice; and fixed/true-up are separate rows, not part of any day's marginal difference.
+
+#### Worked example — how the rows for one subscription-month are computed
+
+**Setup.** A 30-day monthly subscription with:
+- a **$30/month platform fee**, billed **in advance**;
+- a **usage meter** at a flat **$0.01/call**, with **20,000 calls included** (allowance);
+- a **$500 minimum commitment** on usage.
+- Actual usage: **2,000 calls/day** → **60,000 calls** for the month.
+
+**Step 1 — usage rows (marginal, daily).** The allowance (20,000) is consumed earliest-first, i.e. over days 1–10 (2,000/day). The engine's cumulative *billable* charge is $0 through day 10, then rises $20/day.
+- Day 11's row = `charge(through 11) − charge(through 10)` = $20 − $0 = **$20**. Every later day is the same.
+- Days 1–10: gross `usage_at_list_rate` = $20, `entitlement_credit` = $20, `net_amount` = **$0** (fully inside the allowance — visible as a giveaway, not hidden).
+- Days 11–30: `usage_at_list_rate` = $20, `entitlement_credit` = $0, `net_amount` = **$20**. That's 20 days × $20 = **$400** of usage revenue.
+
+**Step 2 — fixed row (period_only).** One row on **day 1** (advance cadence): `revenue_source=fixed`, `net_amount=$30`, `decomposition_mode=period_only`. (Not $1/day — that straight-line spread is the *recognized* view, Phase 4.)
+
+**Step 3 — commitment true-up (period_only).** Usage revenue ($400) is below the $500 minimum, so a true-up of **$100** is booked as one row on **day 30**: `revenue_source=commitment_trueup`, `net_amount=$100`, `period_only`.
+
+**Resulting rows (representative):**
+
+| day | revenue_source | usage_at_list_rate | entitlement_credit | net_amount | mode |
+|---|---|---:|---:|---:|---|
+| 1 | fixed | – | – | 30.00 | period_only |
+| 1 | usage | 20.00 | 20.00 | 0.00 | marginal |
+| … 2–10 | usage | 20.00 | 20.00 | 0.00 | marginal |
+| 11 | usage | 20.00 | 0.00 | 20.00 | marginal |
+| … 12–30 | usage | 20.00 | 0.00 | 20.00 | marginal |
+| 30 | commitment_trueup | – | – | 100.00 | period_only |
+
+`SUM(net_amount)` = $30 + (10 × $0) + (20 × $20) + $100 = **$530**, which equals the invoice's pre-tax revenue (`Subtotal − TotalDiscount`). Each row answers "what revenue was earned, of what kind, on what day" — and they add up to the invoice, exactly.
+
+**Guard:** the rollup reads **pre-aggregated `meter_usage`** (event quantities already clamped ≥ 0), **never raw events** — removing an entire class of "negative day" bugs.
+
+**When marginal decomposition is valid vs. not:**
+
+```mermaid
+flowchart TD
+  A[Usage line item for a period] --> B{charge cumulative<br/>monotonic and additive?}
+  B -- yes --> C[decomposition_mode = marginal<br/>engine day checkpoints]
+  B -- no --> D[decomposition_mode = period_only<br/>one authoritative row per cycle]
+  C --> E[daily rows exact, sum to period total]
+  D --> F[daily *shape* for charts is a READ-TIME allocation,<br/>flagged 'estimated', never stored, never summed]
+```
+
+`marginal` (exact): `SUM`/`COUNT`/`COUNT_UNIQUE`/`SUM_WITH_MULTIPLIER`/`MAX` with flat/graduated/package pricing; also bucketed-`MAX` with **sub-day** buckets (15m…day — all divide a day evenly).
+
+`period_only` (non-decomposable — one authoritative row per cycle):
+
+| Condition | Why daily decomposition breaks |
+|---|---|
+| **Volume tiers** | Resolved rate applies to all units; crossing to a cheaper tier makes the total *drop* → negative marginal day. |
+| **`LATEST`** | Value can fall over time → cumulative charge drops. |
+| **`AVG`** | Cumulative average falls on a low day → charge drops. |
+| **`WEIGHTED_SUM`** | Weights depend on `period_end`; recomputing "cumulative through D" re-weights all prior events → non-additive. |
+| **Bucketed `MAX`, week/month buckets** | A bucket spans multiple days; a single day's share is undefined. (Sub-day buckets are fine.) |
+
+Explicitly **safe** (not on the list): package/`ceil` (monotonic, only lumpy), and negative raw quantities (prevented by the ingestion clamp).
+
+**Authoritative rule (bookkeeping):** stored rows are `marginal` (daily) or `period_only` (per cycle), mutually exclusive per line-item-period — so summing stored rows is always exact. The approximate daily *shape* for a `period_only` item (for a chart) is computed **at read time** by proportional allocation over `meter_usage`, labeled `estimated`, and is **never stored and never summed** into an authoritative total.
+
+### 6.6 Tax is excluded from `revenue_facts`
+
+Tax in Flexprice is computed **at the invoice level** (one `tax_applied` row per tax rate; no per-line-item tax), and under ASC 606 collected tax is a **liability, not revenue**. So `revenue_facts` carries **tax-excluded** revenue and has **no tax column**. Tax lives at invoice grain in the synced `invoice` table (`TotalTax`) and reconciles separately. If a tenant ever wants "tax by dimension," it can only be a **read-time estimated allocation** of invoice tax by line share (flagged estimated) — the system does not compute per-line tax, so we will not fabricate it as authoritative.
+
+### 6.7 Prepaid credits are excluded (ASC 606-aligned)
+
+`revenue_facts` records the **earned charge**. It does **not** subtract prepaid/wallet drawdown: under ASC 606 prepaid money is a **contract liability (deferred revenue)** until the service is delivered; the revenue is earned regardless of settlement method. Prepaid drawdown lives in the `wallet_transactions` ledger. *(Recognition-phase nuance: credits sold at a discount/bonus recognize at their cost basis when consumed — §11, not a `revenue_facts` column. Expired unused credits become `credit_breakage` revenue — §6.2.)*
+
+---
+
+## 7. Write path (the rollup)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant WM as Watermark (Postgres)
+    participant RJ as Rollup job (Temporal)
+    participant EN as Billing Preview Engine
+    participant RF as revenue_facts (CH-B)
+
+    WM->>RJ: dirty subscriptions (usage moved / period close / amendment)
+    loop each dirty subscription
+        RJ->>EN: preview OPEN period (standard reference point)<br/>request cumulative day-checkpoints
+        Note over RJ,EN: feed our cumulative commitment prior-base
+        EN-->>RJ: decomposed line items + cumulative curve
+        RJ->>RJ: usage rows -> marginal (else period_only);<br/>fixed / true-up -> own rows
+        RJ->>RJ: assert per-row + Σ net == line-item / invoice revenue
+        alt period still open
+            RJ->>RF: upsert (version++)
+        else finalized / accounting-locked
+            RJ->>RF: append REVERTED row(s) + fresh rows
+        end
+    end
+```
+
+- **Dirty-subscription set** — from a usage watermark plus period-close and amendment events; only subscriptions that moved are rebuilt.
+- **Whole-open-period recompute** — tiers/allowances/commitments are period-cumulative; cheap because it reads aggregated `meter_usage`, not raw events.
+- **Cadence** — watermark-driven; a modest default (e.g. hourly) for open periods, tunable. `FINAL` periods are never recomputed, only corrected (§8). A configurable **grace window** (~3 days, à la Orb) keeps a period `PROVISIONAL` while late usage settles.
+- **Isolation** — separate ClickHouse role/quota so a backfill can't starve the tenant read path.
+- **Engine dependency to build** — a preview entry point returning cumulative charge as-of an arbitrary in-period date, ideally all day-checkpoints in one pass (Q2).
+
+---
+
+## 8. Lifecycle, locks, and corrections
+
+Two **independent** locks:
+
+```mermaid
+stateDiagram-v2
+    [*] --> PROVISIONAL: period opens
+    PROVISIONAL --> PROVISIONAL: rebuild (ReplacingMergeTree, version++)
+    PROVISIONAL --> FINAL: invoice finalized + reconcile assert
+    FINAL --> REVERTED: correction — append REVERTED (negatives)
+    REVERTED --> FINAL: fresh FINAL rows (new version)
+    note right of PROVISIONAL
+        Lock 1: invoice finalization
+        (per subscription-period)
+    end note
+    note right of FINAL
+        Lock 2: accounting-period close
+        (per calendar period, all subs)
+        -> corrections post as catch-up
+        to next open period (lock_adjusted_day)
+    end note
+```
+
+1. **Invoice finalization** (per subscription-period): billed amounts become legally fixed. Rows flip `PROVISIONAL → FINAL`, get `invoice_id`/`invoice_line_item_id`, and we assert reconciliation.
+2. **Accounting-period lock** (ASC 606 finance close, per calendar period across all subscriptions): once a month is closed, its recognized numbers are frozen.
+
+**Storage by lock state:**
+- **Open / provisional** → `ReplacingMergeTree(version)`: recompute freely, last version wins, high churn, nobody depends on it yet.
+- **Finalized or accounting-locked** → **append-only, corrected via reverts.** There is **no `AMENDED` state.** A correction appends **`REVERTED`** rows (the exact negatives of what's being corrected, `is_revert=1`) plus fresh `FINAL` rows with a new `version`. Summing all rows is self-correcting (original + its `REVERTED` twin = 0). Closed accounting periods are never mutated in place.
+
+**`lock_adjusted_day`** is the day a row is *recognized* given lock posture: it equals `day` when the period is open, and shifts to the **first day of the next open period** when the real period is closed — a "catch-up" so a closed month is never rewritten. Reports key on `lock_adjusted_day`; analytics/attribution key on `day`.
+
+---
+
+## 9. Serving layer (a translator, not a compiler)
+
+A **saved view is a JSON row in Postgres**, immutable and versioned. It creates nothing in ClickHouse.
+
+```json
+{
+  "view_id": "view_01JQZ8...",
+  "view_version": 3,
+  "name": "Revenue by feature",
+  "shape": "breakdown",
+  "metrics": ["revenue"],
+  "dimensions": ["feature_id"],
+  "allocation_policy": "billed",
+  "filters": [{ "field": "customer_id", "op": "in", "value": "{{customers}}", "optional": true }],
+  "time": { "range": "{{date_range}}", "grain": "month" },
+  "sort": [{ "field": "revenue", "dir": "desc" }],
+  "limit": 25,
+  "variables": [
+    { "name": "date_range", "type": "date_range", "required": true },
+    { "name": "customers", "type": "string_list", "required": false }
+  ]
+}
+```
+
+```mermaid
+flowchart LR
+  V[View JSON + variables] --> T1[resolve & type-check variables]
+  T1 --> T2[inject tenant + env RLS]
+  T2 --> T3{metric to table}
+  T3 -- usage --> MU[meter_usage query builder]
+  T3 -- revenue --> RF[revenue_facts SQL<br/>+ allocation join]
+  T3 -- ledger --> SY[synced table SQL]
+  MU --> BIND[bind vars as CH query params]
+  RF --> BIND
+  SY --> BIND
+  BIND --> EX[execute on CH-B] --> SH[shape to columns + rows]
+```
+
+- **Shapes (v1):** `timeseries`, `breakdown`, `single_value`, `drilldown`. (`pivot`, `distribution` later.)
+- **Variables** bind as **ClickHouse query parameters**, never string interpolation. Optional filters with no value are dropped from `WHERE`. Dimension-position variables are allowed only against a per-tenant registered-property allowlist.
+- **Custom dimensions** are aggregated **at read time** (`JSONExtract` over `meter_usage`; an allocation join for revenue).
+- **Allocation presets** (custom-dimension revenue only): `billed` (default; aggregate-level components as their own rows so every line is defensible) and `amortized` (aggregate effects spread by usage share). Allocate per price, then sum. A third, `list` (usage at list rate only), is an opt-in for efficiency comparisons; it deliberately does **not** reconcile and returns `reconciles_to_invoice: false`.
+- **Authoritative vs. estimated:** a revenue query returns stored authoritative rows (`marginal` + `period_only`). A daily-shape chart over `period_only` items uses read-time `estimated` allocation, labeled and never summed into an authoritative total.
+
+### 9.1 Anatomy of a view — what each field means
+
+| Field | Meaning | Notes |
+|---|---|---|
+| `shape` | The query template: `timeseries` (metric over time), `breakdown` (metric grouped by 1–N dimensions, ranked), `single_value` (one number, e.g. a KPI), `drilldown` (raw rows). | Determines the SQL structure and the chart type. |
+| `metrics` | *What* to measure — each maps to a `(table, aggregation)` (see 9.2). E.g. `usage_quantity`, `event_count`, `billable_usage`, `revenue`. | Multiple metrics allowed if they share a source table. |
+| `dimensions` | The **group-by** keys. Structural (`customer_id`, `plan_id`, `feature_id`, `meter_id`) or custom (any event property, e.g. `region`, `api_key`). | This is the `GROUP BY`. Order matters for `breakdown` ranking. |
+| `filters` | `WHERE` predicates as `{field, op, value}`. `op` ∈ eq/in/gt/…; `value` may be a `{{variable}}`. | An **optional** filter whose variable is unset is **dropped** from the query, not passed as null. |
+| `time` | `range` (often a `{{variable}}`) + `grain` (`day`/`week`/`month`). | `grain` sets the time bucket for `timeseries`. |
+| `sort`, `limit` | Ordering and top-N. | Drives "top 10 customers by revenue". |
+| `allocation_policy` | Only for **custom-dimension revenue** — `billed` / `amortized` / `list` (§9 bullets). | Ignored for usage metrics and structural revenue breakdowns. |
+| `variables` | Typed placeholders (`date_range`, `string`, `string_list`, `number`, `enum`, `boolean`) bound at query time. | Bound as **ClickHouse query parameters**, never string-interpolated. |
+
+**Group-by resolution.** A **structural** dimension resolves by joining `price_id`/`meter_id`/`customer_id` to the PeerDB-synced entity tables in CH-B (e.g. `feature_id` via the meter→feature relation). A **custom** dimension (e.g. `region`) resolves via `JSONExtractString(properties, 'region')` on `meter_usage` **at read time** — no pre-declaration, but it must pass the registered-property allowlist to become a legal group-by.
+
+### 9.2 What powers a view — and where "runtime adjustments" apply
+
+The metric decides the source table. This is the crux of your question, and the split is deliberate:
+
+| Metric kind | Powered by | Adjustments |
+|---|---|---|
+| **Usage** (`usage_quantity`, `event_count`, `billable_usage`, `overage_units`) | **`meter_usage`** via the existing query builder | "Adjusted" usage (`billable_usage`, `overage_units`) is computed **at runtime** by applying the *current* entitlement/price config to the raw usage — never stored, so it can't go stale. |
+| **Revenue** (`revenue`, `usage_at_list_rate`, `entitlement_credit`, …) | **`revenue_facts`** (pre-computed) | Money is **not** derived from `meter_usage` at read time — tiers/allowances/commitments make `usage × rate` wrong. It is read from `revenue_facts`, which the engine already priced. Custom-dimension revenue additionally does a read-time **allocation join** to `meter_usage` for the dimension's usage share. |
+| **Ledger** (credit top-ups, balance, price-change history) | **synced tables** (`wallet_transactions`, …) | Simple filters/sums; no pricing. |
+
+So: **usage views** *are* powered by `meter_usage` with runtime-computed adjustment fields — exactly as you said. But **revenue views** are powered by `revenue_facts`, precisely because revenue can't be safely recomputed from usage at read time. A view that mixes a usage metric and a revenue metric runs two sub-queries (one per source) and joins the results in the serving layer.
+
+---
+
+## 10. Warehouse export
+
+Daily grain makes tenant-side BI viable. Export surface:
+- **Derived:** `revenue_facts` (and, later, the recognition table).
+- **Raw (PeerDB-synced):** `invoice`, `invoice_line_item`, entities, `wallet_transactions` — reconciliation anchor and structural dimensions.
+
+Export is a fast-follow on `revenue_facts`, hedging the risk that a full in-app builder is more than some tenants need. Mechanism (snapshot vs. incremental by `updated_at`/`version`; destinations) is deferred; the common pattern is a first full snapshot then daily incrementals.
+
+---
+
+## 11. ASC 606 recognition-readiness
+
+v1 carries the fields a recognition engine needs — daily grain, `service_start`/`service_end`, `recognition_method`, `net_amount`, `is_revert`, `lock_adjusted_day`, `revenue_source` — but v1 stores **billed** revenue only; it does **not** compute recognized/deferred/unbilled.
+
+Concretely, this is the billed-vs-recognized split the fixed-charge example makes vivid: a $30/month fee **bills** as a lump on its cadence day (v1), but **recognizes** straight-line ≈ $1/day over its service window (`recognition_method='ratable'`, Phase 4). The recognition engine (Phase 4) will also handle usage-based recognition, deferred & unbilled balances, credit cost-basis, **breakage** (`credit_breakage` from expired credits), performance obligations, and period locks. Deferring it costs nothing structurally because the schema is already shaped for it.
+
+### 11.1 Breakage, worked through — why it is revenue with no invoice
+
+"Breakage" is the accounting term for **deferred revenue that becomes real when a prepaid obligation will never be fulfilled** — here, when prepaid credits expire unused. It matters because otherwise that pre-collected cash would sit forever as a liability that will never be delivered against.
+
+**Example.** A customer prepays **$100** for **10,000 credits** (1 credit = $0.01), expiring in 90 days.
+1. **At purchase** — $100 cash in. This is **deferred revenue (a liability)**, *not* revenue. Nothing lands in `revenue_facts`. (Prepaid is excluded — §6.7.)
+2. **As credits are consumed** — say the customer runs **6,000 credits** ($60) of usage over the quarter. That usage is *billed* like any usage (invoice line items), so it appears as normal **`usage` revenue** in `revenue_facts`, reconciling to those invoices. The wallet drawdown that *settles* those invoices is just a `wallet_transactions` movement.
+3. **At expiry** — **4,000 credits ($40) expire unused.** The system already writes a `CREDIT_EXPIRED` debit to `wallet_transactions`. The recognition engine reads that and books a **`credit_breakage`** row in `revenue_facts`: `net_amount=$40` (at the credits' cost basis), `day` = expiry date, `invoice_id=''`, `decomposition_mode=period_only`.
+
+**Total recognized** from the $100 prepaid = $60 usage (as consumed) + $40 breakage (at expiry) = **$100** — it ties back to the cash over time, but through two different revenue sources and two different moments. Breakage is `revenue_source=credit_breakage`, reconciles to **no** invoice (there never was one), and is therefore excluded from the invoice-reconciliation invariants.
+
+**Use-cases this unlocks:** "breakage revenue this quarter", "deferred-revenue balance outstanding" (unconsumed, unexpired credits), and "prepaid → recognized waterfall" (how a cohort's prepayment converts to usage vs. breakage over time). All are recognition-era (Phase 4); v1 only reserves the `revenue_source` slot so no schema change is needed later.
+
+---
+
+## 12. Design choices and non-goals
+
+- **No tenant SQL and no semantic-model DSL / query compiler.** The serving layer is a translator over an existing hardened query builder.
+- **No cross-tenant "auto-cube" discovery in v1.** `meter_usage`'s sort key serves hot dimensions; custom dimensions use `JSONExtract`. Targeted per-shape projections come later, on query-log evidence.
+- **No pre-declared attribution/dimension registry.** Custom dimensions work on demand.
+- **Money is engine-computed, never re-derived in SQL.**
+- **Analytics never feeds billing.**
+
+---
+
+## 13. Invariants (asserted in code, with alerts)
+
+1. Per-row reconciliation residual ≈ 0 (usage rows against their component sum).
+2. `Σ net_amount(day) == engine period total` for a line item; at FINAL, `Σ net_amount == invoice.Subtotal − TotalDiscount` for the invoice. Fail → alert, never silent-correct.
+3. Tax reconciles separately: invoice-grain `Σ tax_applied == invoice.TotalTax`. Tax never appears in `revenue_facts`.
+4. Any allocation policy except `list`: `Σ returned revenue == reconcilable revenue for the filter scope`. `list` carries `reconciles_to_invoice: false`.
+5. No query executes without tenant + environment predicates injected by the serving layer.
+6. No cache entry is keyed without tenant + environment.
+7. Analytics tables are never read by the invoicing path.
+8. Finalized / accounting-locked rows are never mutated in place — corrections are append + `REVERTED`.
+9. The rollup reads pre-aggregated `meter_usage`, never raw events.
+10. Multi-period commitments use the standard preview path + our cumulative prior-base, never the internal-preview path.
+11. Revenue-facts join to invoices on the **line item's** subscription, never the invoice's (grouped invoicing).
+
+---
+
+## 14. Phasing
+
+| Phase | Ships | Proves | Prerequisites |
+|---|---|---|---|
+| **1** | Saved-view model + serving translator + `/analytics/query` over `meter_usage` (usage only). `timeseries` + `breakdown`. | The view model expresses today's hand-built usage views. | none |
+| **2** | `revenue_facts` (daily, columnar, multi-source) + preview rollup + engine day-checkpoints + cumulative commitment prior-base + append/`REVERTED` + two-lock lifecycle + `usage`/`fixed`/`commitment_trueup` sources + **structural** revenue breakdowns + reconciliation asserts. Run silently one full cycle. | Billed money in-surface, reconciling, at daily grain. | engine cumulative-checkpoint entry point; decomposition-mode classifier |
+| **3** | **Custom-dimension** revenue allocation + `billed`/`amortized` presets + non-usage ledger views. | Flexible revenue slicing that reconciles. | Phase 2 green |
+| **4** | Warehouse export; evidence-driven acceleration; **ASC 606 recognition engine** (recognized/deferred/unbilled, straight-line fixed, usage recognition, `credit_breakage`, period locks). | Tenant BI; recognized revenue. | query-log evidence; recognition spec |
+
+**Phase 2 gate:** do not expose revenue breakdowns until reconciliation (invariants 1–2) has been green for a full cycle.
+
+---
+
+## 15. Open questions
+
+**Q1 — Cost of the preview call under rollup load.** The rollup re-runs the billing preview for every dirty subscription's open period, potentially hourly. *Why it matters:* it sets achievable cadence and whether we (a) lengthen the interval, (b) reuse an already-computed draft invoice, or (c) cache the preview per period keyed on the usage watermark. *Resolved by:* a benchmark against realistic volumes with the billing-workflow owners.
+
+**Q2 — Engine entry point for as-of-day cumulative charge.** Daily decomposition needs `charge(cumulative through D)` at each day boundary, ideally emitted in one pass. *Why it matters:* calling the engine once per day per subscription may be too costly, and a one-pass API keeps pricing logic in the engine (never reimplemented in the rollup). *Resolved by:* a design review with billing to extend the preview path to return a cumulative curve; scope the change.
+
+**Q3 — Multi-period commitment prior-base.** For an annual commitment billed monthly, month N needs cumulative consumption from months 1..N-1; the engine reads it only from *finalized* invoices and degrades silently otherwise. *Why it matters:* the rollup produces provisional numbers before finalization, exactly when the engine's source is incomplete. *Resolved by:* fixing the fields of a rollup-maintained cumulative prior-base (sum of usage-line base; overage lines ÷ overage factor; true-up excluded), where it's stored, and the rule gating true-up to the final period.
+
+**Q4 — PeerDB sync coverage and latency.** The design assumes `invoice`, `invoice_line_item`, `wallet_transactions`, and entities are in CH-B with low lag. *Why it matters:* structural breakdowns and ledger views join these; the reconciliation anchor is the synced invoice. *Resolved by:* confirming which tables PeerDB replicates into CH-B, observed lag, and failure/backfill behavior.
+
+**Q5 — Allocation basis for `period_only` daily shape.** Rendering a daily shape for a non-decomposable item allocates the period total proportionally, proposed as that day's usage share. *Why it matters:* for volume tiers and `LATEST`/`AVG` meters this is defensible but not unique; even-spread may read better for some. *Resolved by:* picking a default and checking it against real volume-tier and `LATEST` examples; decide if it's per-aggregation-type.
+
+**Q6 — Ownership and rules of the accounting-period lock.** `lock_adjusted_day` and catch-up assume someone closes periods. *Why it matters:* it determines whether this is a tenant-facing finance control, the catch-up posting rule for backdated activity, and its interaction with invoice finalization. *Resolved by:* a product decision on period-close ownership and a short spec of catch-up rules.
+
+**Q7 — Retention at daily grain.** Daily `revenue_facts` grows with `subscriptions × prices × days`. *Why it matters:* replica storage vs. how far back tenants query at daily resolution. *Resolved by:* a retention policy (e.g. daily for N months, then monthly), informed by expected volume.
+
+**Q8 — Export mechanism.** Destinations, full-snapshot vs. incremental watermark, dedupe semantics. *Why it matters:* it's the interface tenants' BI depends on; wrong choices create duplicate/stale rows. *Resolved by:* a Phase-4 export design following "first full snapshot, then daily incremental."
+
+**Q9 — Breakage timing and reconciliation.** Expired credits (`CREDIT_EXPIRED` debits) become `credit_breakage` revenue, but this is recognition-era and does not tie to an invoice. *Why it matters:* it's revenue with no invoice anchor, so it needs its own correctness story (when recognized, at what amount/cost-basis). *Resolved by:* the Phase-4 recognition spec.
+
+---
+
+## Appendix A — Glossary
+
+- **Meter / aggregation type** — how usage events become a billable quantity (`SUM`, `COUNT`, `COUNT_UNIQUE`, `MAX`, `LATEST`, `AVG`, `SUM_WITH_MULTIPLIER`, `WEIGHTED_SUM`).
+- **Graduated vs. volume tiers** — graduated charges each bracket at its rate; volume applies one rate (the reached tier's) to all units.
+- **Entitlement / allowance** — included usage, not charged.
+- **Commitment / true-up** — minimum spend; true-up covers a shortfall. May span multiple billing periods.
+- **Billing cadence (advance/arrear)** — a recurring fee billed at period start vs. period end.
+- **Billed vs. recognized revenue** — invoiced vs. earned; ASC 606 governs recognition timing.
+- **Deferred revenue** — money received but not yet earned (a liability); prepaid credits are deferred until consumed.
+- **Breakage** — deferred revenue recognized when prepaid credits expire unused.
+- **PeerDB / CH-B** — the CDC pipeline replicating Postgres into the ClickHouse analytics replica this platform reads.
+
+## Appendix B — Codebase anchors
+
+- Preview (correct path): `PrepareSubscriptionInvoiceRequest` `internal/ee/service/billing.go:1558`; standard preview reference point `billing.go:1735`. **Avoid** `GetInternalPreviewInvoice` `invoice.go:2355` for commitments.
+- Commitment cumulative logic: `billing_meter_usage.go:53,77`; `getCumulativePriorBaseFromInvoices` `billing.go:1335` (finalized-only); math `billing_commitment.go:218,397,489`.
+- Tax (invoice-level): `CalculateTaxesOnInvoice` `internal/ee/service/tax.go:1130`; `taxableAmount` `tax.go:1118`; `TaxApplied` `internal/domain/taxapplied/model.go:13` (entity=invoice, no line-item ref). Invoice totals `internal/domain/invoice/model.go` (Subtotal 51, Total 54, TotalTax 131); total formula `invoice.go:3975`.
+- Invoice/line-item linking + grouped invoicing: line item `subscription_id`/`sub_line_item_id` `internal/domain/invoice/line_item.go:19,54`; grouped merge stamps child subscription `billing.go:1870-1904`; draft-first flow `invoice.go:289,378`.
+- Fixed charge cadence: `InvoiceCadence` ADVANCE/ARREAR `internal/types/invoice.go:31`; processing `billing.go:158-220`; service-window stamp `buildFixedInvoiceLineItem` `billing.go:332,374`.
+- Credit expiry (breakage source): `ExpireCredits` `internal/ee/service/wallet.go:2457`; `TransactionReasonCreditExpired` `internal/types/wallet.go:66`; cron `temporal/workflows/cron/wallet_credit_expiry_workflow.go`.
+- Usage engine (build on): `internal/repository/clickhouse/meter_usage_query_builder.go`, `aggregators.go`; table `migrations/clickhouse/000007_create_meter_usage.sql`; ingestion clamp `meter_usage_tracking.go:493`.
+- Price math: `internal/ee/service/price.go:1088-1239`, bucketed max `1065-1084`; `internal/domain/price/model.go:275-360`.
+- Monthly persistence (no analytics precompute exists): `invoice.go:430-618,2112`.
+- Analytics-lake feed (usage → CH-B): `internal/ee/analytics/meter_usage_sink_publisher.go` (`cfg.Analytics`).

--- a/docs/design/2026-09-10-FLE-1257-analytics-platform-erd.md
+++ b/docs/design/2026-09-10-FLE-1257-analytics-platform-erd.md
@@ -61,7 +61,7 @@ A reader who has *not* followed the design discussion. Section 2 gives the backg
 3. **Analytics is downstream-only.** Derived, read-only; the billing/invoicing path never reads it.
 4. **Nothing tenant-authored becomes a database object.** Saved views are JSON in Postgres; tenants never cause DDL or submit SQL.
 5. **Product analytics shows usage; money comes only from the revenue table.** Never approximate money as `usage × rate` in the product-analytics path — it ignores tiers/allowances and is wrong.
-6. **ClickHouse is optional; revenue analytics runs on Postgres alone.** `revenue_facts` and everything it joins to live in Postgres, so a tenant with no metered usage still gets full revenue analytics. ClickHouse is required only for usage/product analytics.
+6. **Revenue's system of record is Postgres; analytics is served from ClickHouse (B).** `revenue_facts` is authored in Postgres by the rollup, so revenue is computed and durable **without any ClickHouse dependency** — a tenant with no usage/metered features still gets full revenue data. Postgres (incl. `revenue_facts`) is then synced into the **ClickHouse (B)** analytics replica, and **all** analytics queries — usage *and* revenue — are served from CH (B), so there is one uniform read store and no cross-store joins. The `revenue_facts` primary can later move from Postgres to **ClickHouse (A)** without touching the serving layer, since CH (A) also syncs to CH (B).
 
 ---
 
@@ -69,43 +69,39 @@ A reader who has *not* followed the design discussion. Section 2 gives the backg
 
 ```mermaid
 flowchart LR
-  subgraph PG[Postgres  •  source of truth + revenue store]
-    SRC[subs, prices, entitlements, commitments,<br/>invoices, invoice_line_items, wallet_transactions]
-    RF[revenue_facts<br/>DERIVED, daily]
+  subgraph PG[Postgres  •  system of record]
+    SRC[subs · prices · entitlements · commitments<br/>invoices · invoice_line_items · wallet_transactions]
+    RF[revenue_facts  DERIVED, daily<br/>primary today; movable to ClickHouse A later]
   end
 
-  subgraph CH[ClickHouse  •  OPTIONAL — only with metered usage]
-    MU[meter_usage<br/>usage facts]
+  EV[Usage events] --> MU[ClickHouse A · meter_usage]
+
+  subgraph CHB[ClickHouse B  •  analytics serving replica]
+    Q[meter_usage + revenue_facts + entities<br/>all synced here — serves every query]
   end
 
-  EV[Usage events] --> MU
-  ENG[Billing Preview Engine<br/>non-mutating]
-  ROLL[Rollup workflow<br/>watermarked]
-  SRV[Serving layer<br/>view JSON to SQL + RLS]
-
-  SRC --> ENG
-  MU -. metered usage only .-> ENG
-  ENG --> ROLL
-  MU -. usage curve .-> ROLL
+  SRC --> ENG[Billing Preview Engine · non-mutating]
+  MU -. metered usage + cumulative curve .-> ENG
+  ENG --> ROLL[Rollup workflow · watermarked]
   ROLL --> RF
+  PG == PeerDB CDC ==> CHB
+  MU == sync ==> CHB
 
-  RF --> SRV
-  SRC --> SRV
-  MU -. usage / product analytics .-> SRV
+  CHB --> SRV[Serving layer · view JSON to SQL + RLS]
   SRV --> API[Views API + Saved Views]
   SRV --> EXP[Warehouse export]
 ```
 
-- **`revenue_facts` lives in Postgres.** Revenue exists even for tenants with no usage events or metered features (fixed fees, commitments, one-off invoices), so revenue analytics must **not** depend on ClickHouse. The table is **small by construction** (subscriptions × prices × days), well within Postgres's reach, and it joins natively to the invoice/entity tables that already live in Postgres — no cross-store hop for structural revenue.
-- **ClickHouse is optional.** It holds `meter_usage` (aggregated usage) and powers **product/usage analytics**. Tenants who don't use metered features never need it; a read replica can isolate the analytics read path when it *is* used.
-- **`revenue_facts`** — the new **derived** table produced by the rollup (§6–7), in Postgres.
-- **Serving layer** — turns a saved view into parameterized SQL, injects tenant isolation, and routes by metric: **revenue → Postgres**, **usage → ClickHouse** (when present). Custom-dimension revenue (money × usage share) is the one cross-store case, and it applies only when ClickHouse is in use (§9.2).
+- **Postgres is the system of record for `revenue_facts`.** The rollup (§6–7) writes it in Postgres, so revenue is computed and durable with **no ClickHouse dependency** — a tenant with no metered usage still gets full revenue data. It is **small by construction** (subscriptions × prices × days).
+- **ClickHouse (B) is the uniform serving replica.** Postgres — `revenue_facts`, invoices, entities — syncs to CH (B) via **PeerDB**; `meter_usage` (from ClickHouse A) syncs there too. **All** analytics queries, usage *and* revenue, are served from CH (B). One read store ⇒ no cross-store joins.
+- **Movable primary.** The `revenue_facts` primary can later move from Postgres to ClickHouse (A); since CH (A) also syncs to CH (B), the serving layer is unaffected.
+- **Serving layer** — turns a saved view into parameterized SQL over CH (B), injects tenant isolation, and feeds the API and exports.
 
 Everything is scoped by `tenant_id` + `environment_id`; every query filters on both.
 
 ### 4.1 Data model (ERD)
 
-`revenue_facts` (**Postgres**) is the one **derived** table; the entities it joins to — `invoice`, `invoice_line_item`, `subscription`, `price`, `customer`, `wallet_transaction` — are **native Postgres** source tables, and `meter_usage` is the **ClickHouse** usage store (optional). Relationships below are the join keys the serving/rollup layers use — `revenue_facts` is intentionally denormalized (it stores ids, not FKs) so these are logical joins, not enforced constraints.
+`revenue_facts` is the one **derived** table. Its **system of record is Postgres** (authored by the rollup); it — with the invoice/entity/wallet source tables — is synced into **ClickHouse (B)**, the analytics replica that **serves all queries**. `meter_usage` is the ClickHouse usage store. Relationships below are the join keys the serving/rollup layers use — `revenue_facts` is intentionally denormalized (it stores ids, not FKs) so these are logical joins, not enforced constraints.
 
 ```mermaid
 erDiagram
@@ -211,7 +207,7 @@ The flexible lens, largely **reusing existing infrastructure**: `meter_usage` pl
 Added on top:
 - **Saved views** (§9) — reusable, shareable slices as JSON.
 - **Runtime "adjusted usage."** "Billable vs. included usage" or "overage units" are computed **at query time** from the *current* entitlement/price config — **never stored**, because that config is versioned and a stored copy would go stale.
-- **Non-usage series.** Wallet transactions, credit grants, and price-change history are native Postgres tables queried through the same view machinery (filtered lists, running totals) — no ClickHouse required.
+- **Non-usage series.** Wallet transactions, credit grants, and price-change history are Postgres source tables, synced to CH (B) and queried there through the same view machinery (filtered lists, running totals).
 
 **Hard rule:** product-analytics views never render money as `usage × rate`. Money comes from `revenue_facts`.
 
@@ -247,7 +243,7 @@ Usage / fixed / true-up come from the billing engine and reconcile to the invoic
 
 ### 6.3 Schema
 
-A **Postgres** table (§4 — keeps ClickHouse optional). One row per **`(tenant, environment, subscription, price, day, revenue_source)`**. Daily grain enables fine-grained exports and future recognition. Money is decomposed into **columns on `usage` rows**; `fixed`/`trueup`/etc. are their own rows carrying just `net_amount`. Usage is measured **gross** (billable + allowance) so the allowance shows as a visible credit. **Tax and prepaid are excluded** (§6.6, §6.7).
+The **authoring / system-of-record** table is **Postgres** (§4); it is synced to ClickHouse (B) for serving, and its primary can later move to ClickHouse (A). The DDL below is the Postgres authoring schema. One row per **`(tenant, environment, subscription, price, day, revenue_source)`**. Daily grain enables fine-grained exports and future recognition. Money is decomposed into **columns on `usage` rows**; `fixed`/`trueup`/etc. are their own rows carrying just `net_amount`. Usage is measured **gross** (billable + allowance) so the allowance shows as a visible credit. **Tax and prepaid are excluded** (§6.6, §6.7).
 
 ```sql
 CREATE TABLE revenue_facts (
@@ -446,7 +442,8 @@ sequenceDiagram
 - **Dirty-subscription set** — from a usage watermark plus period-close and amendment events; only subscriptions that moved are rebuilt.
 - **Whole-open-period recompute** — tiers/allowances/commitments are period-cumulative. For metered charges the engine reads aggregated `meter_usage` from ClickHouse; for fixed/commitment charges no ClickHouse is needed at all.
 - **Cadence** — watermark-driven; a modest default (e.g. hourly) for open periods, tunable. `FINAL` periods are never recomputed, only corrected (§8). A configurable **grace window** (~3 days, à la Orb) keeps a period `PROVISIONAL` while late usage settles.
-- **Isolation** — rollup writes go to Postgres; its `meter_usage` reads (when metered) can use a ClickHouse read replica so a backfill can't starve the tenant read path.
+- **Sync to the serving replica** — after the rollup writes Postgres, **PeerDB** replicates `revenue_facts` (and the source tables) into **ClickHouse (B)**, where the serving layer (§9) reads. Writes and reads are thus separated: the rollup never touches the read path, and serving never touches Postgres.
+- **Isolation** — rollup writes go to Postgres; its `meter_usage` reads (when metered) use ClickHouse. A backfill storm can't starve the tenant read path because reads hit CH (B), a different store from the Postgres write target.
 - **Engine dependency to build** — a preview entry point returning cumulative charge as-of an arbitrary in-period date, ideally all day-checkpoints in one pass (Q2).
 
 ---
@@ -513,20 +510,21 @@ A **saved view is a JSON row in Postgres**, immutable and versioned. It creates 
 flowchart LR
   V[View JSON + variables] --> T1[resolve & type-check variables]
   T1 --> T2[inject tenant + env RLS]
-  T2 --> T3{route by metric}
-  T3 -- revenue --> RF[revenue_facts SQL<br/>Postgres]
-  T3 -- ledger --> SY[Postgres source-table SQL]
-  T3 -- usage --> MU[meter_usage query builder<br/>ClickHouse, optional]
-  RF --> PG[bind params, execute on Postgres]
-  SY --> PG
-  MU --> CH[bind params, execute on ClickHouse]
-  PG --> SH[shape to columns + rows]
-  CH --> SH
+  T2 --> T3{metric to source table}
+  T3 -- usage --> MU[meter_usage]
+  T3 -- revenue --> RF[revenue_facts]
+  T3 -- ledger --> WT[wallet_transactions, ...]
+  MU --> BIND[bind params, execute on ClickHouse B]
+  RF --> BIND
+  WT --> BIND
+  BIND --> SH[shape to columns + rows]
 ```
 
+**Everything is served from ClickHouse (B)** — `meter_usage`, `revenue_facts`, and the synced source tables all live there, so the serving layer executes every query against a single store.
+
 - **Shapes (v1):** `timeseries`, `breakdown`, `single_value`, `drilldown`. (`pivot`, `distribution` later.)
-- **Variables** bind as **query parameters** on the target store (Postgres for revenue/ledger, ClickHouse for usage), never string interpolation. Optional filters with no value are dropped from `WHERE`. Dimension-position variables are allowed only against a per-tenant registered-property allowlist.
-- **Custom dimensions** are aggregated **at read time**: for usage, `JSONExtract` over `meter_usage` (ClickHouse); for revenue, the money comes from `revenue_facts` (Postgres) allocated by the dimension's usage share from `meter_usage` — the one **cross-store** path, available only when ClickHouse is in use.
+- **Variables** bind as **ClickHouse query parameters** (never string interpolation). Optional filters with no value are dropped from `WHERE`. Dimension-position variables are allowed only against a per-tenant registered-property allowlist.
+- **Custom dimensions** are aggregated **at read time**: usage via `JSONExtract` over `meter_usage`; custom-dimension **revenue** joins `revenue_facts` (money) to `meter_usage` (usage share) — and because both are in CH (B), this is a **single-store join**, not a cross-store hop.
 - **Allocation presets** (custom-dimension revenue only): `billed` (default; aggregate-level components as their own rows so every line is defensible) and `amortized` (aggregate effects spread by usage share). Allocate per price, then sum. A third, `list` (usage at list rate only), is an opt-in for efficiency comparisons; it deliberately does **not** reconcile and returns `reconciles_to_invoice: false`.
 - **Authoritative vs. estimated:** a revenue query returns stored authoritative rows (`marginal` + `period_only`). A daily-shape chart over `period_only` items uses read-time `estimated` allocation, labeled and never summed into an authoritative total.
 
@@ -543,28 +541,28 @@ flowchart LR
 | `allocation_policy` | Only for **custom-dimension revenue** — `billed` / `amortized` / `list` (§9 bullets). | Ignored for usage metrics and structural revenue breakdowns. |
 | `variables` | Typed placeholders (`date_range`, `string`, `string_list`, `number`, `enum`, `boolean`) bound at query time. | Bound as **query parameters** on the target store, never string-interpolated. |
 
-**Group-by resolution.** A **structural** dimension resolves by joining `price_id`/`meter_id`/`customer_id`/`plan_id` to the entity tables. For **revenue**, those entity tables are the **native Postgres** tables `revenue_facts` already sits beside — a plain SQL join. For **usage**, a **custom** dimension (e.g. `region`) resolves via `JSONExtractString(properties, 'region')` on `meter_usage` in ClickHouse **at read time** — no pre-declaration, but it must pass the registered-property allowlist to become a legal group-by.
+**Group-by resolution.** A **structural** dimension resolves by joining `price_id`/`meter_id`/`customer_id`/`plan_id` to the entity tables synced into CH (B) — a single-store join. A **custom** dimension (e.g. `region`) resolves via `JSONExtractString(properties, 'region')` on `meter_usage` in CH (B) **at read time** — no pre-declaration, but it must pass the registered-property allowlist to become a legal group-by.
 
 ### 9.2 What powers a view — and where "runtime adjustments" apply
 
-The metric decides the source table. This is the crux of your question, and the split is deliberate:
+The metric decides which **source table** the view reads — all of them served from ClickHouse (B):
 
-| Metric kind | Powered by | Adjustments |
+| Metric kind | Source table (in CH B) | Adjustments |
 |---|---|---|
-| **Usage** (`usage_quantity`, `event_count`, `billable_usage`, `overage_units`) | **`meter_usage`** via the existing query builder | "Adjusted" usage (`billable_usage`, `overage_units`) is computed **at runtime** by applying the *current* entitlement/price config to the raw usage — never stored, so it can't go stale. |
-| **Revenue** (`revenue`, `usage_at_list_rate`, `entitlement_credit`, …) | **`revenue_facts`** (Postgres, pre-computed) | Money is **not** derived from `meter_usage` at read time — tiers/allowances/commitments make `usage × rate` wrong. It is read from `revenue_facts`, which the engine already priced. Custom-dimension revenue additionally does a read-time **allocation join** to `meter_usage` (ClickHouse) for the dimension's usage share. |
-| **Ledger** (credit top-ups, balance, price-change history) | **native Postgres tables** (`wallet_transactions`, …) | Simple filters/sums; no pricing. |
+| **Usage** (`usage_quantity`, `event_count`, `billable_usage`, `overage_units`) | `meter_usage` | "Adjusted" usage (`billable_usage`, `overage_units`) is computed **at runtime** by applying the *current* entitlement/price config to the raw usage — never stored, so it can't go stale. |
+| **Revenue** (`revenue`, `usage_at_list_rate`, `entitlement_credit`, …) | `revenue_facts` (authored in Postgres, synced to CH B) | Money is **not** derived from `meter_usage` at read time — tiers/allowances/commitments make `usage × rate` wrong. It is read from `revenue_facts`, which the engine already priced. Custom-dimension revenue joins `meter_usage` for the usage share — a single-store join in CH (B). |
+| **Ledger** (credit top-ups, balance, price-change history) | `wallet_transactions`, … (synced to CH B) | Simple filters/sums; no pricing. |
 
-So: **usage views** are powered by ClickHouse `meter_usage` with runtime-computed adjustment fields — exactly as you said. **Revenue and ledger views** are powered by **Postgres** (`revenue_facts` + native source tables), so they work with **no ClickHouse at all**. A view that mixes a usage metric and a revenue metric runs two sub-queries — one per store — and joins the results in the serving layer; that is also the only place a cross-store hop occurs.
+So every view — usage, revenue, or ledger — executes against CH (B). The money still originates from `revenue_facts` (authored in Postgres, never recomputed as `usage × rate`); serving just reads the synced copy. A view that mixes a usage metric and a revenue metric is a single-store join in CH (B), not a cross-store hop.
 
 ---
 
 ## 10. Warehouse export
 
-Daily grain makes tenant-side BI viable. Export surface:
-- **Derived:** `revenue_facts` from Postgres (and, later, the recognition table).
-- **Raw (native Postgres):** `invoice`, `invoice_line_item`, entities, `wallet_transactions` — reconciliation anchor and structural dimensions.
-- **Usage (ClickHouse, when present):** `meter_usage` for tenants doing usage BI.
+Daily grain makes tenant-side BI viable. Export surface (all resident in CH (B), the serving replica):
+- **Derived:** `revenue_facts` (and, later, the recognition table).
+- **Raw (synced):** `invoice`, `invoice_line_item`, entities, `wallet_transactions` — reconciliation anchor and structural dimensions.
+- **Usage:** `meter_usage` for tenants doing usage BI.
 
 Export is a fast-follow on `revenue_facts`, hedging the risk that a full in-app builder is more than some tenants need. Mechanism (snapshot vs. incremental by `updated_at`/`version`; destinations) is deferred; the common pattern is a first full snapshot then daily incrementals.
 
@@ -638,7 +636,7 @@ Concretely, this is the billed-vs-recognized split the fixed-charge example make
 
 **Q3 — Multi-period commitment prior-base.** For an annual commitment billed monthly, month N needs cumulative consumption from months 1..N-1; the engine reads it only from *finalized* invoices and degrades silently otherwise. *Why it matters:* the rollup produces provisional numbers before finalization, exactly when the engine's source is incomplete. *Resolved by:* fixing the fields of a rollup-maintained cumulative prior-base (sum of usage-line base; overage lines ÷ overage factor; true-up excluded), where it's stored, and the rule gating true-up to the final period.
 
-**Q4 — ClickHouse read isolation and entity enrichment for usage views.** Revenue/ledger run on Postgres, but usage/product analytics reads `meter_usage` in ClickHouse. *Why it matters:* under load, analytical scans shouldn't degrade ingestion or the tenant read path, and structural dimensions for *usage* (feature/plan names) live in Postgres. *Resolved by:* deciding whether usage reads hit a ClickHouse read replica, and whether usage-side entity names are joined in the Go serving layer (as today) or need a lightweight entity copy in ClickHouse.
+**Q4 — PeerDB sync coverage/latency into CH (B), and the CH (A) migration path.** All serving reads hit CH (B), fed by PeerDB from Postgres (`revenue_facts`, invoices, entities, wallet) plus `meter_usage` from CH (A). *Why it matters:* provisional revenue freshness and reconciliation timing depend on sync lag; and we've asserted the `revenue_facts` primary can later move Postgres → CH (A) without changing serving. *Resolved by:* confirming which tables PeerDB replicates into CH (B) and the observed lag; and sketching the CH (A) primary-migration (dual-write or cutover) so the "movable primary" claim is real, not aspirational.
 
 **Q5 — Allocation basis for `period_only` daily shape.** Rendering a daily shape for a non-decomposable item allocates the period total proportionally, proposed as that day's usage share. *Why it matters:* for volume tiers and `LATEST`/`AVG` meters this is defensible but not unique; even-spread may read better for some. *Resolved by:* picking a default and checking it against real volume-tier and `LATEST` examples; decide if it's per-aggregation-type.
 
@@ -662,7 +660,9 @@ Concretely, this is the billed-vs-recognized split the fixed-charge example make
 - **Billed vs. recognized revenue** — invoiced vs. earned; ASC 606 governs recognition timing.
 - **Deferred revenue** — money received but not yet earned (a liability); prepaid credits are deferred until consumed.
 - **Breakage** — deferred revenue recognized when prepaid credits expire unused.
-- **ClickHouse (optional)** — the usage store holding `meter_usage`; required only for usage/product analytics. Revenue analytics runs on Postgres alone.
+- **ClickHouse (A)** — the primary/operational ClickHouse holding `meter_usage` (usage facts); a future home for the `revenue_facts` primary.
+- **ClickHouse (B)** — the analytics **serving replica**; every analytics query reads here. Fed by CH (A) (usage) and by PeerDB from Postgres (`revenue_facts`, invoices, entities, wallet).
+- **PeerDB** — the CDC pipeline replicating Postgres tables (incl. the Postgres-authored `revenue_facts`) into ClickHouse (B).
 
 ## Appendix B — Codebase anchors
 

--- a/docs/design/2026-09-11-FLE-1257-analytics-phase1-implementation-plan.md
+++ b/docs/design/2026-09-11-FLE-1257-analytics-phase1-implementation-plan.md
@@ -1,0 +1,1172 @@
+# Analytics Platform — Phase 1 (Saved Views + Serving Translator) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a tenant-facing analytics query layer — a saved-view model, a serving *translator*, and `/v1/analytics/query` + `/v1/analytics/views` endpoints — that answers **usage** questions (shapes `timeseries` and `breakdown`) by reusing the existing `meter_usage` query engine. No money/revenue in Phase 1.
+
+**Architecture:** A saved view is a JSON document persisted in Postgres (`analytics_saved_view`). The **translator** resolves a view's variables, injects tenant/environment RLS, and maps the view onto the *existing* `MeterUsageQueryParams` / `MeterUsageDetailedAnalyticsParams` structs — then calls the existing `MeterUsageService` to execute. Results are shaped into a visualization-agnostic `{columns, rows, meta}` response. We add **no** new query builder and **no** ClickHouse objects.
+
+**Tech Stack:** Go 1.23+, Gin, Uber FX (DI), Ent (Postgres), the existing ClickHouse `meter_usage` engine, testify suites with `internal/testutil` in-memory stores.
+
+**Spec:** `docs/design/2026-09-10-FLE-1257-analytics-platform-erd.md` (§5 product analytics, §9 serving layer, §14 Phase 1). Read it alongside this plan.
+
+## Global Constraints
+
+- **Multi-tenancy:** every query and every persisted row carries and filters on `tenant_id` + `environment_id`, pulled from context via `types.GetTenantID(ctx)` / `types.GetEnvironmentID(ctx)`. RLS is injected by the serving layer, never supplied by the caller.
+- **No tenant SQL / no string interpolation:** variables bind as query parameters; the existing `meter_usage` builder already binds `tenant_id`/`environment_id` as the first two positional `?` args — reuse that path, never build raw SQL.
+- **Money rule:** Phase 1 exposes usage metrics only. Never compute money as `usage × rate`.
+- **Layering (AGENTS.md):** handlers parse→validate→delegate; no business logic or DB access in `internal/api/v1/`. Domain interfaces in `internal/domain/`, implementations in `internal/repository/`. New deps registered in `cmd/server/main.go` via `fx.Provide`.
+- **Logging (loglint gate):** structured `internal/logger` ctx-first API; every `log.Error(ctx, msg, ...)` MUST include a literal `"error"` key. No `fmt.Print*`. `make lint-ci` must pass.
+- **Ent workflow:** edit `ent/schema/*.go` → `make generate-ent` → `make generate-migration`. Never hand-edit generated files.
+- **Enterprise code** lives under `internal/ee/service/`; follow the existing `MeterUsageService` placement.
+
+---
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `internal/domain/analytics/view.go` | View-definition value types (`ViewDefinition`, `Filter`, `TimeSpec`, `Variable`, enums) + getters | Create |
+| `internal/domain/analytics/resolver.go` | Variable resolution & type-checking (view + supplied vars → resolved view) | Create |
+| `internal/domain/analytics/view_test.go`, `resolver_test.go` | Unit tests for the above | Create |
+| `internal/domain/analytics/saved_view.go` | `SavedView` domain model + `Repository` interface + `FromEnt` | Create |
+| `internal/ee/service/analytics_translator.go` | View → `events.MeterUsage*Params` mapping (metric/dimension registry, RLS) | Create |
+| `internal/ee/service/analytics_shaper.go` | `MeterUsage*Result` → `{columns, rows, meta}` | Create |
+| `internal/ee/service/analytics.go` | `AnalyticsService`: `ExecuteView`, saved-view CRUD | Create |
+| `internal/ee/service/analytics_test.go` | Service suite (in-memory meter_usage) | Create |
+| `ent/schema/analytics_saved_view.go` | Ent schema for `analytics_saved_view` | Create |
+| `internal/repository/ent/analytics_saved_view.go` | Repository implementation | Create |
+| `internal/testutil/inmemory_analytics_saved_view_store.go` | In-memory repo for tests | Create |
+| `internal/api/dto/analytics.go` | Request/response DTOs + validation + mappers | Create |
+| `internal/api/v1/analytics.go` | Gin handlers | Create |
+| `internal/api/router.go` | Route registration (`/analytics` group) + `Handlers` field | Modify |
+| `cmd/server/main.go` | `fx.Provide` repo + service; `provideHandlers` param + wiring | Modify |
+
+---
+
+### Task 1: View-definition types + variable resolution
+
+**Files:**
+- Create: `internal/domain/analytics/view.go`
+- Create: `internal/domain/analytics/resolver.go`
+- Test: `internal/domain/analytics/view_test.go`, `internal/domain/analytics/resolver_test.go`
+
+**Interfaces:**
+- Consumes: nothing (pure value types).
+- Produces:
+  - `type Shape string` with `ShapeTimeseries="timeseries"`, `ShapeBreakdown="breakdown"`.
+  - `type ViewDefinition struct` (private fields + getters) built via `NewViewDefinition(...)`; fields: name, shape, metrics `[]string`, dimensions `[]string`, filters `[]Filter`, time `TimeSpec`, sort `[]SortSpec`, limit `int`, variables `[]Variable`.
+  - `type Filter struct { Field, Op string; Value any; Optional bool }`
+  - `type TimeSpec struct { From, To time.Time; Grain string }` (post-resolution) and a raw form for pre-resolution.
+  - `type Variable struct { Name, Type string; Required bool; Default any }`
+  - `func ResolveVariables(def ViewDefinition, supplied map[string]any) (ResolvedView, error)` where `ResolvedView` has concrete filter values, a `TimeSpec` with real `From`/`To`, and **optional filters with unsupplied vars dropped**.
+  - `func (v ViewDefinition) Validate() error`.
+
+- [ ] **Step 1: Write failing tests for shape/validation + variable resolution**
+
+```go
+// internal/domain/analytics/resolver_test.go
+package analytics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveVariables_DropsUnsuppliedOptionalFilter(t *testing.T) {
+	def := ViewDefinition{
+		Shape:   ShapeBreakdown,
+		Metrics: []string{"usage_quantity"},
+		Filters: []Filter{
+			{Field: "meter_id", Op: "eq", Value: "{{meter}}"},
+			{Field: "customer_id", Op: "in", Value: "{{customers}}", Optional: true},
+		},
+		Time:      TimeSpecRaw{Range: "{{date_range}}", Grain: "day"},
+		Variables: []Variable{{Name: "meter", Type: "string", Required: true}, {Name: "customers", Type: "string_list"}},
+	}
+	rv, err := ResolveVariables(def, map[string]any{
+		"meter":      "meter_1",
+		"date_range": map[string]any{"from": "2026-08-01", "to": "2026-09-01"},
+	})
+	require.NoError(t, err)
+	assert.Len(t, rv.Filters, 1) // optional customers filter dropped
+	assert.Equal(t, "meter_1", rv.Filters[0].Value)
+	assert.Equal(t, time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), rv.Time.From)
+}
+
+func TestResolveVariables_MissingRequiredVar(t *testing.T) {
+	def := ViewDefinition{
+		Shape: ShapeTimeseries, Metrics: []string{"usage_quantity"},
+		Variables: []Variable{{Name: "meter", Type: "string", Required: true}},
+	}
+	_, err := ResolveVariables(def, map[string]any{})
+	require.Error(t, err)
+}
+
+func TestValidate_RejectsUnknownShape(t *testing.T) {
+	def := ViewDefinition{Shape: Shape("pie"), Metrics: []string{"usage_quantity"}}
+	require.Error(t, def.Validate())
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/domain/analytics/ -run TestResolveVariables -v`
+Expected: FAIL — package/types not defined.
+
+- [ ] **Step 3: Implement `view.go` (types + Validate)**
+
+```go
+// internal/domain/analytics/view.go
+package analytics
+
+import (
+	"time"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+)
+
+type Shape string
+
+const (
+	ShapeTimeseries Shape = "timeseries"
+	ShapeBreakdown  Shape = "breakdown"
+)
+
+type Filter struct {
+	Field    string `json:"field"`
+	Op       string `json:"op"`
+	Value    any    `json:"value"`
+	Optional bool   `json:"optional,omitempty"`
+}
+
+type SortSpec struct {
+	Field string `json:"field"`
+	Dir   string `json:"dir"`
+}
+
+type Variable struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Required bool   `json:"required,omitempty"`
+	Default  any    `json:"default,omitempty"`
+}
+
+// TimeSpecRaw is the unresolved time spec (Range may be a "{{var}}").
+type TimeSpecRaw struct {
+	Range any    `json:"range"`
+	Grain string `json:"grain"`
+}
+
+type TimeSpec struct {
+	From  time.Time
+	To    time.Time
+	Grain string
+}
+
+type ViewDefinition struct {
+	Name       string      `json:"name"`
+	Shape      Shape       `json:"shape"`
+	Metrics    []string    `json:"metrics"`
+	Dimensions []string    `json:"dimensions,omitempty"`
+	Filters    []Filter    `json:"filters,omitempty"`
+	Time       TimeSpecRaw `json:"time"`
+	Sort       []SortSpec  `json:"sort,omitempty"`
+	Limit      int         `json:"limit,omitempty"`
+	Variables  []Variable  `json:"variables,omitempty"`
+}
+
+func (v ViewDefinition) Validate() error {
+	switch v.Shape {
+	case ShapeTimeseries, ShapeBreakdown:
+	default:
+		return ierr.NewError("unsupported shape").
+			WithHint("shape must be one of: timeseries, breakdown").
+			Mark(ierr.ErrValidation)
+	}
+	if len(v.Metrics) == 0 {
+		return ierr.NewError("at least one metric is required").Mark(ierr.ErrValidation)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Implement `resolver.go`**
+
+```go
+// internal/domain/analytics/resolver.go
+package analytics
+
+import (
+	"fmt"
+	"time"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+)
+
+type ResolvedView struct {
+	Shape      Shape
+	Metrics    []string
+	Dimensions []string
+	Filters    []Filter // concrete values; optional-with-unsupplied dropped
+	Time       TimeSpec
+	Sort       []SortSpec
+	Limit      int
+}
+
+func ResolveVariables(def ViewDefinition, supplied map[string]any) (ResolvedView, error) {
+	if err := def.Validate(); err != nil {
+		return ResolvedView{}, err
+	}
+	for _, va := range def.Variables {
+		if _, ok := supplied[va.Name]; !ok && va.Required {
+			return ResolvedView{}, ierr.NewError(fmt.Sprintf("missing required variable %q", va.Name)).Mark(ierr.ErrValidation)
+		}
+	}
+	rv := ResolvedView{Shape: def.Shape, Metrics: def.Metrics, Dimensions: def.Dimensions, Sort: def.Sort, Limit: def.Limit}
+
+	for _, f := range def.Filters {
+		val, present := resolveValue(f.Value, supplied)
+		if !present {
+			if f.Optional {
+				continue // drop optional filter with no value
+			}
+			return ResolvedView{}, ierr.NewError(fmt.Sprintf("filter %q has no value", f.Field)).Mark(ierr.ErrValidation)
+		}
+		rv.Filters = append(rv.Filters, Filter{Field: f.Field, Op: f.Op, Value: val})
+	}
+
+	ts, err := resolveTime(def.Time, supplied)
+	if err != nil {
+		return ResolvedView{}, err
+	}
+	rv.Time = ts
+	return rv, nil
+}
+
+// resolveValue returns (value, present). A "{{name}}" looks the var up in supplied.
+func resolveValue(raw any, supplied map[string]any) (any, bool) {
+	s, ok := raw.(string)
+	if ok && len(s) > 4 && s[:2] == "{{" && s[len(s)-2:] == "}}" {
+		name := s[2 : len(s)-2]
+		v, present := supplied[name]
+		return v, present
+	}
+	return raw, true // literal
+}
+
+func resolveTime(raw TimeSpecRaw, supplied map[string]any) (TimeSpec, error) {
+	val, present := resolveValue(raw.Range, supplied)
+	if !present {
+		return TimeSpec{}, ierr.NewError("time range not supplied").Mark(ierr.ErrValidation)
+	}
+	m, ok := val.(map[string]any)
+	if !ok {
+		return TimeSpec{}, ierr.NewError("time range must be {from,to}").Mark(ierr.ErrValidation)
+	}
+	from, err := parseDate(m["from"])
+	if err != nil {
+		return TimeSpec{}, err
+	}
+	to, err := parseDate(m["to"])
+	if err != nil {
+		return TimeSpec{}, err
+	}
+	return TimeSpec{From: from, To: to, Grain: raw.Grain}, nil
+}
+
+func parseDate(v any) (time.Time, error) {
+	s, ok := v.(string)
+	if !ok {
+		return time.Time{}, ierr.NewError("date must be a string").Mark(ierr.ErrValidation)
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, ierr.NewError("invalid date").WithHint("expected YYYY-MM-DD").Mark(ierr.ErrValidation)
+	}
+	return t.UTC(), nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/domain/analytics/ -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/domain/analytics/view.go internal/domain/analytics/resolver.go internal/domain/analytics/view_test.go internal/domain/analytics/resolver_test.go
+git commit -m "feat(analytics): view-definition types and variable resolution"
+```
+
+---
+
+### Task 2: Translator — resolved view → existing meter_usage params
+
+**Files:**
+- Create: `internal/ee/service/analytics_translator.go`
+- Test: `internal/ee/service/analytics_translator_test.go`
+
+**Interfaces:**
+- Consumes: `analytics.ResolvedView` (Task 1); `events.MeterUsageQueryParams` and `events.MeterUsageDetailedAnalyticsParams` (`internal/domain/events/meter_usage.go`); `types.GetTenantID/GetEnvironmentID`.
+- Produces:
+  - `func TranslateBreakdown(ctx, rv analytics.ResolvedView) (*events.MeterUsageDetailedAnalyticsParams, error)`
+  - `func TranslateTimeseries(ctx, rv analytics.ResolvedView) (*events.MeterUsageQueryParams, error)`
+  - Metric registry: `usage_quantity` → the meter's own aggregation (carried by the existing detailed path); `event_count` → event count column. Dimension allowlist mirrors the builder's rule: `meter_id`, `source`, `properties.<field>` matching `^[A-Za-z0-9_.]+$`.
+
+- [ ] **Step 1: Write failing test — breakdown translation sets RLS + filters + group-by**
+
+```go
+// internal/ee/service/analytics_translator_test.go
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/analytics"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateBreakdown_InjectsRLSAndGroupBy(t *testing.T) {
+	ctx := context.WithValue(context.Background(), types.CtxTenantID, "tenant_1")
+	ctx = context.WithValue(ctx, types.CtxEnvironmentID, "env_1")
+
+	rv := analytics.ResolvedView{
+		Shape:      analytics.ShapeBreakdown,
+		Metrics:    []string{"usage_quantity"},
+		Dimensions: []string{"properties.region"},
+		Filters:    []analytics.Filter{{Field: "meter_id", Op: "eq", Value: "meter_1"}},
+		Time:       analytics.TimeSpec{From: time.Now().Add(-24 * time.Hour), To: time.Now(), Grain: "day"},
+	}
+	p, err := TranslateBreakdown(ctx, rv)
+	require.NoError(t, err)
+	assert.Equal(t, "tenant_1", p.TenantID)
+	assert.Equal(t, "env_1", p.EnvironmentID)
+	assert.Contains(t, p.MeterIDs, "meter_1")
+	assert.Contains(t, p.GroupBy, "properties.region")
+}
+
+func TestTranslateBreakdown_RejectsIllegalDimension(t *testing.T) {
+	ctx := context.Background()
+	rv := analytics.ResolvedView{
+		Shape: analytics.ShapeBreakdown, Metrics: []string{"usage_quantity"},
+		Dimensions: []string{"properties.region; DROP TABLE"},
+	}
+	_, err := TranslateBreakdown(ctx, rv)
+	require.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/ee/service/ -run TestTranslateBreakdown -v`
+Expected: FAIL — `TranslateBreakdown` undefined.
+
+- [ ] **Step 3: Implement the translator**
+
+```go
+// internal/ee/service/analytics_translator.go
+package service
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/flexprice/flexprice/internal/domain/analytics"
+	"github.com/flexprice/flexprice/internal/domain/events"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+var validDimension = regexp.MustCompile(`^[A-Za-z0-9_.]+$`)
+
+func validateDimensions(dims []string) error {
+	for _, d := range dims {
+		if !validDimension.MatchString(d) {
+			return ierr.NewError("illegal dimension").
+				WithHint("dimensions must match [A-Za-z0-9_.]+").
+				Mark(ierr.ErrValidation)
+		}
+	}
+	return nil
+}
+
+// splitFilters pulls meter_id / customer_id / source into the typed slices the
+// meter_usage params expect; anything else becomes a property filter.
+func applyFilters[T any](filters []analytics.Filter, meterIDs, customerIDs, sources *[]string, props map[string][]string) {
+	for _, f := range filters {
+		vals := toStringSlice(f.Value)
+		switch f.Field {
+		case "meter_id":
+			*meterIDs = append(*meterIDs, vals...)
+		case "customer_id":
+			*customerIDs = append(*customerIDs, vals...)
+		case "source":
+			*sources = append(*sources, vals...)
+		default:
+			props[f.Field] = append(props[f.Field], vals...)
+		}
+	}
+}
+
+func TranslateBreakdown(ctx context.Context, rv analytics.ResolvedView) (*events.MeterUsageDetailedAnalyticsParams, error) {
+	if err := validateDimensions(rv.Dimensions); err != nil {
+		return nil, err
+	}
+	p := &events.MeterUsageDetailedAnalyticsParams{
+		TenantID:        types.GetTenantID(ctx),
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		StartTime:       rv.Time.From,
+		EndTime:         rv.Time.To,
+		WindowSize:      types.WindowSize(rv.Time.Grain),
+		GroupBy:         rv.Dimensions,
+		PropertyFilters: map[string][]string{},
+		UseFinal:        true,
+	}
+	applyFilters[any](rv.Filters, &p.MeterIDs, &p.ExternalCustomerIDs, &p.Sources, p.PropertyFilters)
+	return p, nil
+}
+
+func TranslateTimeseries(ctx context.Context, rv analytics.ResolvedView) (*events.MeterUsageQueryParams, error) {
+	p := &events.MeterUsageQueryParams{
+		TenantID:        types.GetTenantID(ctx),
+		EnvironmentID:   types.GetEnvironmentID(ctx),
+		StartTime:       rv.Time.From,
+		EndTime:         rv.Time.To,
+		WindowSize:      types.WindowSize(rv.Time.Grain),
+		PropertyFilters: map[string][]string{},
+		UseFinal:        true,
+	}
+	applyFilters[any](rv.Filters, &p.MeterIDs, &p.ExternalCustomerIDs, &p.Sources, p.PropertyFilters)
+	return p, nil
+}
+
+func toStringSlice(v any) []string {
+	switch t := v.(type) {
+	case string:
+		return []string{t}
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+```
+
+> **Executor note:** verify the exact field names on `events.MeterUsageQueryParams` / `MeterUsageDetailedAnalyticsParams` (`internal/domain/events/meter_usage.go:34,84`) — use `ExternalCustomerIDs`/`MeterIDs`/`Sources`/`PropertyFilters`/`GroupBy`/`WindowSize` as they exist there; adjust singular/plural to match.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/ee/service/ -run TestTranslateBreakdown -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ee/service/analytics_translator.go internal/ee/service/analytics_translator_test.go
+git commit -m "feat(analytics): translate resolved views to meter_usage params with RLS"
+```
+
+---
+
+### Task 3: Result shaper → `{columns, rows, meta}`
+
+**Files:**
+- Create: `internal/ee/service/analytics_shaper.go`
+- Test: `internal/ee/service/analytics_shaper_test.go`
+
+**Interfaces:**
+- Consumes: the existing detailed-analytics result type (`events.MeterUsageDetailedResult` / the `dto.GetUsageAnalyticsResponse` items) and the timeseries result (`events.MeterUsageAggregationResult` with `Points`).
+- Produces:
+  - `type Column struct { Name, Type, Role string; Currency string omitempty }`
+  - `type QueryResult struct { Columns []Column; Rows [][]any; Meta map[string]any }`
+  - `func ShapeBreakdown(items []events.MeterUsageDetailedResult, dims []string) QueryResult`
+  - `func ShapeTimeseries(res *events.MeterUsageAggregationResult) QueryResult`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/ee/service/analytics_shaper_test.go
+package service
+
+import (
+	"testing"
+
+	"github.com/flexprice/flexprice/internal/domain/events"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShapeBreakdown_ColumnsAndRows(t *testing.T) {
+	items := []events.MeterUsageDetailedResult{
+		{Properties: map[string]string{"region": "us"}, TotalUsage: decimal.NewFromInt(60000)},
+		{Properties: map[string]string{"region": "eu"}, TotalUsage: decimal.NewFromInt(30000)},
+	}
+	got := ShapeBreakdown(items, []string{"properties.region"})
+	assert.Equal(t, "properties.region", got.Columns[0].Name)
+	assert.Equal(t, "dimension", got.Columns[0].Role)
+	assert.Len(t, got.Rows, 2)
+	assert.Equal(t, "us", got.Rows[0][0])
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/ee/service/ -run TestShapeBreakdown -v`
+Expected: FAIL — `ShapeBreakdown` undefined.
+
+- [ ] **Step 3: Implement the shaper**
+
+```go
+// internal/ee/service/analytics_shaper.go
+package service
+
+import (
+	"strings"
+
+	"github.com/flexprice/flexprice/internal/domain/events"
+)
+
+type Column struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Role     string `json:"role"` // "dimension" | "metric"
+	Currency string `json:"currency,omitempty"`
+}
+
+type QueryResult struct {
+	Columns []Column       `json:"columns"`
+	Rows    [][]any        `json:"rows"`
+	Meta    map[string]any `json:"meta"`
+}
+
+func ShapeBreakdown(items []events.MeterUsageDetailedResult, dims []string) QueryResult {
+	cols := make([]Column, 0, len(dims)+1)
+	for _, d := range dims {
+		cols = append(cols, Column{Name: d, Type: "string", Role: "dimension"})
+	}
+	cols = append(cols, Column{Name: "usage_quantity", Type: "decimal", Role: "metric"})
+
+	rows := make([][]any, 0, len(items))
+	for _, it := range items {
+		row := make([]any, 0, len(dims)+1)
+		for _, d := range dims {
+			key := strings.TrimPrefix(d, "properties.")
+			row = append(row, it.Properties[key])
+		}
+		row = append(row, it.TotalUsage.String())
+		rows = append(rows, row)
+	}
+	return QueryResult{Columns: cols, Rows: rows, Meta: map[string]any{"query_source": "meter_usage"}}
+}
+
+func ShapeTimeseries(res *events.MeterUsageAggregationResult) QueryResult {
+	cols := []Column{
+		{Name: "window_start", Type: "datetime", Role: "dimension"},
+		{Name: "usage_quantity", Type: "decimal", Role: "metric"},
+	}
+	rows := make([][]any, 0, len(res.Points))
+	for _, p := range res.Points {
+		rows = append(rows, []any{p.WindowStart, p.Value.String()})
+	}
+	return QueryResult{Columns: cols, Rows: rows, Meta: map[string]any{"query_source": "meter_usage", "total": res.TotalValue.String()}}
+}
+```
+
+> **Executor note:** confirm the field names on `events.MeterUsageDetailedResult` (`Properties map[string]string`, `TotalUsage decimal.Decimal`) and `MeterUsageResult` (`WindowStart`, `Value`) at `internal/domain/events/meter_usage.go:74,124`; adjust to the real names.
+
+- [ ] **Step 4: Run test to verify it passes** — Run: `go test ./internal/ee/service/ -run TestShapeBreakdown -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ee/service/analytics_shaper.go internal/ee/service/analytics_shaper_test.go
+git commit -m "feat(analytics): shape meter_usage results into columns/rows"
+```
+
+---
+
+### Task 4: `analytics_saved_view` ent schema + domain + repository
+
+**Files:**
+- Create: `ent/schema/analytics_saved_view.go`
+- Create: `internal/domain/analytics/saved_view.go`
+- Create: `internal/repository/ent/analytics_saved_view.go`
+- Create: `internal/testutil/inmemory_analytics_saved_view_store.go`
+- Modify (generated): run `make generate-ent`, `make generate-migration`
+
+**Interfaces:**
+- Consumes: `analytics.ViewDefinition` (Task 1); `postgres.IClient`, `logger.Logger`; `mixin.BaseMixin`, `mixin.EnvironmentMixin`.
+- Produces:
+  - `analytics.SavedView struct { ID, Name string; Version int; Definition ViewDefinition; types.BaseModel }` with `FromEnt(*ent.AnalyticsSavedView) *SavedView`.
+  - `analytics.Repository interface { Create(ctx, *SavedView) error; Get(ctx, id string) (*SavedView, error); List(ctx) ([]*SavedView, error) }`.
+  - `func NewAnalyticsSavedViewRepository(client postgres.IClient, log *logger.Logger) analytics.Repository`.
+
+- [ ] **Step 1: Write the ent schema**
+
+```go
+// ent/schema/analytics_saved_view.go
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/field"
+	"entgo.io/ent/schema/index"
+	"github.com/flexprice/flexprice/ent/schema/mixin"
+)
+
+type AnalyticsSavedView struct{ ent.Schema }
+
+func (AnalyticsSavedView) Mixin() []ent.Mixin {
+	return []ent.Mixin{mixin.BaseMixin{}, mixin.EnvironmentMixin{}}
+}
+
+func (AnalyticsSavedView) Fields() []ent.Field {
+	return []ent.Field{
+		field.String("id").SchemaType(map[string]string{"postgres": "varchar(50)"}).Unique().Immutable(),
+		field.String("name").NotEmpty(),
+		field.Int("version").Default(1),
+		field.JSON("definition", map[string]interface{}{}).
+			SchemaType(map[string]string{"postgres": "jsonb"}),
+	}
+}
+
+func (AnalyticsSavedView) Indexes() []ent.Index {
+	return []ent.Index{
+		index.Fields("tenant_id", "environment_id", "status"),
+	}
+}
+```
+
+- [ ] **Step 2: Generate ent code + migration**
+
+Run:
+```bash
+make generate-ent
+make generate-migration
+```
+Expected: `ent/analyticssavedview*.go` generated; a new SQL file under `migrations/ent/`. Do not hand-edit generated files.
+
+- [ ] **Step 3: Write the domain model + repository interface**
+
+```go
+// internal/domain/analytics/saved_view.go
+package analytics
+
+import (
+	"context"
+
+	"github.com/flexprice/flexprice/ent"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+type SavedView struct {
+	ID         string
+	Name       string
+	Version    int
+	Definition ViewDefinition
+	types.BaseModel
+}
+
+type Repository interface {
+	Create(ctx context.Context, v *SavedView) error
+	Get(ctx context.Context, id string) (*SavedView, error)
+	List(ctx context.Context) ([]*SavedView, error)
+}
+
+func FromEnt(e *ent.AnalyticsSavedView) *SavedView {
+	if e == nil {
+		return nil
+	}
+	// definition is stored as jsonb; unmarshal via the shared decoder used elsewhere.
+	var def ViewDefinition
+	_ = decodeDefinition(e.Definition, &def)
+	return &SavedView{
+		ID: e.ID, Name: e.Name, Version: e.Version, Definition: def,
+		BaseModel: types.BaseModel{TenantID: e.TenantID, Status: types.Status(e.Status), CreatedAt: e.CreatedAt, UpdatedAt: e.UpdatedAt},
+	}
+}
+```
+
+> **Executor note:** `e.Definition` is `map[string]interface{}`; implement `decodeDefinition` with `mapstructure` or `json.Marshal`/`Unmarshal` round-trip. Match the `types.BaseModel` field set actually present (`internal/types/base_model.go`).
+
+- [ ] **Step 4: Write the repository implementation (model on `internal/repository/ent/settings.go`)**
+
+```go
+// internal/repository/ent/analytics_saved_view.go
+package ent
+
+import (
+	"context"
+
+	domainAnalytics "github.com/flexprice/flexprice/internal/domain/analytics"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/postgres"
+	"github.com/flexprice/flexprice/internal/types"
+)
+
+type analyticsSavedViewRepository struct {
+	client postgres.IClient
+	log    *logger.Logger
+}
+
+func NewAnalyticsSavedViewRepository(client postgres.IClient, log *logger.Logger) domainAnalytics.Repository {
+	return &analyticsSavedViewRepository{client: client, log: log}
+}
+
+func (r *analyticsSavedViewRepository) Create(ctx context.Context, v *domainAnalytics.SavedView) error {
+	client := r.client.Writer(ctx)
+	created, err := client.AnalyticsSavedView.Create().
+		SetID(v.ID).
+		SetTenantID(types.GetTenantID(ctx)).
+		SetEnvironmentID(types.GetEnvironmentID(ctx)).
+		SetName(v.Name).
+		SetVersion(v.Version).
+		SetDefinition(encodeDefinition(v.Definition)).
+		Save(ctx)
+	if err != nil {
+		return ierr.WithError(err).WithHint("failed to create saved view").Mark(ierr.ErrDatabase)
+	}
+	*v = *domainAnalytics.FromEnt(created)
+	return nil
+}
+// Get / List follow the settings.go pattern: r.client.Reader(ctx), .Where(analyticssavedview.TenantID(...)), map ent.NotFound -> ierr.ErrNotFound.
+```
+
+- [ ] **Step 5: Write the in-memory store (model on `inmemory_meter_usage_store.go`)**
+
+```go
+// internal/testutil/inmemory_analytics_saved_view_store.go
+package testutil
+
+import (
+	"context"
+	"sync"
+
+	domainAnalytics "github.com/flexprice/flexprice/internal/domain/analytics"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+)
+
+type InMemoryAnalyticsSavedViewStore struct {
+	mu    sync.RWMutex
+	views map[string]*domainAnalytics.SavedView
+}
+
+func NewInMemoryAnalyticsSavedViewStore() *InMemoryAnalyticsSavedViewStore {
+	return &InMemoryAnalyticsSavedViewStore{views: map[string]*domainAnalytics.SavedView{}}
+}
+
+func (s *InMemoryAnalyticsSavedViewStore) Create(ctx context.Context, v *domainAnalytics.SavedView) error {
+	s.mu.Lock(); defer s.mu.Unlock()
+	s.views[v.ID] = v
+	return nil
+}
+func (s *InMemoryAnalyticsSavedViewStore) Get(ctx context.Context, id string) (*domainAnalytics.SavedView, error) {
+	s.mu.RLock(); defer s.mu.RUnlock()
+	v, ok := s.views[id]
+	if !ok { return nil, ierr.NewError("not found").Mark(ierr.ErrNotFound) }
+	return v, nil
+}
+func (s *InMemoryAnalyticsSavedViewStore) List(ctx context.Context) ([]*domainAnalytics.SavedView, error) {
+	s.mu.RLock(); defer s.mu.RUnlock()
+	out := make([]*domainAnalytics.SavedView, 0, len(s.views))
+	for _, v := range s.views { out = append(out, v) }
+	return out, nil
+}
+```
+
+- [ ] **Step 6: Wire the in-memory store into the base suite** — Modify `internal/testutil/base_service_suite.go`: add `AnalyticsSavedViewRepo domainAnalytics.Repository` to the `Stores` struct and set `AnalyticsSavedViewRepo: NewInMemoryAnalyticsSavedViewStore()` in `setupStores()`.
+
+- [ ] **Step 7: Verify build + migration dry-run**
+
+Run:
+```bash
+go build ./...
+make migrate-ent-dry-run
+```
+Expected: compiles; dry-run prints the `analytics_saved_view` DDL.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ent/ internal/domain/analytics/saved_view.go internal/repository/ent/analytics_saved_view.go internal/testutil/ migrations/
+git commit -m "feat(analytics): analytics_saved_view schema, domain, repository, in-memory store"
+```
+
+---
+
+### Task 5: `AnalyticsService` — ExecuteView + saved-view CRUD
+
+**Files:**
+- Create: `internal/ee/service/analytics.go`
+- Test: `internal/ee/service/analytics_test.go`
+
+**Interfaces:**
+- Consumes: `analytics.Repository` (Task 4); `MeterUsageService` (existing, `internal/ee/service/meter_usage.go`) for execution; Tasks 1–3.
+- Produces:
+  - `type AnalyticsService interface { ExecuteView(ctx, def analytics.ViewDefinition, vars map[string]any) (*QueryResult, error); CreateView(ctx, *analytics.SavedView) error; QuerySavedView(ctx, id string, vars map[string]any) (*QueryResult, error) }`
+  - `func NewAnalyticsService(params ServiceParams, savedViews analytics.Repository) AnalyticsService`.
+
+- [ ] **Step 1: Write failing service test (in-memory meter_usage seeded)**
+
+```go
+// internal/ee/service/analytics_test.go
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/domain/analytics"
+	"github.com/flexprice/flexprice/internal/testutil"
+	"github.com/stretchr/testify/suite"
+)
+
+type AnalyticsServiceSuite struct {
+	testutil.BaseServiceTestSuite
+	svc AnalyticsService
+}
+
+func TestAnalyticsService(t *testing.T) { suite.Run(t, new(AnalyticsServiceSuite)) }
+
+func (s *AnalyticsServiceSuite) SetupTest() {
+	s.BaseServiceTestSuite.SetupTest()
+	params := ServiceParams{
+		Logger:         s.GetLogger(),
+		DB:             s.GetDB(),
+		MeterUsageRepo: s.GetStores().MeterUsageRepo,
+		MeterRepo:      s.GetStores().MeterRepo,
+	}
+	meterUsageSvc := NewMeterUsageService(params)
+	_ = meterUsageSvc
+	s.svc = NewAnalyticsService(params, s.GetStores().AnalyticsSavedViewRepo)
+}
+
+func (s *AnalyticsServiceSuite) TestExecuteView_BreakdownReturnsRows() {
+	// seed a meter + usage rows via the base-suite helpers (mirror meter_usage_test.go setup)
+	def := analytics.ViewDefinition{
+		Shape: analytics.ShapeBreakdown, Metrics: []string{"usage_quantity"},
+		Dimensions: []string{"properties.region"},
+		Filters:    []analytics.Filter{{Field: "meter_id", Op: "eq", Value: "{{meter}}"}},
+		Time:       analytics.TimeSpecRaw{Range: "{{dr}}", Grain: "day"},
+		Variables:  []analytics.Variable{{Name: "meter", Type: "string", Required: true}, {Name: "dr", Type: "date_range", Required: true}},
+	}
+	res, err := s.svc.ExecuteView(s.GetContext(), def, map[string]any{
+		"meter": "meter_1",
+		"dr":    map[string]any{"from": time.Now().Add(-48 * time.Hour).Format("2006-01-02"), "to": time.Now().Format("2006-01-02")},
+	})
+	s.NoError(err)
+	s.NotNil(res)
+	s.Equal("properties.region", res.Columns[0].Name)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails** — Run: `go test ./internal/ee/service/ -run TestAnalyticsService -v` → FAIL (`NewAnalyticsService` undefined).
+
+- [ ] **Step 3: Implement the service**
+
+```go
+// internal/ee/service/analytics.go
+package service
+
+import (
+	"context"
+
+	"github.com/flexprice/flexprice/internal/domain/analytics"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+)
+
+type AnalyticsService interface {
+	ExecuteView(ctx context.Context, def analytics.ViewDefinition, vars map[string]any) (*QueryResult, error)
+	CreateView(ctx context.Context, v *analytics.SavedView) error
+	QuerySavedView(ctx context.Context, id string, vars map[string]any) (*QueryResult, error)
+}
+
+type analyticsService struct {
+	ServiceParams
+	savedViews  analytics.Repository
+	meterUsage  MeterUsageService
+}
+
+func NewAnalyticsService(params ServiceParams, savedViews analytics.Repository) AnalyticsService {
+	return &analyticsService{
+		ServiceParams: params,
+		savedViews:    savedViews,
+		meterUsage:    NewMeterUsageService(params),
+	}
+}
+
+func (s *analyticsService) ExecuteView(ctx context.Context, def analytics.ViewDefinition, vars map[string]any) (*QueryResult, error) {
+	rv, err := analytics.ResolveVariables(def, vars)
+	if err != nil {
+		return nil, err
+	}
+	switch rv.Shape {
+	case analytics.ShapeBreakdown:
+		params, err := TranslateBreakdown(ctx, rv)
+		if err != nil {
+			return nil, err
+		}
+		items, err := s.meterUsage.GetDetailedAnalytics(ctx, params) // reuse existing execution
+		if err != nil {
+			s.Logger.Error(ctx, "analytics breakdown execution failed", "error", err)
+			return nil, err
+		}
+		res := ShapeBreakdown(items, rv.Dimensions)
+		return &res, nil
+	case analytics.ShapeTimeseries:
+		params, err := TranslateTimeseries(ctx, rv)
+		if err != nil {
+			return nil, err
+		}
+		agg, err := s.meterUsage.GetUsage(ctx, params)
+		if err != nil {
+			s.Logger.Error(ctx, "analytics timeseries execution failed", "error", err)
+			return nil, err
+		}
+		res := ShapeTimeseries(agg)
+		return &res, nil
+	default:
+		return nil, ierr.NewError("unsupported shape").Mark(ierr.ErrValidation)
+	}
+}
+
+func (s *analyticsService) CreateView(ctx context.Context, v *analytics.SavedView) error {
+	if err := v.Definition.Validate(); err != nil {
+		return err
+	}
+	return s.savedViews.Create(ctx, v)
+}
+
+func (s *analyticsService) QuerySavedView(ctx context.Context, id string, vars map[string]any) (*QueryResult, error) {
+	v, err := s.savedViews.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return s.ExecuteView(ctx, v.Definition, vars)
+}
+```
+
+> **Executor note:** align `GetDetailedAnalytics` / `GetUsage` return types with what `MeterUsageService` actually exposes (`internal/ee/service/meter_usage.go`). If the service returns a `*dto.GetUsageAnalyticsResponse` rather than `[]events.MeterUsageDetailedResult`, adjust the shaper's input type in Task 3 to match, or unwrap here.
+
+- [ ] **Step 4: Run test to verify it passes** — Run: `go test ./internal/ee/service/ -run TestAnalyticsService -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ee/service/analytics.go internal/ee/service/analytics_test.go
+git commit -m "feat(analytics): AnalyticsService ExecuteView + saved-view CRUD"
+```
+
+---
+
+### Task 6: DTOs, handlers, routes, FX wiring
+
+**Files:**
+- Create: `internal/api/dto/analytics.go`
+- Create: `internal/api/v1/analytics.go`
+- Modify: `internal/api/router.go` (add `Analytics *v1.AnalyticsHandler` to `Handlers`; register `/analytics` group)
+- Modify: `cmd/server/main.go` (`fx.Provide` repo + service; `provideHandlers` param + field)
+
+**Interfaces:**
+- Consumes: `AnalyticsService` (Task 5); `types.GetTenantID/GetEnvironmentID`; `validator.ValidateRequest`.
+- Produces: HTTP endpoints
+  - `POST /v1/analytics/query` — body `{definition, variables}` (ad-hoc) → `QueryResult`.
+  - `POST /v1/analytics/views` — create a saved view.
+  - `POST /v1/analytics/views/{id}/query` — body `{variables}` → `QueryResult`.
+
+- [ ] **Step 1: Write the DTOs** (`internal/api/dto/analytics.go`)
+
+```go
+package dto
+
+import (
+	"github.com/flexprice/flexprice/internal/domain/analytics"
+	"github.com/flexprice/flexprice/internal/validator"
+)
+
+type AnalyticsQueryRequest struct {
+	Definition analytics.ViewDefinition `json:"definition" validate:"required"`
+	Variables  map[string]any           `json:"variables"`
+}
+
+func (r *AnalyticsQueryRequest) Validate() error { return validator.ValidateRequest(r) }
+
+type SavedViewQueryRequest struct {
+	Variables map[string]any `json:"variables"`
+}
+
+type CreateSavedViewRequest struct {
+	Name       string                   `json:"name" validate:"required"`
+	Definition analytics.ViewDefinition `json:"definition" validate:"required"`
+}
+
+func (r *CreateSavedViewRequest) Validate() error { return validator.ValidateRequest(r) }
+```
+
+- [ ] **Step 2: Write the handler** (`internal/api/v1/analytics.go`) — model on `meter_usage.go:20-58`
+
+```go
+package v1
+
+import (
+	"net/http"
+
+	"github.com/flexprice/flexprice/internal/api/dto"
+	"github.com/flexprice/flexprice/internal/domain/analytics"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/service"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/gin-gonic/gin"
+)
+
+type AnalyticsHandler struct {
+	svc service.AnalyticsService
+	log *logger.Logger
+}
+
+func NewAnalyticsHandler(svc service.AnalyticsService, log *logger.Logger) *AnalyticsHandler {
+	return &AnalyticsHandler{svc: svc, log: log}
+}
+
+// @Summary Run an ad-hoc analytics query
+// @Tags Analytics
+// @Param request body dto.AnalyticsQueryRequest true "query"
+// @Success 200 {object} service.QueryResult
+// @x-scope "read"
+// @Router /analytics/query [post]
+func (h *AnalyticsHandler) Query(c *gin.Context) {
+	ctx := c.Request.Context()
+	var req dto.AnalyticsQueryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.Error(ierr.WithError(err).WithHint("invalid request").Mark(ierr.ErrValidation))
+		return
+	}
+	if err := req.Validate(); err != nil {
+		c.Error(err)
+		return
+	}
+	res, err := h.svc.ExecuteView(ctx, req.Definition, req.Variables)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	c.JSON(http.StatusOK, res)
+}
+
+// CreateView and QuerySavedView follow the same parse->validate->delegate shape;
+// CreateView builds &analytics.SavedView{ID: types.GenerateUUIDWithPrefix(types.UUIDPrefixAnalyticsView), Name: req.Name, Version: 1, Definition: req.Definition}
+// then h.svc.CreateView(ctx, v).
+```
+
+> **Executor note:** add a `UUIDPrefixAnalyticsView` constant in `internal/types` next to the existing prefixes, and add `@x-scope "read"` to the two POST *query* endpoints (they are read-only) per AGENTS.md.
+
+- [ ] **Step 3: Register routes + Handlers field** (`internal/api/router.go`) — add field `Analytics *v1.AnalyticsHandler` to `Handlers` (near line 61) and:
+
+```go
+analytics := v1Private.Group("/analytics")
+{
+	analytics.POST("/query", handlers.Analytics.Query)
+	analytics.POST("/views", handlers.Analytics.CreateView)
+	analytics.POST("/views/:id/query", handlers.Analytics.QuerySavedView)
+}
+```
+
+- [ ] **Step 4: FX wiring** (`cmd/server/main.go`)
+  - In the repositories `fx.Provide` block (near line 140): add `repository.NewAnalyticsSavedViewRepository,`.
+  - In the services `fx.Provide` block (near line 237): add `service.NewAnalyticsService,`.
+  - Add `analyticsService service.AnalyticsService` as a `provideHandlers` param (near line 369) and set `Analytics: v1.NewAnalyticsHandler(analyticsService, logger)` in the returned `Handlers` (near line 422).
+
+> **Executor note:** `NewAnalyticsService(params ServiceParams, savedViews analytics.Repository)` has two args, so FX must be able to provide both. Either (a) add `AnalyticsSavedViewRepo` to `ServiceParams` and `NewServiceParams`, then change the signature to `NewAnalyticsService(params ServiceParams)`, or (b) leave the two-arg form and ensure `analytics.Repository` is provided. Prefer (a) for consistency with the existing `ServiceParams` pattern.
+
+- [ ] **Step 5: Build, generate swagger, run the full package test**
+
+Run:
+```bash
+go build ./...
+make swagger
+go test ./internal/ee/service/ ./internal/domain/analytics/ -v
+make lint-ci
+```
+Expected: compiles; swagger regenerates with the new endpoints; tests pass; loglint clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/dto/analytics.go internal/api/v1/analytics.go internal/api/router.go cmd/server/main.go docs/swagger/ internal/types/
+git commit -m "feat(analytics): /v1/analytics query + saved-view endpoints, FX wiring"
+```
+
+---
+
+### Task 7: End-to-end smoke test against the running server
+
+**Files:**
+- Test: `internal/api/v1/analytics_e2e_test.go` (or extend an existing API test harness if one exists)
+
+**Interfaces:**
+- Consumes: the full wired app.
+
+- [ ] **Step 1: Write an httptest-based test** that boots the router with a stubbed `AnalyticsService` (or the real one over in-memory stores), POSTs a `breakdown` query with tenant/env context headers, and asserts a 200 with `columns[0].role == "dimension"`. Model it on any existing `internal/api/v1/*_test.go`; if none exist, assert at the service layer only and skip this task.
+
+- [ ] **Step 2: Run** — `go test ./internal/api/v1/ -run Analytics -v` → PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/api/v1/analytics_e2e_test.go
+git commit -m "test(analytics): endpoint smoke test for /analytics/query"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (§14 Phase 1):**
+- Saved-view model → Task 4 (ent + domain + repo).
+- Serving translator → Task 2 (view → meter_usage params) + Task 3 (shaping) + Task 5 (orchestration).
+- `/analytics/query` over meter_usage → Task 6.
+- Shapes `timeseries` + `breakdown` → Tasks 2/3/5 handle both.
+- Usage only, no money → enforced: translator maps only to `meter_usage`; no revenue path exists yet.
+- RLS (tenant+env) → Task 2 injects from context; the meter_usage builder binds them as params (Global Constraints).
+- Variables as query params, optional filters dropped → Task 1 resolver + reuse of the parameterized builder.
+
+**Placeholder scan:** No "TODO/TBD"; every code step has real code. "Executor notes" flag exactly where the engineer must confirm a real signature against the cited file — these are verification pointers, not missing content.
+
+**Type consistency:** `ViewDefinition`/`ResolvedView`/`Filter`/`TimeSpec` names are consistent across Tasks 1→2→5. `QueryResult`/`Column` consistent across Tasks 3→5→6. `analytics.Repository` / `NewAnalyticsSavedViewRepository` consistent across Tasks 4→6. The one open coupling is the `MeterUsageService` return type feeding Task 3's shaper — flagged in Task 5's executor note as the first thing to reconcile.
+
+**Known risks to confirm during execution (not placeholders — real integration seams):**
+1. Exact field names/plurality on `events.MeterUsageQueryParams` / `MeterUsageDetailedAnalyticsParams` and the result structs (Tasks 2/3).
+2. `MeterUsageService` method names/signatures for detailed + timeseries execution (Task 5).
+3. `ServiceParams` field set and whether to thread the saved-view repo through it (Task 6 note).
+4. `types.BaseModel` field set for `FromEnt` (Task 4).
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/design/2026-09-11-FLE-1257-analytics-phase1-implementation-plan.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — a fresh subagent per task, review between tasks, fast iteration. First step per task is to confirm the real signatures the executor notes flag.
+
+**2. Inline Execution** — execute tasks in this session with checkpoints for review.
+
+**Which approach?**


### PR DESCRIPTION
## Summary

Adds the design + ERD for a tenant-facing **analytics platform** over usage and revenue, served from the ClickHouse analytics replica (CH-B).

- **Linear:** [FLE-1257](https://linear.app/flexprice/issue/FLE-1257/analytics)
- Doc: `docs/design/2026-09-10-FLE-1257-analytics-platform-erd.md`

### What it proposes
- **Product analytics** on the existing `meter_usage` + query builder, with runtime-computed "adjusted usage" and saved views (JSON in Postgres, no DDL).
- **Revenue analytics** via a new **derived, daily-grain `revenue_facts`** table built by **re-running the billing preview engine** (non-mutating) — so numbers reconcile to the invoice *by construction* rather than via a parallel pricing implementation.
- **Daily decomposition** by the marginal-cumulative method (engine day-checkpoints), with a `marginal | period_only` split for non-monotonic pricing/aggregations (volume tiers, LATEST/AVG/WEIGHTED_SUM, week/month buckets).
- **`revenue_source`** dimension (usage / fixed / commitment_trueup / credit_breakage / manual_adjustment); tax and prepaid excluded (ASC 606-aligned); `PROVISIONAL → FINAL` with append + `REVERTED` corrections and a two-lock (invoice-finalization + accounting-period) model.
- **Recognition-ready** schema (service window, recognition method, `lock_adjusted_day`) with the ASC 606 recognition engine deferred to a later phase.
- Warehouse **export** path over the derived + PeerDB-synced raw tables, phasing, invariants, and open questions.

Includes an `erDiagram` plus architecture / write-path / lifecycle / serving mermaid diagrams, and worked examples for daily row computation and breakage.

## Test plan
- [ ] Design review — this is a proposal doc; no code changes.
- [ ] Confirm open questions (§15), esp. the engine cumulative-checkpoint entry point (Q2) and the multi-period commitment prior-base (Q3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the analytics architecture to use ClickHouse B as the unified serving replica.
  * Clarified data flows for revenue, usage, ledger, mixed queries, joins, custom-dimension allocation, and exports.
  * Documented Postgres as authoritative for revenue and source data, with replication to ClickHouse B.
  * Added a Phase 1 implementation plan covering saved views, analytics querying, result formatting, API endpoints, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->