### PR TITLE
feat(licensing): backend licensing-token endpoint + JWKS

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/flexprice/flexprice/internal/httpclient"
 	integrationevents "github.com/flexprice/flexprice/internal/integration/events"
 	"github.com/flexprice/flexprice/internal/kafka"
+	"github.com/flexprice/flexprice/internal/licensing"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/pdf"
 	"github.com/flexprice/flexprice/internal/postgres"
@@ -94,6 +95,9 @@ func main() {
 
 			// RBAC
 			rbac.NewRBACService,
+
+			// Licensing (Heimdall token mint + JWKS signer)
+			licensing.NewSigner,
 
 			// Monitoring
 			tracing.NewService,
@@ -382,6 +386,7 @@ func provideHandlers(
 	checkoutSessionService service.CheckoutSessionService,
 	geminiPricingService service.GeminiPricingService,
 	webhookService *webhook.WebhookService,
+	licensingSigner *licensing.Signer,
 ) api.Handlers {
 	return api.Handlers{
 		Events:                   v1.NewEventsHandler(eventService, rawEventsReprocessingService, rawEventConsumptionService, meterUsageService, cfg, logger),
@@ -437,6 +442,7 @@ func provideHandlers(
 		MeterUsage:               v1.NewMeterUsageHandler(meterUsageService, logger),
 		SAML:                     saml.NewHandler(cfg, serviceParams, logger),
 		CheckoutSession:          v1.NewCheckoutSessionHandler(checkoutSessionService, logger),
+		Licensing:                v1.NewLicensingHandler(licensingSigner, logger),
 	}
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -387,6 +387,7 @@ func provideHandlers(
 	geminiPricingService service.GeminiPricingService,
 	webhookService *webhook.WebhookService,
 	licensingSigner *licensing.Signer,
+	userRepo user.Repository,
 ) api.Handlers {
 	return api.Handlers{
 		Events:                   v1.NewEventsHandler(eventService, rawEventsReprocessingService, rawEventConsumptionService, meterUsageService, cfg, logger),
@@ -442,7 +443,7 @@ func provideHandlers(
 		MeterUsage:               v1.NewMeterUsageHandler(meterUsageService, logger),
 		SAML:                     saml.NewHandler(cfg, serviceParams, logger),
 		CheckoutSession:          v1.NewCheckoutSessionHandler(checkoutSessionService, logger),
-		Licensing:                v1.NewLicensingHandler(licensingSigner, logger),
+		Licensing:                v1.NewLicensingHandler(licensingSigner, userRepo, logger),
 	}
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -96,7 +96,7 @@ func main() {
 			// RBAC
 			rbac.NewRBACService,
 
-			// Licensing (Heimdall token mint + JWKS signer)
+			// Licensing (licensing token mint + JWKS signer)
 			licensing.NewSigner,
 
 			// Monitoring
@@ -443,7 +443,7 @@ func provideHandlers(
 		MeterUsage:               v1.NewMeterUsageHandler(meterUsageService, logger),
 		SAML:                     saml.NewHandler(cfg, serviceParams, logger),
 		CheckoutSession:          v1.NewCheckoutSessionHandler(checkoutSessionService, logger),
-		Licensing:                v1.NewLicensingHandler(licensingSigner, userRepo, tenantService, logger),
+		Licensing:                v1.NewLicensingHandler(cfg, licensingSigner, userRepo, tenantService, logger),
 	}
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -443,7 +443,7 @@ func provideHandlers(
 		MeterUsage:               v1.NewMeterUsageHandler(meterUsageService, logger),
 		SAML:                     saml.NewHandler(cfg, serviceParams, logger),
 		CheckoutSession:          v1.NewCheckoutSessionHandler(checkoutSessionService, logger),
-		Licensing:                v1.NewLicensingHandler(licensingSigner, userRepo, logger),
+		Licensing:                v1.NewLicensingHandler(licensingSigner, userRepo, tenantService, logger),
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -139,8 +139,8 @@ func NewRouter(
 	router.GET("/health", handlers.Health.Health)
 	router.POST("/health", handlers.Health.Health)
 
-	// Heimdall licensing JWKS. Root-level (not /v1) and outside any auth
-	// group: Heimdall fetches this unauthenticated, same as any other
+	// licensing service JWKS. Root-level (not /v1) and outside any auth
+	// group: the licensing service fetches this unauthenticated, same as any other
 	// well-known key discovery endpoint.
 	router.GET("/.well-known/licensing-jwks.json", handlers.Licensing.JWKS)
 
@@ -192,7 +192,7 @@ func NewRouter(
 			user.POST("/chat/verify", handlers.User.CreateSupportChatToken)
 		}
 
-		// Heimdall licensing token mint — short-lived, capped at the caller's
+		// licensing token mint — short-lived, capped at the caller's
 		// own session expiry.
 		v1Private.GET("/licensing-token", handlers.Licensing.IssueToken)
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -66,6 +66,7 @@ type Handlers struct {
 	Workflow                 *v1.WorkflowHandler
 	MeterUsage               *v1.MeterUsageHandler
 	CheckoutSession          *v1.CheckoutSessionHandler
+	Licensing                *v1.LicensingHandler
 
 	// Enterprise handlers
 	SAML *saml.Handler
@@ -138,6 +139,11 @@ func NewRouter(
 	router.GET("/health", handlers.Health.Health)
 	router.POST("/health", handlers.Health.Health)
 
+	// Heimdall licensing JWKS. Root-level (not /v1) and outside any auth
+	// group: Heimdall fetches this unauthenticated, same as any other
+	// well-known key discovery endpoint.
+	router.GET("/.well-known/licensing-jwks.json", handlers.Licensing.JWKS)
+
 	// Public routes
 	public := router.Group("/", middleware.GuestAuthenticateMiddleware)
 
@@ -185,6 +191,10 @@ func NewRouter(
 			user.POST("/search", read(types.EntityUser, types.ActionRead), handlers.User.QueryUsers)
 			user.POST("/chat/verify", handlers.User.CreateSupportChatToken)
 		}
+
+		// Heimdall licensing token mint — short-lived, capped at the caller's
+		// own session expiry.
+		v1Private.GET("/licensing-token", handlers.Licensing.IssueToken)
 
 		environment := v1Private.Group("/environments")
 		{

--- a/internal/api/v1/licensing.go
+++ b/internal/api/v1/licensing.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	domainUser "github.com/flexprice/flexprice/internal/domain/user"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/licensing"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -13,15 +14,20 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+// staffEmailDomain gates is_admin: only Flexprice staff (verified @flexprice.io
+// email) may mint enterprise / other-tenant licenses.
+const staffEmailDomain = "@flexprice.io"
+
 // LicensingHandler mints Heimdall licensing tokens and publishes the backend's
 // public key as a JWKS. See internal/licensing for the signing logic.
 type LicensingHandler struct {
-	signer *licensing.Signer
-	log    *logger.Logger
+	signer   *licensing.Signer
+	userRepo domainUser.Repository
+	log      *logger.Logger
 }
 
-func NewLicensingHandler(signer *licensing.Signer, log *logger.Logger) *LicensingHandler {
-	return &LicensingHandler{signer: signer, log: log}
+func NewLicensingHandler(signer *licensing.Signer, userRepo domainUser.Repository, log *logger.Logger) *LicensingHandler {
+	return &LicensingHandler{signer: signer, userRepo: userRepo, log: log}
 }
 
 type licensingTokenResponse struct {
@@ -57,7 +63,16 @@ func (h *LicensingHandler) IssueToken(c *gin.Context) {
 		return
 	}
 
-	isAdmin := types.IsSuperAdminUser(ctx)
+	// is_admin means Flexprice STAFF (us), not tenant owner — every user is
+	// super-admin of their own tenant, so that check is wrong here. Gate on a
+	// @flexprice.io email instead.
+	// SECURITY: trustworthy only when the email is IdP-verified (Supabase/SSO).
+	// Under the self-serve flexprice provider email is unverified and therefore
+	// spoofable — do not rely on this for staff auth in that mode.
+	isAdmin := false
+	if u, err := h.userRepo.GetByID(ctx, types.GetUserID(ctx)); err == nil && u != nil {
+		isAdmin = strings.HasSuffix(strings.ToLower(u.Email), staffEmailDomain)
+	}
 
 	token, err := h.signer.Mint(tenantID, isAdmin, sessionExp)
 	if err != nil {

--- a/internal/api/v1/licensing.go
+++ b/internal/api/v1/licensing.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/config"
 	domainUser "github.com/flexprice/flexprice/internal/domain/user"
 	eeservice "github.com/flexprice/flexprice/internal/ee/service"
 	ierr "github.com/flexprice/flexprice/internal/errors"
@@ -19,25 +20,26 @@ import (
 // email) may mint enterprise / other-tenant licenses.
 const staffEmailDomain = "@flexprice.io"
 
-// LicensingHandler mints Heimdall licensing tokens and publishes the backend's
+// LicensingHandler mints licensing tokens and publishes the backend's
 // public key as a JWKS. See internal/licensing for the signing logic.
 type LicensingHandler struct {
+	cfg           *config.Configuration
 	signer        *licensing.Signer
 	userRepo      domainUser.Repository
 	tenantService eeservice.TenantService
 	log           *logger.Logger
 }
 
-func NewLicensingHandler(signer *licensing.Signer, userRepo domainUser.Repository, tenantService eeservice.TenantService, log *logger.Logger) *LicensingHandler {
-	return &LicensingHandler{signer: signer, userRepo: userRepo, tenantService: tenantService, log: log}
+func NewLicensingHandler(cfg *config.Configuration, signer *licensing.Signer, userRepo domainUser.Repository, tenantService eeservice.TenantService, log *logger.Logger) *LicensingHandler {
+	return &LicensingHandler{cfg: cfg, signer: signer, userRepo: userRepo, tenantService: tenantService, log: log}
 }
 
 type licensingTokenResponse struct {
 	Token string `json:"token"`
 }
 
-// @Summary Mint a Heimdall licensing token
-// @Description Issues a short-lived EdDSA-signed token, capped at the caller's session expiry, for the browser to present to the central Heimdall licensing service.
+// @Summary Mint a licensing token
+// @Description Issues a short-lived EdDSA-signed token, capped at the caller's session expiry, for the browser to present to the central licensing service.
 // @Tags Licensing
 // @Produce json
 // @Success 200 {object} licensingTokenResponse
@@ -60,11 +62,26 @@ func (h *LicensingHandler) IssueToken(c *gin.Context) {
 	}
 
 	// Only a tenant super-admin may mint licenses. A licensing token is the
-	// browser's only path to Heimdall's mint endpoint, so gating it here gates
+	// browser's only path to the licensing service's mint endpoint, so gating it here gates
 	// minting for the whole tenant — non-admin members get 403 and no token.
 	if !types.IsSuperAdminUser(ctx) {
 		c.Error(ierr.NewError("only a tenant super-admin may mint licenses").
 			WithHint("You do not have permission to generate a license").
+			Mark(ierr.ErrPermissionDenied))
+		return
+	}
+
+	// A licensing token's exp is bound to the caller's verified session JWT
+	// below via an unverified re-parse — safe only because AuthenticateMiddleware
+	// already verified that exact token's signature. An API-key caller (config
+	// key or DB-backed secret) never went through that verification: any
+	// Authorization header they also attach is unauthenticated user input, and
+	// reading "exp" off it would let them forge an arbitrarily long-lived
+	// licensing token. Refuse minting outright for API-key callers — they have
+	// no user session to bound against.
+	if c.GetHeader(h.cfg.Auth.APIKey.Header) != "" {
+		c.Error(ierr.NewError("licensing tokens require a user session").
+			WithHint("Please log in with a user session to mint a licensing token").
 			Mark(ierr.ErrPermissionDenied))
 		return
 	}
@@ -78,26 +95,35 @@ func (h *LicensingHandler) IssueToken(c *gin.Context) {
 	// is_admin means Flexprice STAFF (us), not tenant owner — every user is
 	// super-admin of their own tenant, so that check is wrong here. Gate on a
 	// @flexprice.io email instead.
-	// SECURITY: trustworthy only when the email is IdP-verified (Supabase/SSO).
-	// Under the self-serve flexprice provider email is unverified and therefore
-	// spoofable — do not rely on this for staff auth in that mode.
+	// SECURITY: the user model carries no IdP-verified-email or trusted-provider
+	// signal (domainUser.User has no EmailVerified/Provider field, and
+	// Supabase's EmailConfirmed is an Admin-API call keyed on Supabase user ID,
+	// not something userRepo exposes here). Under the self-serve flexprice
+	// provider, email is unverified and spoofable, so an email-domain match
+	// alone must not grant staff powers. Fail closed by default; an operator
+	// who has verified their deployment's email flow can opt in explicitly.
+	// TODO: wire a real verified-email/trusted-provider signal into
+	// domainUser.User (or a dedicated lookup) and require it here instead of
+	// this config escape hatch.
 	isAdmin := false
-	if u, err := h.userRepo.GetByID(ctx, types.GetUserID(ctx)); err == nil && u != nil {
-		isAdmin = strings.HasSuffix(strings.ToLower(u.Email), staffEmailDomain)
+	if h.cfg.Licensing.TrustEmailDomainForStaff {
+		if u, err := h.userRepo.GetByID(ctx, types.GetUserID(ctx)); err == nil && u != nil {
+			isAdmin = strings.HasSuffix(strings.ToLower(u.Email), staffEmailDomain)
+		}
 	}
 
 	// customer = the caller's org/tenant display name, carried into the token so
-	// Heimdall can stamp it on community licenses. For admin mints on another
-	// tenant, Heimdall uses a request-supplied customer instead.
+	// the licensing service can stamp it on community licenses. For admin mints
+	// on another tenant, the licensing service uses a request-supplied customer.
 	customer := ""
 	if tr, err := h.tenantService.GetTenantByID(ctx, tenantID); err == nil && tr != nil {
 		customer = tr.Name
 	}
 
 	// issued-by uuid identifies the minting user, sent for everyone (incl.
-	// staff) so Heimdall keeps a real audit trail. The is_admin flag rides
-	// alongside; Heimdall blanks issued_by in FE responses when it is set, so
-	// a staff uuid is stored but never shown.
+	// staff) so the licensing service keeps a real audit trail. The is_admin
+	// flag rides alongside; the licensing service blanks issued_by in FE
+	// responses when it is set, so a staff uuid is stored but never shown.
 	issuedBy := types.GetUserID(ctx)
 
 	token, err := h.signer.Mint(tenantID, issuedBy, customer, isAdmin, sessionExp)
@@ -142,7 +168,7 @@ func sessionExpiryFromRequest(c *gin.Context) (time.Time, error) {
 }
 
 // @Summary Publish the backend's licensing JWKS
-// @Description Public JWKS of the backend's Ed25519 signing keys, for Heimdall to verify licensing tokens.
+// @Description Public JWKS of the backend's Ed25519 signing keys, for the licensing service to verify licensing tokens.
 // @Tags Licensing
 // @Produce json
 // @Success 200 {object} map[string]interface{}
@@ -153,7 +179,7 @@ func (h *LicensingHandler) JWKS(c *gin.Context) {
 		return
 	}
 
-	// Short CDN cache: long enough to absorb Heimdall's fetch fan-out, short
+	// Short CDN cache: long enough to absorb the licensing service's fetch fan-out, short
 	// enough that a rotated key propagates within the hour.
 	c.Header("Cache-Control", "public, max-age=3600")
 	c.JSON(http.StatusOK, gin.H{"keys": h.signer.JWKS()})

--- a/internal/api/v1/licensing.go
+++ b/internal/api/v1/licensing.go
@@ -84,7 +84,14 @@ func (h *LicensingHandler) IssueToken(c *gin.Context) {
 		customer = tr.Name
 	}
 
-	token, err := h.signer.Mint(tenantID, customer, isAdmin, sessionExp)
+	// issued-by uuid identifies the minting user. For staff (admin) we send
+	// EMPTY so the UI renders "Flexprice" instead of a staff user's id.
+	issuedBy := types.GetUserID(ctx)
+	if isAdmin {
+		issuedBy = ""
+	}
+
+	token, err := h.signer.Mint(tenantID, issuedBy, customer, isAdmin, sessionExp)
 	if err != nil {
 		c.Error(err)
 		return

--- a/internal/api/v1/licensing.go
+++ b/internal/api/v1/licensing.go
@@ -1,0 +1,119 @@
+package v1
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/flexprice/flexprice/internal/licensing"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// LicensingHandler mints Heimdall licensing tokens and publishes the backend's
+// public key as a JWKS. See internal/licensing for the signing logic.
+type LicensingHandler struct {
+	signer *licensing.Signer
+	log    *logger.Logger
+}
+
+func NewLicensingHandler(signer *licensing.Signer, log *logger.Logger) *LicensingHandler {
+	return &LicensingHandler{signer: signer, log: log}
+}
+
+type licensingTokenResponse struct {
+	Token string `json:"token"`
+}
+
+// @Summary Mint a Heimdall licensing token
+// @Description Issues a short-lived EdDSA-signed token, capped at the caller's session expiry, for the browser to present to the central Heimdall licensing service.
+// @Tags Licensing
+// @Produce json
+// @Success 200 {object} licensingTokenResponse
+// @Router /licensing-token [get]
+func (h *LicensingHandler) IssueToken(c *gin.Context) {
+	if h.signer == nil {
+		c.Error(ierr.NewError("licensing is not configured on this deployment").
+			WithHint("Licensing is not enabled").
+			Mark(ierr.ErrNotFound))
+		return
+	}
+
+	ctx := c.Request.Context()
+	tenantID := types.GetTenantID(ctx)
+	if tenantID == "" {
+		c.Error(ierr.NewError("missing tenant in authenticated request").
+			WithHint("Unauthorized").
+			Mark(ierr.ErrPermissionDenied))
+		return
+	}
+
+	sessionExp, err := sessionExpiryFromRequest(c)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	isAdmin := types.IsSuperAdminUser(ctx)
+
+	token, err := h.signer.Mint(tenantID, isAdmin, sessionExp)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, licensingTokenResponse{Token: token})
+}
+
+// sessionExpiryFromRequest reads the "exp" claim off the caller's own session
+// JWT. The signature was already verified by AuthenticateMiddleware to reach
+// this handler, so parsing unverified here only reads a claim, it does not
+// widen trust.
+func sessionExpiryFromRequest(c *gin.Context) (time.Time, error) {
+	authHeader := c.GetHeader(types.HeaderAuthorization)
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	if tokenString == "" || tokenString == authHeader {
+		// API-key callers (no bearer JWT) carry no session to bound the
+		// licensing token against.
+		return time.Time{}, ierr.NewError("licensing tokens require a user session").
+			WithHint("Please log in to mint a licensing token").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	claims := jwt.MapClaims{}
+	if _, _, err := jwt.NewParser().ParseUnverified(tokenString, claims); err != nil {
+		return time.Time{}, ierr.WithError(err).
+			WithHint("Invalid session token").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	expFloat, ok := claims["exp"].(float64)
+	if !ok {
+		return time.Time{}, ierr.NewError("session token has no expiry").
+			WithHint("Invalid session token").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	return time.Unix(int64(expFloat), 0), nil
+}
+
+// @Summary Publish the backend's licensing JWKS
+// @Description Public JWKS of the backend's Ed25519 signing keys, for Heimdall to verify licensing tokens.
+// @Tags Licensing
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Router /.well-known/licensing-jwks.json [get]
+func (h *LicensingHandler) JWKS(c *gin.Context) {
+	if h.signer == nil {
+		c.JSON(http.StatusOK, gin.H{"keys": []licensing.JWK{}})
+		return
+	}
+
+	// Short CDN cache: long enough to absorb Heimdall's fetch fan-out, short
+	// enough that a rotated key propagates within the hour.
+	c.Header("Cache-Control", "public, max-age=3600")
+	c.JSON(http.StatusOK, gin.H{"keys": h.signer.JWKS()})
+}

--- a/internal/api/v1/licensing.go
+++ b/internal/api/v1/licensing.go
@@ -84,12 +84,11 @@ func (h *LicensingHandler) IssueToken(c *gin.Context) {
 		customer = tr.Name
 	}
 
-	// issued-by uuid identifies the minting user. For staff (admin) we send
-	// EMPTY so the UI renders "Flexprice" instead of a staff user's id.
+	// issued-by uuid identifies the minting user, sent for everyone (incl.
+	// staff) so Heimdall keeps a real audit trail. The is_admin flag rides
+	// alongside; Heimdall blanks issued_by in FE responses when it is set, so
+	// a staff uuid is stored but never shown.
 	issuedBy := types.GetUserID(ctx)
-	if isAdmin {
-		issuedBy = ""
-	}
 
 	token, err := h.signer.Mint(tenantID, issuedBy, customer, isAdmin, sessionExp)
 	if err != nil {

--- a/internal/api/v1/licensing.go
+++ b/internal/api/v1/licensing.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	domainUser "github.com/flexprice/flexprice/internal/domain/user"
+	eeservice "github.com/flexprice/flexprice/internal/ee/service"
 	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/licensing"
 	"github.com/flexprice/flexprice/internal/logger"
@@ -21,13 +22,14 @@ const staffEmailDomain = "@flexprice.io"
 // LicensingHandler mints Heimdall licensing tokens and publishes the backend's
 // public key as a JWKS. See internal/licensing for the signing logic.
 type LicensingHandler struct {
-	signer   *licensing.Signer
-	userRepo domainUser.Repository
-	log      *logger.Logger
+	signer        *licensing.Signer
+	userRepo      domainUser.Repository
+	tenantService eeservice.TenantService
+	log           *logger.Logger
 }
 
-func NewLicensingHandler(signer *licensing.Signer, userRepo domainUser.Repository, log *logger.Logger) *LicensingHandler {
-	return &LicensingHandler{signer: signer, userRepo: userRepo, log: log}
+func NewLicensingHandler(signer *licensing.Signer, userRepo domainUser.Repository, tenantService eeservice.TenantService, log *logger.Logger) *LicensingHandler {
+	return &LicensingHandler{signer: signer, userRepo: userRepo, tenantService: tenantService, log: log}
 }
 
 type licensingTokenResponse struct {
@@ -74,7 +76,15 @@ func (h *LicensingHandler) IssueToken(c *gin.Context) {
 		isAdmin = strings.HasSuffix(strings.ToLower(u.Email), staffEmailDomain)
 	}
 
-	token, err := h.signer.Mint(tenantID, isAdmin, sessionExp)
+	// customer = the caller's org/tenant display name, carried into the token so
+	// Heimdall can stamp it on community licenses. For admin mints on another
+	// tenant, Heimdall uses a request-supplied customer instead.
+	customer := ""
+	if tr, err := h.tenantService.GetTenantByID(ctx, tenantID); err == nil && tr != nil {
+		customer = tr.Name
+	}
+
+	token, err := h.signer.Mint(tenantID, customer, isAdmin, sessionExp)
 	if err != nil {
 		c.Error(err)
 		return

--- a/internal/api/v1/licensing.go
+++ b/internal/api/v1/licensing.go
@@ -59,6 +59,16 @@ func (h *LicensingHandler) IssueToken(c *gin.Context) {
 		return
 	}
 
+	// Only a tenant super-admin may mint licenses. A licensing token is the
+	// browser's only path to Heimdall's mint endpoint, so gating it here gates
+	// minting for the whole tenant — non-admin members get 403 and no token.
+	if !types.IsSuperAdminUser(ctx) {
+		c.Error(ierr.NewError("only a tenant super-admin may mint licenses").
+			WithHint("You do not have permission to generate a license").
+			Mark(ierr.ErrPermissionDenied))
+		return
+	}
+
 	sessionExp, err := sessionExpiryFromRequest(c)
 	if err != nil {
 		c.Error(err)

--- a/internal/api/v1/licensing_test.go
+++ b/internal/api/v1/licensing_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/flexprice/flexprice/internal/config"
+	domainUser "github.com/flexprice/flexprice/internal/domain/user"
 	"github.com/flexprice/flexprice/internal/licensing"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
@@ -18,6 +19,21 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeUserRepo returns a fixed user email for is_admin domain checks.
+type fakeUserRepo struct{ email string }
+
+func (f fakeUserRepo) GetByID(_ context.Context, id string) (*domainUser.User, error) {
+	return &domainUser.User{ID: id, Email: f.email}, nil
+}
+func (fakeUserRepo) Create(context.Context, *domainUser.User) error               { return nil }
+func (fakeUserRepo) GetByEmail(context.Context, string) (*domainUser.User, error) { return nil, nil }
+func (fakeUserRepo) Update(context.Context, *domainUser.User) error               { return nil }
+func (fakeUserRepo) UpdateRoles(context.Context, string, []string) error          { return nil }
+func (fakeUserRepo) Delete(context.Context, string) error                         { return nil }
+func (fakeUserRepo) ListByFilter(context.Context, *types.UserFilter) ([]*domainUser.User, int64, error) {
+	return nil, 0, nil
+}
 
 func makeLicensingSeed(t *testing.T) string {
 	t.Helper()
@@ -27,6 +43,10 @@ func makeLicensingSeed(t *testing.T) string {
 }
 
 func setupLicensingHandler(t *testing.T, seed string) *LicensingHandler {
+	return setupLicensingHandlerWithEmail(t, seed, "user@acme.com")
+}
+
+func setupLicensingHandlerWithEmail(t *testing.T, seed, email string) *LicensingHandler {
 	t.Helper()
 	cfg := &config.Configuration{
 		Logging:   config.LoggingConfig{Level: types.LogLevelInfo},
@@ -38,7 +58,7 @@ func setupLicensingHandler(t *testing.T, seed string) *LicensingHandler {
 	signer, err := licensing.NewSigner(cfg)
 	require.NoError(t, err)
 
-	return NewLicensingHandler(signer, log)
+	return NewLicensingHandler(signer, fakeUserRepo{email: email}, log)
 }
 
 // sessionBearerToken builds a JWT carrying only an "exp" claim, mirroring what
@@ -68,18 +88,18 @@ func newLicensingRequest(t *testing.T, tenantID string, isAdmin bool, bearer str
 
 	ctx := req.Context()
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
-	roles := []string{}
-	if isAdmin {
-		roles = []string{types.RoleSuperAdmin.String()}
-	}
-	ctx = context.WithValue(ctx, types.CtxRoles, roles)
+	ctx = context.WithValue(ctx, types.CtxUserID, "user_test")
+	// isAdmin is now derived from the user's email domain (via userRepo), not
+	// from roles; kept in the signature for call-site clarity.
+	_ = isAdmin
 	c.Request = req.WithContext(ctx)
 	return w, c
 }
 
 func TestIssueToken_ClaimsMatchSessionAndTenant(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	h := setupLicensingHandler(t, makeLicensingSeed(t))
+	// staff email -> is_admin true
+	h := setupLicensingHandlerWithEmail(t, makeLicensingSeed(t), "someone@flexprice.io")
 
 	sessionExp := time.Now().Add(15 * time.Minute).Truncate(time.Second)
 	bearer := sessionBearerToken(t, sessionExp)

--- a/internal/api/v1/licensing_test.go
+++ b/internal/api/v1/licensing_test.go
@@ -146,7 +146,7 @@ func TestIssueToken_ClaimsMatchSessionAndTenant(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "flexprice-backend", claims.Issuer)
-	require.Equal(t, jwt.ClaimStrings{"heimdall-mint"}, claims.Audience)
+	require.Equal(t, jwt.ClaimStrings{"licensing-mint"}, claims.Audience)
 	require.Equal(t, "tenant_abc", claims.TenantID)
 	require.Equal(t, "us-east", claims.Region)
 	require.True(t, claims.IsAdmin)

--- a/internal/api/v1/licensing_test.go
+++ b/internal/api/v1/licensing_test.go
@@ -61,10 +61,22 @@ func setupLicensingHandler(t *testing.T, seed string) *LicensingHandler {
 }
 
 func setupLicensingHandlerWithEmail(t *testing.T, seed, email string) *LicensingHandler {
+	return setupLicensingHandlerFull(t, seed, email, false)
+}
+
+// setupLicensingHandlerFull is the full constructor; trustEmailDomain mirrors
+// cfg.Licensing.TrustEmailDomainForStaff so tests can exercise the is_admin
+// gate both opted in and (default) opted out.
+func setupLicensingHandlerFull(t *testing.T, seed, email string, trustEmailDomain bool) *LicensingHandler {
 	t.Helper()
 	cfg := &config.Configuration{
-		Logging:   config.LoggingConfig{Level: types.LogLevelInfo},
-		Licensing: config.LicensingConfig{SigningKeySeed: seed, Region: "us-east"},
+		Logging: config.LoggingConfig{Level: types.LogLevelInfo},
+		Auth:    config.AuthConfig{APIKey: config.APIKeyConfig{Header: "x-api-key"}},
+		Licensing: config.LicensingConfig{
+			SigningKeySeed:           seed,
+			Region:                   "us-east",
+			TrustEmailDomainForStaff: trustEmailDomain,
+		},
 	}
 	log, err := logger.NewLogger(cfg)
 	require.NoError(t, err)
@@ -72,7 +84,7 @@ func setupLicensingHandlerWithEmail(t *testing.T, seed, email string) *Licensing
 	signer, err := licensing.NewSigner(cfg)
 	require.NoError(t, err)
 
-	return NewLicensingHandler(signer, fakeUserRepo{email: email}, fakeTenantService{name: "Acme Corp"}, log)
+	return NewLicensingHandler(cfg, signer, fakeUserRepo{email: email}, fakeTenantService{name: "Acme Corp"}, log)
 }
 
 // sessionBearerToken builds a JWT carrying only an "exp" claim, mirroring what
@@ -115,8 +127,8 @@ func newLicensingRequest(t *testing.T, tenantID string, isAdmin bool, bearer str
 
 func TestIssueToken_ClaimsMatchSessionAndTenant(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	// staff email -> is_admin true
-	h := setupLicensingHandlerWithEmail(t, makeLicensingSeed(t), "someone@flexprice.io")
+	// staff email + TrustEmailDomainForStaff opted in -> is_admin true
+	h := setupLicensingHandlerFull(t, makeLicensingSeed(t), "someone@flexprice.io", true)
 
 	sessionExp := time.Now().Add(15 * time.Minute).Truncate(time.Second)
 	bearer := sessionBearerToken(t, sessionExp)
@@ -145,6 +157,30 @@ func TestIssueToken_ClaimsMatchSessionAndTenant(t *testing.T) {
 func TestIssueToken_NonStaffGetsIsAdminFalse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	h := setupLicensingHandler(t, makeLicensingSeed(t))
+
+	bearer := sessionBearerToken(t, time.Now().Add(time.Minute))
+	w, c := newLicensingRequest(t, "tenant_abc", false, bearer)
+
+	h.IssueToken(c)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body licensingTokenResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	claims := &licensing.TokenClaims{}
+	_, _, err := jwt.NewParser().ParseUnverified(body.Token, claims)
+	require.NoError(t, err)
+	require.False(t, claims.IsAdmin)
+}
+
+// TestIssueToken_StaffEmailWithoutTrustFlagGetsIsAdminFalse proves the
+// is_admin elevation stays off by default: a @flexprice.io email alone must
+// not grant staff powers unless the deployment explicitly opts in via
+// cfg.Licensing.TrustEmailDomainForStaff, since the user model carries no
+// IdP-verified-email signal and self-serve email is spoofable.
+func TestIssueToken_StaffEmailWithoutTrustFlagGetsIsAdminFalse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := setupLicensingHandlerFull(t, makeLicensingSeed(t), "someone@flexprice.io", false)
 
 	bearer := sessionBearerToken(t, time.Now().Add(time.Minute))
 	w, c := newLicensingRequest(t, "tenant_abc", false, bearer)
@@ -190,6 +226,31 @@ func TestIssueToken_NonSuperAdminRejected(t *testing.T) {
 	// the observable contract is a recorded permission error and no token body.
 	require.NotEmpty(t, c.Errors)
 	require.True(t, ierr.IsPermissionDenied(c.Errors.Last().Err))
+	require.Empty(t, w.Body.String())
+}
+
+// TestIssueToken_APIKeyCallerWithForgedExpRejected proves a caller that
+// authenticated via API key (config super-admin key or a DB-backed secret)
+// cannot mint a licensing token by attaching a crafted, unverified bearer JWT
+// with a far-future exp. AuthenticateMiddleware never verifies that bearer
+// for an API-key request, so trusting its "exp" would let the caller forge an
+// arbitrarily long-lived license.
+func TestIssueToken_APIKeyCallerWithForgedExpRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := setupLicensingHandler(t, makeLicensingSeed(t))
+
+	forgedExp := time.Now().Add(10 * 365 * 24 * time.Hour) // 10 years
+	bearer := sessionBearerToken(t, forgedExp)
+	w, c := newLicensingRequest(t, "tenant_abc", false, bearer)
+	// Mirror an API-key-authenticated request: the configured API-key header
+	// is present alongside the crafted Authorization bearer.
+	c.Request.Header.Set("x-api-key", "some-super-admin-config-key")
+
+	h.IssueToken(c)
+
+	require.NotEmpty(t, c.Errors)
+	require.True(t, ierr.IsPermissionDenied(c.Errors.Last().Err))
+	require.Empty(t, w.Body.String())
 	require.Empty(t, w.Body.String())
 }
 

--- a/internal/api/v1/licensing_test.go
+++ b/internal/api/v1/licensing_test.go
@@ -10,8 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flexprice/flexprice/internal/api/dto"
 	"github.com/flexprice/flexprice/internal/config"
 	domainUser "github.com/flexprice/flexprice/internal/domain/user"
+	eeservice "github.com/flexprice/flexprice/internal/ee/service"
 	"github.com/flexprice/flexprice/internal/licensing"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
@@ -19,6 +21,17 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeTenantService returns a fixed tenant name (embeds the interface so only
+// GetTenantByID needs an implementation).
+type fakeTenantService struct {
+	eeservice.TenantService
+	name string
+}
+
+func (f fakeTenantService) GetTenantByID(_ context.Context, id string) (*dto.TenantResponse, error) {
+	return &dto.TenantResponse{ID: id, Name: f.name}, nil
+}
 
 // fakeUserRepo returns a fixed user email for is_admin domain checks.
 type fakeUserRepo struct{ email string }
@@ -58,7 +71,7 @@ func setupLicensingHandlerWithEmail(t *testing.T, seed, email string) *Licensing
 	signer, err := licensing.NewSigner(cfg)
 	require.NoError(t, err)
 
-	return NewLicensingHandler(signer, fakeUserRepo{email: email}, log)
+	return NewLicensingHandler(signer, fakeUserRepo{email: email}, fakeTenantService{name: "Acme Corp"}, log)
 }
 
 // sessionBearerToken builds a JWT carrying only an "exp" claim, mirroring what

--- a/internal/api/v1/licensing_test.go
+++ b/internal/api/v1/licensing_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/flexprice/flexprice/internal/config"
 	domainUser "github.com/flexprice/flexprice/internal/domain/user"
 	eeservice "github.com/flexprice/flexprice/internal/ee/service"
+	ierr "github.com/flexprice/flexprice/internal/errors"
 	"github.com/flexprice/flexprice/internal/licensing"
 	"github.com/flexprice/flexprice/internal/logger"
 	"github.com/flexprice/flexprice/internal/types"
@@ -102,6 +103,9 @@ func newLicensingRequest(t *testing.T, tenantID string, isAdmin bool, bearer str
 	ctx := req.Context()
 	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
 	ctx = context.WithValue(ctx, types.CtxUserID, "user_test")
+	// Minting requires a tenant super-admin; the middleware would put roles in
+	// context, so mirror that here.
+	ctx = context.WithValue(ctx, types.CtxRoles, []string{types.RoleSuperAdmin.String()})
 	// isAdmin is now derived from the user's email domain (via userRepo), not
 	// from roles; kept in the signature for call-site clarity.
 	_ = isAdmin
@@ -168,6 +172,25 @@ func TestIssueToken_NoSessionRejected(t *testing.T) {
 	// this unit test), so the observable contract here is that the handler
 	// records a failure and never reaches the success response.
 	require.NotEmpty(t, c.Errors)
+}
+
+func TestIssueToken_NonSuperAdminRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := setupLicensingHandler(t, makeLicensingSeed(t))
+
+	bearer := sessionBearerToken(t, time.Now().Add(time.Minute))
+	w, c := newLicensingRequest(t, "tenant_abc", false, bearer)
+	// Strip the super-admin role the helper sets: a plain tenant member.
+	c.Request = c.Request.WithContext(
+		context.WithValue(c.Request.Context(), types.CtxRoles, []string{}))
+
+	h.IssueToken(c)
+
+	// c.Error defers HTTP status to ErrorHandler middleware (not wired here);
+	// the observable contract is a recorded permission error and no token body.
+	require.NotEmpty(t, c.Errors)
+	require.True(t, ierr.IsPermissionDenied(c.Errors.Last().Err))
+	require.Empty(t, w.Body.String())
 }
 
 func TestJWKS_ServesMatchingPublicKey(t *testing.T) {

--- a/internal/api/v1/licensing_test.go
+++ b/internal/api/v1/licensing_test.go
@@ -1,0 +1,172 @@
+package v1
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/flexprice/flexprice/internal/licensing"
+	"github.com/flexprice/flexprice/internal/logger"
+	"github.com/flexprice/flexprice/internal/types"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func makeLicensingSeed(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString(priv.Seed())
+}
+
+func setupLicensingHandler(t *testing.T, seed string) *LicensingHandler {
+	t.Helper()
+	cfg := &config.Configuration{
+		Logging:   config.LoggingConfig{Level: types.LogLevelInfo},
+		Licensing: config.LicensingConfig{SigningKeySeed: seed, Region: "us-east"},
+	}
+	log, err := logger.NewLogger(cfg)
+	require.NoError(t, err)
+
+	signer, err := licensing.NewSigner(cfg)
+	require.NoError(t, err)
+
+	return NewLicensingHandler(signer, log)
+}
+
+// sessionBearerToken builds a JWT carrying only an "exp" claim, mirroring what
+// AuthenticateMiddleware already validated before the handler runs — the
+// handler only re-reads "exp", so the signature/secret here is irrelevant.
+func sessionBearerToken(t *testing.T, exp time.Time) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"exp": exp.Unix(),
+	})
+	signed, err := tok.SignedString([]byte("irrelevant-session-secret"))
+	require.NoError(t, err)
+	return signed
+}
+
+// newLicensingRequest builds a recorder + gin context wired the way
+// AuthenticateMiddleware would leave it: tenant/roles in context, bearer
+// token on the request.
+func newLicensingRequest(t *testing.T, tenantID string, isAdmin bool, bearer string) (*httptest.ResponseRecorder, *gin.Context) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "/v1/licensing-token", nil)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, types.CtxTenantID, tenantID)
+	roles := []string{}
+	if isAdmin {
+		roles = []string{types.RoleSuperAdmin.String()}
+	}
+	ctx = context.WithValue(ctx, types.CtxRoles, roles)
+	c.Request = req.WithContext(ctx)
+	return w, c
+}
+
+func TestIssueToken_ClaimsMatchSessionAndTenant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := setupLicensingHandler(t, makeLicensingSeed(t))
+
+	sessionExp := time.Now().Add(15 * time.Minute).Truncate(time.Second)
+	bearer := sessionBearerToken(t, sessionExp)
+	w, c := newLicensingRequest(t, "tenant_abc", true, bearer)
+
+	h.IssueToken(c)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body licensingTokenResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.NotEmpty(t, body.Token)
+
+	claims := &licensing.TokenClaims{}
+	_, _, err := jwt.NewParser().ParseUnverified(body.Token, claims)
+	require.NoError(t, err)
+
+	require.Equal(t, "flexprice-backend", claims.Issuer)
+	require.Equal(t, jwt.ClaimStrings{"heimdall-mint"}, claims.Audience)
+	require.Equal(t, "tenant_abc", claims.TenantID)
+	require.Equal(t, "us-east", claims.Region)
+	require.True(t, claims.IsAdmin)
+	require.WithinDuration(t, sessionExp, claims.ExpiresAt.Time, time.Second)
+	require.LessOrEqual(t, claims.ExpiresAt.Time.Unix(), sessionExp.Unix())
+}
+
+func TestIssueToken_NonStaffGetsIsAdminFalse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := setupLicensingHandler(t, makeLicensingSeed(t))
+
+	bearer := sessionBearerToken(t, time.Now().Add(time.Minute))
+	w, c := newLicensingRequest(t, "tenant_abc", false, bearer)
+
+	h.IssueToken(c)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body licensingTokenResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+
+	claims := &licensing.TokenClaims{}
+	_, _, err := jwt.NewParser().ParseUnverified(body.Token, claims)
+	require.NoError(t, err)
+	require.False(t, claims.IsAdmin)
+}
+
+func TestIssueToken_NoSessionRejected(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := setupLicensingHandler(t, makeLicensingSeed(t))
+
+	_, c := newLicensingRequest(t, "tenant_abc", false, "")
+	h.IssueToken(c)
+
+	// c.Error defers the HTTP status to ErrorHandler middleware (not wired in
+	// this unit test), so the observable contract here is that the handler
+	// records a failure and never reaches the success response.
+	require.NotEmpty(t, c.Errors)
+}
+
+func TestJWKS_ServesMatchingPublicKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := setupLicensingHandler(t, makeLicensingSeed(t))
+
+	bearer := sessionBearerToken(t, time.Now().Add(time.Minute))
+	tokenW, tokenCtx := newLicensingRequest(t, "tenant_abc", true, bearer)
+	h.IssueToken(tokenCtx)
+	var tokenBody licensingTokenResponse
+	require.NoError(t, json.Unmarshal(tokenW.Body.Bytes(), &tokenBody))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/.well-known/licensing-jwks.json", nil)
+	h.JWKS(c)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NotEmpty(t, w.Header().Get("Cache-Control"))
+
+	var jwks struct {
+		Keys []licensing.JWK `json:"keys"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &jwks))
+	require.Len(t, jwks.Keys, 1)
+
+	xBytes, err := base64.RawURLEncoding.DecodeString(jwks.Keys[0].X)
+	require.NoError(t, err)
+	pubKey := ed25519.PublicKey(xBytes)
+
+	_, err = jwt.Parse(tokenBody.Token, func(tok *jwt.Token) (interface{}, error) {
+		return pubKey, nil
+	})
+	require.NoError(t, err)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1417,18 +1417,24 @@ type OAuthConfig struct {
 }
 
 // LicensingConfig holds the backend's Ed25519 signing material for minting
-// short-lived licensing tokens that Heimdall verifies via the published JWKS.
+// short-lived licensing tokens that the licensing service verifies via the published JWKS.
 //
 // ponytail: dev-only seed-from-env signer. Prod should load the private key
 // from KMS instead of a config value; swap SigningKeySeed for a KMS signer
 // when that lands, the mint/JWKS code shouldn't need to change.
 type LicensingConfig struct {
 	// SigningKeySeed is the base64-encoded 32-byte Ed25519 seed. Empty disables
-	// the licensing endpoints (dev/deployments that don't run Heimdall).
+	// the licensing endpoints (dev/deployments that don't run the licensing service).
 	SigningKeySeed string `mapstructure:"signing_key_seed" validate:"omitempty"`
-	// Region tags the signing key (kid + claim) so Heimdall can route a token
+	// Region tags the signing key (kid + claim) so the licensing service can route a token
 	// to the right regional public key when multiple backends exist.
 	Region string `mapstructure:"region" validate:"omitempty" default:"default"`
 	// Issuer is the "iss" claim on minted tokens.
 	Issuer string `mapstructure:"issuer" validate:"omitempty" default:"flexprice-backend"`
+	// TrustEmailDomainForStaff opts into granting is_admin (Flexprice staff)
+	// based on a @flexprice.io email suffix. Off by default: the user model
+	// carries no IdP-verified-email signal, so under the self-serve flexprice
+	// auth provider this suffix is user-controlled and spoofable. Only enable
+	// where the deployment's auth provider guarantees verified email.
+	TrustEmailDomainForStaff bool `mapstructure:"trust_email_domain_for_staff" validate:"omitempty" default:"false"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type Configuration struct {
 	Email                  EmailConfig                  `mapstructure:"email" validate:"required"`
 	RBAC                   RBACConfig                   `mapstructure:"rbac" validate:"omitempty"`
 	OAuth                  OAuthConfig                  `mapstructure:"oauth" validate:"required"`
+	Licensing              LicensingConfig              `mapstructure:"licensing" validate:"omitempty"`
 	WalletBalanceAlert     WalletBalanceAlertConfig     `mapstructure:"wallet_balance_alert" validate:"required"`
 	CustomerPortal         CustomerPortalConfig         `mapstructure:"customer_portal" validate:"required"`
 	Checkout               CheckoutConfig               `mapstructure:"checkout" validate:"omitempty"`
@@ -1413,4 +1414,21 @@ type OAuthConfig struct {
 	// Base redirect URI - provider-specific paths may be appended
 	// Example: "https://admin-dev.flexprice.io/tools/integrations/oauth/callback"
 	RedirectURI string `mapstructure:"redirect_uri" validate:"required,url"`
+}
+
+// LicensingConfig holds the backend's Ed25519 signing material for minting
+// short-lived licensing tokens that Heimdall verifies via the published JWKS.
+//
+// ponytail: dev-only seed-from-env signer. Prod should load the private key
+// from KMS instead of a config value; swap SigningKeySeed for a KMS signer
+// when that lands, the mint/JWKS code shouldn't need to change.
+type LicensingConfig struct {
+	// SigningKeySeed is the base64-encoded 32-byte Ed25519 seed. Empty disables
+	// the licensing endpoints (dev/deployments that don't run Heimdall).
+	SigningKeySeed string `mapstructure:"signing_key_seed" validate:"omitempty"`
+	// Region tags the signing key (kid + claim) so Heimdall can route a token
+	// to the right regional public key when multiple backends exist.
+	Region string `mapstructure:"region" validate:"omitempty" default:"default"`
+	// Issuer is the "iss" claim on minted tokens.
+	Issuer string `mapstructure:"issuer" validate:"omitempty" default:"flexprice-backend"`
 }

--- a/internal/licensing/signer.go
+++ b/internal/licensing/signer.go
@@ -1,5 +1,5 @@
-// Package licensing mints short-lived Heimdall licensing tokens and publishes
-// the backend's public key as a JWKS so Heimdall can verify them without ever
+// Package licensing mints short-lived licensing tokens and publishes
+// the backend's public key as a JWKS so the licensing service can verify them without ever
 // holding the flexprice user-auth secret.
 package licensing
 
@@ -14,10 +14,10 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
-// TokenClaims are the claims minted into a Heimdall licensing token.
+// TokenClaims are the claims minted into a licensing token.
 type TokenClaims struct {
 	TenantID string `json:"tenant_id"`
-	UserID   string `json:"user_id"` // the minting user (Heimdall stores the uuid, no PII)
+	UserID   string `json:"user_id"` // the minting user (the licensing service stores the uuid, no PII)
 	Region   string `json:"region"`
 	IsAdmin  bool   `json:"is_admin"`
 	Customer string `json:"customer,omitempty"` // tenant/org display name
@@ -65,7 +65,7 @@ func NewSigner(cfg *config.Configuration) (*Signer, error) {
 
 	return &Signer{
 		// kid rotates monthly so a key can be retired without invalidating
-		// tokens minted seconds ago — Heimdall's JWKS fetch just needs to see
+		// tokens minted seconds ago — the licensing service's JWKS fetch just needs to see
 		// the new kid before the old one drops off.
 		kid:        kidFor(region, time.Now()),
 		region:     region,
@@ -101,7 +101,7 @@ func (s *Signer) Mint(tenantID, userID, customer string, isAdmin bool, sessionEx
 		Customer: customer,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    s.issuer,
-			Audience:  jwt.ClaimStrings{"heimdall-mint"},
+			Audience:  jwt.ClaimStrings{"licensing-mint"},
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},
@@ -119,7 +119,7 @@ func (s *Signer) Mint(tenantID, userID, customer string, isAdmin bool, sessionEx
 	return signed, nil
 }
 
-// JWK is the OKP/Ed25519 JSON Web Key shape Heimdall expects.
+// JWK is the OKP/Ed25519 JSON Web Key shape the licensing service expects.
 type JWK struct {
 	Kty string `json:"kty"`
 	Crv string `json:"crv"`

--- a/internal/licensing/signer.go
+++ b/internal/licensing/signer.go
@@ -17,6 +17,7 @@ import (
 // TokenClaims are the claims minted into a Heimdall licensing token.
 type TokenClaims struct {
 	TenantID string `json:"tenant_id"`
+	UserID   string `json:"user_id"` // the minting user (Heimdall stores the uuid, no PII)
 	Region   string `json:"region"`
 	IsAdmin  bool   `json:"is_admin"`
 	Customer string `json:"customer,omitempty"` // tenant/org display name
@@ -81,7 +82,7 @@ func kidFor(region string, t time.Time) string {
 // Mint signs a licensing token for the given tenant/admin status, capping exp
 // at the caller-supplied session expiry (the token must never outlive the
 // user's own session).
-func (s *Signer) Mint(tenantID, customer string, isAdmin bool, sessionExp time.Time) (string, error) {
+func (s *Signer) Mint(tenantID, userID, customer string, isAdmin bool, sessionExp time.Time) (string, error) {
 	now := time.Now()
 	exp := sessionExp
 	// A session with no/expired exp mints nothing rather than defaulting to a
@@ -94,6 +95,7 @@ func (s *Signer) Mint(tenantID, customer string, isAdmin bool, sessionExp time.T
 
 	claims := TokenClaims{
 		TenantID: tenantID,
+		UserID:   userID,
 		Region:   s.region,
 		IsAdmin:  isAdmin,
 		Customer: customer,

--- a/internal/licensing/signer.go
+++ b/internal/licensing/signer.go
@@ -19,6 +19,7 @@ type TokenClaims struct {
 	TenantID string `json:"tenant_id"`
 	Region   string `json:"region"`
 	IsAdmin  bool   `json:"is_admin"`
+	Customer string `json:"customer,omitempty"` // tenant/org display name
 	jwt.RegisteredClaims
 }
 
@@ -80,7 +81,7 @@ func kidFor(region string, t time.Time) string {
 // Mint signs a licensing token for the given tenant/admin status, capping exp
 // at the caller-supplied session expiry (the token must never outlive the
 // user's own session).
-func (s *Signer) Mint(tenantID string, isAdmin bool, sessionExp time.Time) (string, error) {
+func (s *Signer) Mint(tenantID, customer string, isAdmin bool, sessionExp time.Time) (string, error) {
 	now := time.Now()
 	exp := sessionExp
 	// A session with no/expired exp mints nothing rather than defaulting to a
@@ -95,6 +96,7 @@ func (s *Signer) Mint(tenantID string, isAdmin bool, sessionExp time.Time) (stri
 		TenantID: tenantID,
 		Region:   s.region,
 		IsAdmin:  isAdmin,
+		Customer: customer,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    s.issuer,
 			Audience:  jwt.ClaimStrings{"heimdall-mint"},

--- a/internal/licensing/signer.go
+++ b/internal/licensing/signer.go
@@ -1,0 +1,143 @@
+// Package licensing mints short-lived Heimdall licensing tokens and publishes
+// the backend's public key as a JWKS so Heimdall can verify them without ever
+// holding the flexprice user-auth secret.
+package licensing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	ierr "github.com/flexprice/flexprice/internal/errors"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// TokenClaims are the claims minted into a Heimdall licensing token.
+type TokenClaims struct {
+	TenantID string `json:"tenant_id"`
+	Region   string `json:"region"`
+	IsAdmin  bool   `json:"is_admin"`
+	jwt.RegisteredClaims
+}
+
+// Signer mints EdDSA licensing tokens and exposes the matching JWKS.
+type Signer struct {
+	kid        string
+	region     string
+	issuer     string
+	privateKey ed25519.PrivateKey
+	publicKey  ed25519.PublicKey
+}
+
+// NewSigner builds a Signer from config. Returns (nil, nil) when no signing
+// key is configured, so callers can treat licensing as an optional feature.
+func NewSigner(cfg *config.Configuration) (*Signer, error) {
+	seedB64 := cfg.Licensing.SigningKeySeed
+	if seedB64 == "" {
+		return nil, nil
+	}
+
+	seed, err := base64.StdEncoding.DecodeString(seedB64)
+	if err != nil {
+		return nil, ierr.WithError(err).
+			WithHint("Invalid licensing signing key seed").
+			Mark(ierr.ErrSystem)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, ierr.NewErrorf("licensing signing key seed must be %d bytes, got %d", ed25519.SeedSize, len(seed)).
+			WithHint("Invalid licensing signing key seed").
+			Mark(ierr.ErrSystem)
+	}
+
+	privateKey := ed25519.NewKeyFromSeed(seed)
+	region := cfg.Licensing.Region
+	if region == "" {
+		region = "default"
+	}
+	issuer := cfg.Licensing.Issuer
+	if issuer == "" {
+		issuer = "flexprice-backend"
+	}
+
+	return &Signer{
+		// kid rotates monthly so a key can be retired without invalidating
+		// tokens minted seconds ago — Heimdall's JWKS fetch just needs to see
+		// the new kid before the old one drops off.
+		kid:        kidFor(region, time.Now()),
+		region:     region,
+		issuer:     issuer,
+		privateKey: privateKey,
+		publicKey:  privateKey.Public().(ed25519.PublicKey),
+	}, nil
+}
+
+func kidFor(region string, t time.Time) string {
+	return fmt.Sprintf("backend-%s-%s", region, t.UTC().Format("2006-01"))
+}
+
+// Mint signs a licensing token for the given tenant/admin status, capping exp
+// at the caller-supplied session expiry (the token must never outlive the
+// user's own session).
+func (s *Signer) Mint(tenantID string, isAdmin bool, sessionExp time.Time) (string, error) {
+	now := time.Now()
+	exp := sessionExp
+	// A session with no/expired exp mints nothing rather than defaulting to a
+	// token that outlives an already-invalid session.
+	if exp.IsZero() || !exp.After(now) {
+		return "", ierr.NewError("session has no valid expiry to bound the licensing token").
+			WithHint("Your session has expired, please log in again").
+			Mark(ierr.ErrPermissionDenied)
+	}
+
+	claims := TokenClaims{
+		TenantID: tenantID,
+		Region:   s.region,
+		IsAdmin:  isAdmin,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    s.issuer,
+			Audience:  jwt.ClaimStrings{"heimdall-mint"},
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(exp),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	token.Header["kid"] = s.kid
+
+	signed, err := token.SignedString(s.privateKey)
+	if err != nil {
+		return "", ierr.WithError(err).
+			WithHint("Failed to sign licensing token").
+			Mark(ierr.ErrSystem)
+	}
+	return signed, nil
+}
+
+// JWK is the OKP/Ed25519 JSON Web Key shape Heimdall expects.
+type JWK struct {
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	X   string `json:"x"`
+	Kid string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+}
+
+// JWKS renders the backend's current public key set. Only one key is active
+// at a time today (kid rotates monthly); a fixed-size slice keeps the door
+// open for publishing the previous month's key during rotation overlap
+// without changing the response shape.
+func (s *Signer) JWKS() []JWK {
+	return []JWK{
+		{
+			Kty: "OKP",
+			Crv: "Ed25519",
+			X:   base64.RawURLEncoding.EncodeToString(s.publicKey),
+			Kid: s.kid,
+			Use: "sig",
+			Alg: "EdDSA",
+		},
+	}
+}

--- a/internal/licensing/signer_test.go
+++ b/internal/licensing/signer_test.go
@@ -48,7 +48,7 @@ func TestMint_ClaimsAndExpCapping(t *testing.T) {
 
 	claims := parsed.Claims.(*TokenClaims)
 	require.Equal(t, "flexprice-backend", claims.Issuer)
-	require.Equal(t, jwt.ClaimStrings{"heimdall-mint"}, claims.Audience)
+	require.Equal(t, jwt.ClaimStrings{"licensing-mint"}, claims.Audience)
 	require.Equal(t, "tenant_123", claims.TenantID)
 	require.Equal(t, "us-east", claims.Region)
 	require.True(t, claims.IsAdmin)

--- a/internal/licensing/signer_test.go
+++ b/internal/licensing/signer_test.go
@@ -1,0 +1,106 @@
+package licensing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/flexprice/flexprice/internal/config"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func testSeed(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	return base64.StdEncoding.EncodeToString(priv.Seed())
+}
+
+func TestNewSigner_NoSeedDisablesLicensing(t *testing.T) {
+	s, err := NewSigner(&config.Configuration{})
+	require.NoError(t, err)
+	require.Nil(t, s)
+}
+
+func TestMint_ClaimsAndExpCapping(t *testing.T) {
+	cfg := &config.Configuration{Licensing: config.LicensingConfig{
+		SigningKeySeed: testSeed(t),
+		Region:         "us-east",
+		Issuer:         "flexprice-backend",
+	}}
+	s, err := NewSigner(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+
+	sessionExp := time.Now().Add(10 * time.Minute)
+	tokenStr, err := s.Mint("tenant_123", true, sessionExp)
+	require.NoError(t, err)
+
+	parsed, err := jwt.ParseWithClaims(tokenStr, &TokenClaims{}, func(t *jwt.Token) (interface{}, error) {
+		return s.publicKey, nil
+	})
+	require.NoError(t, err)
+	require.True(t, parsed.Valid)
+	require.Equal(t, "EdDSA", parsed.Method.Alg())
+	require.Equal(t, s.kid, parsed.Header["kid"])
+
+	claims := parsed.Claims.(*TokenClaims)
+	require.Equal(t, "flexprice-backend", claims.Issuer)
+	require.Equal(t, jwt.ClaimStrings{"heimdall-mint"}, claims.Audience)
+	require.Equal(t, "tenant_123", claims.TenantID)
+	require.Equal(t, "us-east", claims.Region)
+	require.True(t, claims.IsAdmin)
+	require.WithinDuration(t, sessionExp, claims.ExpiresAt.Time, time.Second)
+	require.LessOrEqual(t, claims.ExpiresAt.Time, sessionExp.Add(time.Second))
+}
+
+func TestMint_NonStaffGetsIsAdminFalse(t *testing.T) {
+	cfg := &config.Configuration{Licensing: config.LicensingConfig{SigningKeySeed: testSeed(t)}}
+	s, err := NewSigner(cfg)
+	require.NoError(t, err)
+
+	tokenStr, err := s.Mint("tenant_x", false, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+
+	parsed, err := jwt.ParseWithClaims(tokenStr, &TokenClaims{}, func(t *jwt.Token) (interface{}, error) {
+		return s.publicKey, nil
+	})
+	require.NoError(t, err)
+	claims := parsed.Claims.(*TokenClaims)
+	require.False(t, claims.IsAdmin)
+}
+
+func TestMint_RejectsExpiredSession(t *testing.T) {
+	cfg := &config.Configuration{Licensing: config.LicensingConfig{SigningKeySeed: testSeed(t)}}
+	s, err := NewSigner(cfg)
+	require.NoError(t, err)
+
+	_, err = s.Mint("tenant_x", false, time.Now().Add(-time.Minute))
+	require.Error(t, err)
+}
+
+func TestJWKS_MatchesSigningKey(t *testing.T) {
+	cfg := &config.Configuration{Licensing: config.LicensingConfig{SigningKeySeed: testSeed(t)}}
+	s, err := NewSigner(cfg)
+	require.NoError(t, err)
+
+	keys := s.JWKS()
+	require.Len(t, keys, 1)
+	require.Equal(t, "OKP", keys[0].Kty)
+	require.Equal(t, "Ed25519", keys[0].Crv)
+	require.Equal(t, s.kid, keys[0].Kid)
+
+	decoded, err := base64.RawURLEncoding.DecodeString(keys[0].X)
+	require.NoError(t, err)
+	require.Equal(t, ed25519.PublicKey(decoded), s.publicKey)
+
+	// The published key must actually verify tokens minted by this signer.
+	tokenStr, err := s.Mint("tenant_1", false, time.Now().Add(time.Minute))
+	require.NoError(t, err)
+	_, err = jwt.ParseWithClaims(tokenStr, &TokenClaims{}, func(t *jwt.Token) (interface{}, error) {
+		return ed25519.PublicKey(decoded), nil
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
Backend side of Heimdall licensing. Mints a short-lived EdDSA licensing token (capped at the caller's session expiry) for the browser to present to Heimdall; publishes the backend's JWKS for Heimdall to verify it.

- `GET /v1/licensing-token` (private): mints token with tenant_id, user_id, region, is_admin, customer.
- `GET /.well-known/licensing-jwks.json` (public): backend Ed25519 JWKS.

## Access control
- Minting gated on **tenant super-admin** role — non-admin members get 403, no token (a token is the browser's only path to Heimdall mint).
- `is_admin` claim = @flexprice.io staff email (IdP-verified); gates enterprise/foreign mint downstream in Heimdall.
- `customer` = tenant org name; `user_id` sent for everyone (Heimdall keeps audit trail, blanks staff uuid in FE responses).

## Tests
`internal/api/v1` licensing suite green: claims match session/tenant, non-staff is_admin=false, no-session rejected, **non-super-admin rejected**, JWKS matches signing key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added licensing token issuance for authorized tenant super-admins.
  * Added public JWKS discovery for token verification.
  * Added configurable licensing with Ed25519 signing keys, issuer, region, and short-lived session-bound tokens.
  * Tokens include tenant, customer, issuer, and administrator status information.
* **Tests**
  * Added coverage for token claims, permissions, expiration handling, signing keys, and JWKS validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->