### PR TITLE
feat(chart): add memory metric to worker HPA

### DIFF
--- a/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-worker.yaml
+++ b/internal/ee/infrastructure/helm/flexprice/templates/autoscaling/hpa-worker.yaml
@@ -21,6 +21,14 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
+    {{- if .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 300


### PR DESCRIPTION
## What
Worker HPA (`hpa-worker.yaml`) rendered **CPU utilization only**. The api HPA already supports CPU **and** memory. This mirrors `hpa-api.yaml` so `worker.autoscaling.targetMemoryUtilizationPercentage` is honored on the worker Deployment.

## Why
FLE-529 — enabling a CPU+mem HPA on the us-west1 temporal-worker (infra values PR is separate). Without this template change the memory target set in values is silently inert.

## Change
Adds the standard `{{- if ...targetMemoryUtilizationPercentage }}` memory `Resource` metric block after the existing CPU block. Byte-identical to the proven api HPA.

Verified with `helm template` — worker HPA now renders both CPU(70%) and memory(80%) metrics, min2/max6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker services can now optionally autoscale based on memory utilization when configured, alongside the existing CPU-based scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->