### PR TITLE
fix(tax): Default tax behaviour if unset is exclusive

### DIFF
--- a/internal/ee/service/invoice.go
+++ b/internal/ee/service/invoice.go
@@ -3954,8 +3954,8 @@ func (s *invoiceService) applyTaxesToInvoice(ctx context.Context, inv *invoice.I
 		prepared, err := taxService.PrepareTaxRatesForInvoice(ctx, dto.CreateInvoiceRequest{
 			SubscriptionID: inv.SubscriptionID,
 			CustomerID:     inv.CustomerID,
-			// An unstamped association defaults its behavior from this. Omit it and they all
-			// resolve against an empty currency, which silently means inclusive.
+			// Currency is used when the request carries rate overrides or raw tax_rate IDs.
+			// Unstamped subscription associations resolve exclusive and do not use this.
 			Currency: inv.Currency,
 		})
 		if err != nil {

--- a/internal/ee/service/tax.go
+++ b/internal/ee/service/tax.go
@@ -1059,15 +1059,14 @@ func (s *taxService) PrepareTaxRatesForInvoice(ctx context.Context, req dto.Crea
 			taxRateIDs[i] = association.TaxRateID
 			behavior := lo.FromPtr(association.TaxBehavior)
 			if behavior == "" {
-				// Creation always stamps one, so a null here should not happen. Fall back to
-				// the same currency default every other unstamped resolution uses.
-				behavior = types.DefaultTaxBehaviorForCurrency(req.Currency)
-				s.Logger.Error(ctx, "subscription tax association missing tax_behavior, defaulting from currency",
-					"error", "tax_behavior is null on a subscription-level association",
+				// Pre-inc/exc rows were never stamped; exclusive is what those invoices charged.
+				// Do not use the currency default here — that would flip INR (and any
+				// non-USD/CAD) to inclusive on the next invoice. Create-time stamping is unchanged.
+				behavior = types.TaxBehaviorExclusive
+				s.Logger.Info(ctx, "unstamped subscription tax association defaulted to exclusive",
 					"tax_association_id", association.ID,
 					"tax_rate_id", association.TaxRateID,
-					"currency", req.Currency,
-					"resolved_behavior", behavior)
+					"currency", req.Currency)
 			}
 			behaviorByRateID[association.TaxRateID] = behavior
 		}

--- a/internal/ee/service/tax_preview_test.go
+++ b/internal/ee/service/tax_preview_test.go
@@ -1231,18 +1231,15 @@ func (s *TaxCalculationSuite) TestPrepareTaxRates_SubscriptionAssociationsKeepTh
 		"each association keeps its own behavior — collapsing to a bare rate list would lose this")
 }
 
-// a subscription-level row with a null tax_behavior should not exist (creation
-// always stamps one). If one is found anyway it is logged as an anomaly and falls back to the
-// same currency default every other unstamped resolution uses, rather than a value special to
-// this branch.
-func (s *TaxCalculationSuite) TestPrepareTaxRates_AssociationWithNullBehaviorFallsBackToCurrencyDefault() {
+// Unstamped subscription associations (pre-inc/exc rows) resolve exclusive at
+// invoice time, including INR — create-time currency defaults are not reapplied here.
+func (s *TaxCalculationSuite) TestPrepareTaxRates_AssociationWithNullBehaviorDefaultsToExclusive() {
 	tests := []struct {
 		name     string
 		currency string
-		want     types.TaxBehavior
 	}{
-		{name: "USD falls back to exclusive", currency: "usd", want: types.TaxBehaviorExclusive},
-		{name: "INR falls back to inclusive", currency: "inr", want: types.TaxBehaviorInclusive},
+		{name: "USD", currency: "usd"},
+		{name: "INR", currency: "inr"},
 	}
 
 	for _, tt := range tests {
@@ -1250,7 +1247,7 @@ func (s *TaxCalculationSuite) TestPrepareTaxRates_AssociationWithNullBehaviorFal
 			cust := s.newCustomer(types.TaxTreatmentTaxable)
 			sub := s.newSubscription(cust.ID, tt.currency)
 			rate := s.persistedRate("null_behavior_"+tt.currency, 10)
-			s.association(rate.ID, sub.ID, nil) // written directly: CreateTaxAssociation would never produce this
+			s.association(rate.ID, sub.ID, nil)
 
 			resolved, err := s.svc.PrepareTaxRatesForInvoice(s.GetContext(), dto.CreateInvoiceRequest{
 				CustomerID:     cust.ID,
@@ -1260,7 +1257,7 @@ func (s *TaxCalculationSuite) TestPrepareTaxRates_AssociationWithNullBehaviorFal
 
 			s.Require().NoError(err)
 			s.Require().Len(resolved.GetRates(), 1)
-			s.Equal(tt.want, resolved.GetRates()[0].TaxBehavior)
+			s.Equal(types.TaxBehaviorExclusive, resolved.GetRates()[0].TaxBehavior)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #<issue-number>


## 📝 Description
Please provide a clear and concise description of what this PR does.

---

## 🔨 Changes Made
- [ ] Feature 1
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable.
- [ ] All new and existing tests pass.
- [ ] I have updated documentation (if needed).

---

## 📷 Screenshots / Demo (if applicable)
_Add screenshots or demo links here._

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tax handling for older subscription tax associations without a recorded tax behavior.
  * These associations now consistently use exclusive tax treatment when invoices are prepared, regardless of currency.
  * Prevents certain invoices—particularly those using currencies with inclusive defaults—from applying an incorrect tax treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->