### PR TITLE
fix(tax): add support for handling default tax behavior

### DIFF
--- a/internal/api/dto/taxassociation.go
+++ b/internal/api/dto/taxassociation.go
@@ -26,10 +26,10 @@ type CreateTaxAssociationRequest struct {
 	// EndDate sets when this association expires. Must be after StartDate when both are provided.
 	EndDate *time.Time `json:"end_date,omitempty"`
 	// TaxBehavior is inclusive or exclusive. Settable at any level. If left empty on a
-	// subscription-level association, it resolves from the currency default at creation
-	// time (internal/types.DefaultTaxBehaviorForCurrency) — tenant/customer-level templates
-	// only need this set explicitly if the tenant wants one; otherwise it stays null and is
-	// resolved when the template is copied down to a subscription.
+	// subscription-level association, it defaults to exclusive at creation time —
+	// tenant/customer-level templates only need this set explicitly if the tenant wants
+	// one; otherwise it stays null and is resolved when the template is copied down to
+	// a subscription.
 	TaxBehavior *types.TaxBehavior `json:"tax_behavior,omitempty"`
 }
 

--- a/internal/domain/taxassociation/model.go
+++ b/internal/domain/taxassociation/model.go
@@ -31,8 +31,8 @@ type TaxAssociation struct {
 	// EndDate is the optional date until which this association is active
 	EndDate *time.Time `json:"end_date,omitempty"`
 
-	// TaxBehavior is inclusive or exclusive; null on tenant/customer-level rows,
-	// resolved when copied down to a subscription
+	// TaxBehavior is inclusive or exclusive. Absent means exclusive; inclusive is only
+	// ever set explicitly.
 	TaxBehavior *types.TaxBehavior `json:"tax_behavior,omitempty"`
 
 	// EnvironmentID is the ID of the environment this tax rate config belongs to
@@ -42,6 +42,12 @@ type TaxAssociation struct {
 }
 
 func FromEnt(ent *ent.TaxAssociation) *TaxAssociation {
+	// Rows stored without a behavior read back as exclusive.
+	taxBehavior := ent.TaxBehavior
+	if taxBehavior == nil || *taxBehavior == "" {
+		taxBehavior = lo.ToPtr(types.TaxBehaviorExclusive)
+	}
+
 	return &TaxAssociation{
 		ID:            ent.ID,
 		TaxRateID:     ent.TaxRateID,
@@ -54,7 +60,7 @@ func FromEnt(ent *ent.TaxAssociation) *TaxAssociation {
 		Metadata:      ent.Metadata,
 		StartDate:     lo.FromPtrOr(ent.StartDate, time.Now().UTC()),
 		EndDate:       ent.EndDate,
-		TaxBehavior:   ent.TaxBehavior,
+		TaxBehavior:   taxBehavior,
 		BaseModel: types.BaseModel{
 			TenantID:  ent.TenantID,
 			Status:    types.Status(ent.Status),

--- a/internal/ee/service/subscription.go
+++ b/internal/ee/service/subscription.go
@@ -5631,13 +5631,17 @@ func (s *subscriptionService) cancelAddonsForSubscription(ctx context.Context, s
 		"entity_ids_filter", addonIDList,
 		"line_items_found", len(allLineItems))
 
-	deleteReq := dto.DeleteSubscriptionLineItemRequest{EffectiveFrom: &effectiveDate}
 	terminated := 0
 	for _, lineItem := range allLineItems {
 		if !lineItem.EndDate.IsZero() {
 			continue
 		}
 
+		termFrom := effectiveDate
+		if lineItem.StartDate.After(effectiveDate) {
+			termFrom = lineItem.StartDate
+		}
+		deleteReq := dto.DeleteSubscriptionLineItemRequest{EffectiveFrom: &termFrom}
 		if _, err := s.deleteSubscriptionLineItem(ctx, lineItem.ID, deleteReq); err != nil {
 			logger.Error(ctx, "failed to terminate addon line item",
 				"line_item_id", lineItem.ID,

--- a/internal/ee/service/subscription_test.go
+++ b/internal/ee/service/subscription_test.go
@@ -3218,6 +3218,106 @@ func (s *SubscriptionServiceSuite) TestCancelSubscription() {
 		}
 	})
 
+	s.Run("TestCancelSubscriptionWithFutureStartAddon", func() {
+		ctx := s.GetContext()
+		subService := s.service.(*subscriptionService)
+
+		subWithAddon := &subscription.Subscription{
+			ID:                 "sub_cancel_future_start_addon",
+			CustomerID:         s.testData.customer.ID,
+			PlanID:             s.testData.plan.ID,
+			SubscriptionStatus: types.SubscriptionStatusActive,
+			StartDate:          s.testData.now.Add(-30 * 24 * time.Hour),
+			CurrentPeriodStart: s.testData.now.Add(-24 * time.Hour),
+			CurrentPeriodEnd:   s.testData.now.Add(6 * 24 * time.Hour),
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			Currency:           "usd",
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+			LineItems:          []*subscription.SubscriptionLineItem{},
+		}
+		s.NoError(s.GetStores().SubscriptionRepo.CreateWithLineItems(ctx, subWithAddon, subWithAddon.LineItems))
+
+		addonID := "addon_cancel_future_start"
+		a := &addon.Addon{
+			ID:        addonID,
+			LookupKey: addonID,
+			Name:      "Future-start addon",
+			BaseModel: types.GetDefaultBaseModel(ctx),
+		}
+		s.NoError(subService.AddonRepo.Create(ctx, a))
+		s.NoError(s.GetStores().PriceRepo.Create(ctx, &price.Price{
+			ID:                 "price_addon_cancel_future_start",
+			Amount:             decimal.Zero,
+			Currency:           "usd",
+			EntityType:         types.PRICE_ENTITY_TYPE_ADDON,
+			EntityID:           addonID,
+			Type:               types.PRICE_TYPE_USAGE,
+			BillingPeriod:      types.BILLING_PERIOD_MONTHLY,
+			BillingPeriodCount: 1,
+			BillingModel:       types.BILLING_MODEL_FLAT_FEE,
+			InvoiceCadence:     types.InvoiceCadenceArrear,
+			MeterID:            s.testData.meters.apiCalls.ID,
+			BaseModel:          types.GetDefaultBaseModel(ctx),
+		}))
+
+		attachAt := time.Now().UTC()
+		_, err := s.service.AddAddonToSubscription(ctx, &dto.AddAddonRequest{
+			SubscriptionID: subWithAddon.ID,
+			AddAddonToSubscriptionRequest: dto.AddAddonToSubscriptionRequest{
+				AddonID:   addonID,
+				StartDate: &attachAt,
+			},
+		})
+		s.NoError(err)
+
+		// Association is already active; line item start is still in the future
+		// (catalog price start / trial end).
+		liFilterPre := types.NewNoLimitSubscriptionLineItemFilter()
+		liFilterPre.SubscriptionIDs = []string{subWithAddon.ID}
+		liFilterPre.EntityIDs = []string{addonID}
+		liFilterPre.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+		preItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilterPre)
+		s.NoError(err)
+		s.NotEmpty(preItems)
+		futureStart := attachAt.Add(7 * 24 * time.Hour)
+		for _, li := range preItems {
+			li.StartDate = futureStart
+			s.NoError(s.GetStores().SubscriptionLineItemRepo.Update(ctx, li))
+		}
+
+		resp, err := s.service.CancelSubscription(ctx, subWithAddon.ID, &dto.CancelSubscriptionRequest{
+			CancellationType:  types.CancellationTypeImmediate,
+			ProrationBehavior: types.ProrationBehaviorNone,
+			Reason:            "test_cancel_future_start_addon",
+		})
+		s.Require().NoError(err)
+		s.Equal(types.SubscriptionStatusCancelled, resp.Status)
+
+		aaFilter := types.NewNoLimitAddonAssociationFilter()
+		aaFilter.EntityIDs = []string{subWithAddon.ID}
+		aaFilter.EntityType = lo.ToPtr(types.AddonAssociationEntityTypeSubscription)
+		associations, err := s.GetStores().AddonAssociationRepo.List(ctx, aaFilter)
+		s.NoError(err)
+		s.NotEmpty(associations)
+		for _, aa := range associations {
+			s.Equal(types.AddonStatusCancelled, aa.AddonStatus)
+			s.NotNil(aa.EndDate)
+		}
+
+		liFilter := types.NewNoLimitSubscriptionLineItemFilter()
+		liFilter.SubscriptionIDs = []string{subWithAddon.ID}
+		liFilter.EntityIDs = []string{addonID}
+		liFilter.EntityType = lo.ToPtr(types.SubscriptionLineItemEntityTypeAddon)
+		lineItems, err := s.GetStores().SubscriptionLineItemRepo.List(ctx, liFilter)
+		s.NoError(err)
+		s.NotEmpty(lineItems)
+		for _, li := range lineItems {
+			s.False(li.EndDate.IsZero(), "unstarted addon line item must still be closed")
+			s.False(li.EndDate.Before(li.StartDate), "end_date must not precede start_date")
+		}
+	})
+
 	s.Run("TestCancelAtPeriodEnd", func() {
 		// Create an active subscription for period end cancel test
 		periodEndSub := &subscription.Subscription{

--- a/internal/ee/service/tax.go
+++ b/internal/ee/service/tax.go
@@ -988,7 +988,7 @@ func (s *taxService) PrepareTaxRatesForInvoice(ctx context.Context, req dto.Crea
 			if override.TaxBehavior != nil {
 				behaviorByCode[override.TaxRateCode] = *override.TaxBehavior
 			} else {
-				behaviorByCode[override.TaxRateCode] = types.DefaultTaxBehaviorForCurrency(override.Currency)
+				behaviorByCode[override.TaxRateCode] = types.TaxBehaviorExclusive
 			}
 		}
 
@@ -1011,10 +1011,10 @@ func (s *taxService) PrepareTaxRatesForInvoice(ctx context.Context, req dto.Crea
 	}
 
 	if len(req.TaxRates) > 0 {
-		// Raw rate IDs carry no association and no behavior, so only the invoice currency is
-		// left to resolve against. Known gap: the tenant/customer hierarchy is not consulted
-		// here — pass tax_rate_overrides instead, which take an explicit behavior.
-		behavior := types.DefaultTaxBehaviorForCurrency(req.Currency)
+		// Raw rate IDs carry no association and no explicit behavior, so they default to
+		// exclusive. Known gap: the tenant/customer hierarchy is not consulted here — pass
+		// tax_rate_overrides instead, which take an explicit behavior.
+		behavior := types.TaxBehaviorExclusive
 		resolved := make([]*dto.TaxRateWithBehavior, 0, len(req.TaxRates))
 		for _, taxRateID := range req.TaxRates {
 			taxRate, err := s.GetTaxRate(ctx, taxRateID)
@@ -1060,9 +1060,9 @@ func (s *taxService) PrepareTaxRatesForInvoice(ctx context.Context, req dto.Crea
 			behavior := lo.FromPtr(association.TaxBehavior)
 			if behavior == "" {
 				// Creation always stamps one, so a null here should not happen. Fall back to
-				// the same currency default every other unstamped resolution uses.
-				behavior = types.DefaultTaxBehaviorForCurrency(req.Currency)
-				s.Logger.Error(ctx, "subscription tax association missing tax_behavior, defaulting from currency",
+				// the same default every other unstamped resolution uses.
+				behavior = types.TaxBehaviorExclusive
+				s.Logger.Error(ctx, "subscription tax association missing tax_behavior, defaulting to exclusive",
 					"error", "tax_behavior is null on a subscription-level association",
 					"tax_association_id", association.ID,
 					"tax_rate_id", association.TaxRateID,
@@ -1328,15 +1328,15 @@ func (s *taxService) buildRateLines(ctx context.Context, inv *invoice.Invoice, t
 func (s *taxService) resolveEffectiveTaxBehavior(ctx context.Context, req *dto.CreateTaxAssociationRequest, taxRate *taxrate.TaxRate, sub *subscription.Subscription) (*types.TaxBehavior, error) {
 	behavior := req.TaxBehavior
 
-	// sub is nil for tenant/customer-level associations: they span several currencies, so
-	// there is no single default to resolve from. They keep whatever the request gave —
-	// including nothing — and are resolved when copied down to a subscription.
+	// sub is nil for tenant/customer-level associations. They keep whatever the request gave
+	// including nothing, and are resolved to the same default when copied down
+	// to a subscription.
 	if sub != nil {
 		resolvedBehavior := lo.FromPtr(req.TaxBehavior)
 		source := types.TaxBehaviorSourceExplicit
 		if req.TaxBehavior == nil {
-			resolvedBehavior = types.DefaultTaxBehaviorForCurrency(sub.Currency)
-			source = types.TaxBehaviorSourceCurrencyDefault
+			resolvedBehavior = types.TaxBehaviorExclusive
+			source = types.TaxBehaviorSourceDefault
 		}
 
 		behavior = &resolvedBehavior

--- a/internal/ee/service/tax_preview_test.go
+++ b/internal/ee/service/tax_preview_test.go
@@ -1122,18 +1122,15 @@ func (s *TaxCalculationSuite) TestPrepareTaxRates_OverridesWinOverSubscriptionAs
 	s.Equal(types.TaxBehaviorInclusive, resolved.GetRates()[0].TaxBehavior)
 }
 
-// an override with no explicit behavior falls back to the currency default, resolved
-// against the override's own currency.
-func (s *TaxCalculationSuite) TestPrepareTaxRates_OverrideWithoutBehaviorUsesCurrencyDefault() {
+// an override with no explicit behavior defaults to exclusive, regardless of currency.
+func (s *TaxCalculationSuite) TestPrepareTaxRates_OverrideWithoutBehaviorDefaultsToExclusive() {
 	tests := []struct {
 		name     string
 		currency string
 		want     types.TaxBehavior
 	}{
-		{name: "USD is in the exclusive list", currency: "usd", want: types.TaxBehaviorExclusive},
-		{name: "CAD is in the exclusive list", currency: "cad", want: types.TaxBehaviorExclusive},
-		{name: "INR is not, so it defaults inclusive", currency: "inr", want: types.TaxBehaviorInclusive},
-		{name: "EUR is not, so it defaults inclusive", currency: "eur", want: types.TaxBehaviorInclusive},
+		{name: "USD defaults exclusive", currency: "usd", want: types.TaxBehaviorExclusive},
+		{name: "INR defaults exclusive too", currency: "inr", want: types.TaxBehaviorExclusive},
 	}
 
 	for _, tt := range tests {
@@ -1233,16 +1230,16 @@ func (s *TaxCalculationSuite) TestPrepareTaxRates_SubscriptionAssociationsKeepTh
 
 // a subscription-level row with a null tax_behavior should not exist (creation
 // always stamps one). If one is found anyway it is logged as an anomaly and falls back to the
-// same currency default every other unstamped resolution uses, rather than a value special to
+// same default every other unstamped resolution uses, rather than a value special to
 // this branch.
-func (s *TaxCalculationSuite) TestPrepareTaxRates_AssociationWithNullBehaviorFallsBackToCurrencyDefault() {
+func (s *TaxCalculationSuite) TestPrepareTaxRates_AssociationWithNullBehaviorFallsBackToExclusive() {
 	tests := []struct {
 		name     string
 		currency string
 		want     types.TaxBehavior
 	}{
 		{name: "USD falls back to exclusive", currency: "usd", want: types.TaxBehaviorExclusive},
-		{name: "INR falls back to inclusive", currency: "inr", want: types.TaxBehaviorInclusive},
+		{name: "INR falls back to exclusive too", currency: "inr", want: types.TaxBehaviorExclusive},
 	}
 
 	for _, tt := range tests {
@@ -1367,17 +1364,16 @@ func (s *TaxCalculationSuite) TestInvoiceTaxRates_NilReceiverIsSafe() {
 // / / CreateTaxAssociation
 // =============================================================================
 
-// a subscription-level association with no explicit behavior is stamped from the
-// subscription's currency, at creation, once.
-func (s *TaxCalculationSuite) TestCreateTaxAssociation_SubscriptionBehaviorDefaultsFromCurrency() {
+// a subscription-level association with no explicit behavior is stamped exclusive at
+// creation, once, regardless of currency.
+func (s *TaxCalculationSuite) TestCreateTaxAssociation_SubscriptionBehaviorDefaultsToExclusive() {
 	tests := []struct {
 		name     string
 		currency string
 		want     types.TaxBehavior
 	}{
-		{name: "USD is in the exclusive list", currency: "usd", want: types.TaxBehaviorExclusive},
-		{name: "CAD is in the exclusive list", currency: "cad", want: types.TaxBehaviorExclusive},
-		{name: "INR is not, so it defaults inclusive", currency: "inr", want: types.TaxBehaviorInclusive},
+		{name: "USD defaults exclusive", currency: "usd", want: types.TaxBehaviorExclusive},
+		{name: "INR defaults exclusive too", currency: "inr", want: types.TaxBehaviorExclusive},
 	}
 
 	for _, tt := range tests {
@@ -1401,16 +1397,16 @@ func (s *TaxCalculationSuite) TestCreateTaxAssociation_SubscriptionBehaviorDefau
 	}
 }
 
-// An explicit behavior on the request wins over the currency default, in both directions —
-// including the case where it contradicts what the currency would have chosen.
+// An explicit behavior on the request wins over the default, in both directions —
+// including the case where it contradicts what the default would have chosen.
 func (s *TaxCalculationSuite) TestCreateTaxAssociation_ExplicitBehaviorOverridesCurrencyDefault() {
 	tests := []struct {
 		name     string
 		currency string
 		explicit types.TaxBehavior
 	}{
-		{name: "inclusive on USD, against the currency default", currency: "usd", explicit: types.TaxBehaviorInclusive},
-		{name: "exclusive on INR, against the currency default", currency: "inr", explicit: types.TaxBehaviorExclusive},
+		{name: "inclusive on USD, against the default", currency: "usd", explicit: types.TaxBehaviorInclusive},
+		{name: "exclusive on INR, against the default", currency: "inr", explicit: types.TaxBehaviorExclusive},
 	}
 
 	for _, tt := range tests {
@@ -1495,8 +1491,8 @@ func (s *TaxCalculationSuite) TestCreateTaxAssociation_ExemptCustomerSubscriptio
 	}{
 		{name: "explicit inclusive", currency: "usd", behavior: lo.ToPtr(types.TaxBehaviorInclusive)},
 		{name: "explicit exclusive", currency: "usd", behavior: lo.ToPtr(types.TaxBehaviorExclusive)},
-		{name: "currency default resolving to exclusive", currency: "usd"},
-		{name: "currency default resolving to inclusive", currency: "inr"},
+		{name: "no explicit behavior, USD", currency: "usd"},
+		{name: "no explicit behavior, INR", currency: "inr"},
 	}
 
 	for _, tt := range tests {
@@ -1546,8 +1542,7 @@ func (s *TaxCalculationSuite) TestCreateTaxAssociation_ExemptCustomerLevelTempla
 
 // an inclusive rate above 100% would mean the tax exceeds the tax-free price it is
 // derived from. The extraction still computes, so this is rejected as a configuration error
-// rather than because the math fails. Checked against the behavior that will actually be
-// stored, so a rate that resolves to inclusive from the currency default is caught too.
+// rather than because the math fails.
 func (s *TaxCalculationSuite) TestCreateTaxAssociation_InclusiveRateAboveHundredPercentIsRejected() {
 	tests := []struct {
 		name       string
@@ -1560,11 +1555,6 @@ func (s *TaxCalculationSuite) TestCreateTaxAssociation_InclusiveRateAboveHundred
 		{
 			name: "explicitly inclusive at 150%", currency: "usd",
 			behavior: lo.ToPtr(types.TaxBehaviorInclusive), percentage: 150, wantErr: true,
-		},
-		{
-			name: "inclusive via the currency default at 150%", currency: "inr",
-			percentage: 150, wantErr: true,
-			why: "INR resolves to inclusive with no explicit behavior — checking before the stamp would miss this",
 		},
 		{
 			name: "explicitly exclusive at 150%", currency: "usd",
@@ -1849,7 +1839,7 @@ func (s *TaxCalculationSuite) TestLinkTaxRatesToEntity_StampsEachOverride() {
 		EntityID:   sub.ID,
 		TaxRateOverrides: []*dto.TaxRateOverride{
 			{TaxRateCode: first.Code, Currency: "inr", AutoApply: true},
-			{TaxRateCode: second.Code, Currency: "inr", AutoApply: true, TaxBehavior: lo.ToPtr(types.TaxBehaviorExclusive)},
+			{TaxRateCode: second.Code, Currency: "inr", AutoApply: true, TaxBehavior: lo.ToPtr(types.TaxBehaviorInclusive)},
 		},
 	})
 	s.Require().NoError(err)
@@ -1866,8 +1856,8 @@ func (s *TaxCalculationSuite) TestLinkTaxRatesToEntity_StampsEachOverride() {
 	for _, r := range resolved.GetRates() {
 		behaviorByID[r.ID] = r.TaxBehavior
 	}
-	s.Equal(types.TaxBehaviorInclusive, behaviorByID[first.ID], "no explicit behavior on an INR subscription defaults inclusive")
-	s.Equal(types.TaxBehaviorExclusive, behaviorByID[second.ID], "the explicit behavior is kept")
+	s.Equal(types.TaxBehaviorExclusive, behaviorByID[first.ID], "no explicit behavior defaults exclusive")
+	s.Equal(types.TaxBehaviorInclusive, behaviorByID[second.ID], "the explicit behavior is kept")
 }
 
 // through the batch path: linking to an exempt customer's subscription is skipped,

--- a/internal/integration/zoho/invoice.go
+++ b/internal/integration/zoho/invoice.go
@@ -509,16 +509,21 @@ func formatPeriodDescription(fallback string, start, end *time.Time) string {
 	if start == nil || end == nil {
 		return fallback
 	}
+	last := inclusiveEnd(start, end)
 	if fallback != "" {
-		return fmt.Sprintf("%s\n(%s - %s)", fallback, start.Format("2006-01-02"), inclusiveEnd(end).Format("2006-01-02"))
+		return fmt.Sprintf("%s\n(%s - %s)", fallback, start.Format("2006-01-02"), last.Format("2006-01-02"))
 	}
-	return fmt.Sprintf("(%s - %s)", start.Format("2006-01-02"), inclusiveEnd(end).Format("2006-01-02"))
+	return fmt.Sprintf("(%s - %s)", start.Format("2006-01-02"), last.Format("2006-01-02"))
 }
 
 // inclusiveEnd converts FlexPrice's exclusive period end into the inclusive last
-// day a tax invoice displays: a period ending 2026-05-01T00:00 reads as 30/04/2026.
-func inclusiveEnd(end *time.Time) time.Time {
-	return end.Add(-time.Nanosecond)
+// day a tax invoice displays. A zero-width period (one-time start == end) stays on start.
+func inclusiveEnd(start, end *time.Time) time.Time {
+	last := end.Add(-time.Nanosecond)
+	if start != nil && last.Before(*start) {
+		return *start
+	}
+	return last
 }
 
 func servicePeriodCustomFields(settings *types.InvoiceSyncSettings, start, end *time.Time) []CustomField {
@@ -531,7 +536,7 @@ func servicePeriodCustomFields(settings *types.InvoiceSyncSettings, start, end *
 
 	return []CustomField{
 		NewCustomField(settings.ServicePeriodCustomFields.StartFieldID, start.Format(zohoAPIDateFormat)),
-		NewCustomField(settings.ServicePeriodCustomFields.EndFieldID, inclusiveEnd(end).Format(zohoAPIDateFormat)),
+		NewCustomField(settings.ServicePeriodCustomFields.EndFieldID, inclusiveEnd(start, end).Format(zohoAPIDateFormat)),
 	}
 }
 

--- a/internal/integration/zoho/invoice_header_test.go
+++ b/internal/integration/zoho/invoice_header_test.go
@@ -62,6 +62,13 @@ func TestFormatPeriodDescription(t *testing.T) {
 			end:      nil,
 			want:     "BBNow",
 		},
+		{
+			name:     "zero-width one-time period stays on the billing date",
+			fallback: "Mandate Registration",
+			start:    tPtr("2026-09-17T00:00:00Z"),
+			end:      tPtr("2026-09-17T00:00:00Z"),
+			want:     "Mandate Registration\n(2026-09-17 - 2026-09-17)",
+		},
 	}
 
 	for _, tt := range tests {
@@ -73,8 +80,10 @@ func TestFormatPeriodDescription(t *testing.T) {
 
 // period_end is exclusive in FlexPrice; the invoice must show the inclusive last day.
 func TestInclusiveEnd(t *testing.T) {
-	assert.Equal(t, "2026-04-30", inclusiveEnd(tPtr("2026-05-01T00:00:00Z")).Format(zohoAPIDateFormat))
-	assert.Equal(t, "2026-12-31", inclusiveEnd(tPtr("2027-01-01T00:00:00Z")).Format(zohoAPIDateFormat))
+	assert.Equal(t, "2026-04-30", inclusiveEnd(tPtr("2026-04-01T00:00:00Z"), tPtr("2026-05-01T00:00:00Z")).Format(zohoAPIDateFormat))
+	assert.Equal(t, "2026-12-31", inclusiveEnd(tPtr("2026-12-01T00:00:00Z"), tPtr("2027-01-01T00:00:00Z")).Format(zohoAPIDateFormat))
+	assert.Equal(t, "2026-09-17", inclusiveEnd(tPtr("2026-09-17T00:00:00Z"), tPtr("2026-09-17T00:00:00Z")).Format(zohoAPIDateFormat),
+		"one-time PeriodStart == PeriodEnd must not walk to the previous day")
 }
 
 func TestServicePeriodCustomFields(t *testing.T) {

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -370,6 +370,7 @@ func (r *subscriptionLineItemRepository) BulkTerminate(ctx context.Context, subs
 			subscriptionlineitem.TenantID(types.GetTenantID(ctx)),
 			subscriptionlineitem.EnvironmentID(types.GetEnvironmentID(ctx)),
 			subscriptionlineitem.SubscriptionID(subscriptionID),
+			subscriptionlineitem.StartDateLTE(effectiveDate),
 			subscriptionlineitem.Or(
 				subscriptionlineitem.EndDateIsNil(),
 				subscriptionlineitem.EndDateGT(effectiveDate),

--- a/internal/repository/ent/taxassociation.go
+++ b/internal/repository/ent/taxassociation.go
@@ -49,6 +49,12 @@ func (r *taxAssociationRepository) Create(ctx context.Context, t *domainTaxConfi
 		t.EnvironmentID = types.GetEnvironmentID(ctx)
 	}
 
+	// Rows never store a null behavior; absent means exclusive.
+	taxBehavior := lo.FromPtr(t.TaxBehavior)
+	if taxBehavior == "" {
+		taxBehavior = types.TaxBehaviorExclusive
+	}
+
 	_, err := client.TaxAssociation.Create().
 		SetID(t.ID).
 		SetTaxRateID(t.TaxRateID).
@@ -56,7 +62,7 @@ func (r *taxAssociationRepository) Create(ctx context.Context, t *domainTaxConfi
 		SetNillableCurrency(lo.EmptyableToPtr(t.Currency)).
 		SetPriority(t.Priority).
 		SetAutoApply(t.AutoApply).
-		SetNillableTaxBehavior(t.TaxBehavior).
+		SetTaxBehavior(taxBehavior).
 		SetMetadata(t.Metadata).
 		SetEnvironmentID(t.EnvironmentID).
 		SetEntityID(t.EntityID).
@@ -148,6 +154,12 @@ func (r *taxAssociationRepository) Update(ctx context.Context, t *domainTaxConfi
 	})
 	defer FinishSpan(span)
 
+	// Rows never store a null behavior; absent means exclusive.
+	taxBehavior := lo.FromPtr(t.TaxBehavior)
+	if taxBehavior == "" {
+		taxBehavior = types.TaxBehaviorExclusive
+	}
+
 	update := client.TaxAssociation.Update().
 		Where(
 			entTaxConfig.ID(t.ID),
@@ -157,7 +169,7 @@ func (r *taxAssociationRepository) Update(ctx context.Context, t *domainTaxConfi
 		SetEntityID(t.EntityID).
 		SetPriority(t.Priority).
 		SetAutoApply(t.AutoApply).
-		SetNillableTaxBehavior(t.TaxBehavior).
+		SetTaxBehavior(taxBehavior).
 		SetUpdatedAt(time.Now().UTC()).
 		SetUpdatedBy(types.GetUserID(ctx)).
 		SetNillableEndDate(t.EndDate).

--- a/internal/testutil/inmemory_subscription_line_item_store.go
+++ b/internal/testutil/inmemory_subscription_line_item_store.go
@@ -224,6 +224,9 @@ func (s *InMemorySubscriptionLineItemStore) BulkTerminate(ctx context.Context, s
 
 	affected := 0
 	for _, item := range items {
+		if !item.StartDate.IsZero() && item.StartDate.After(effectiveDate) {
+			continue
+		}
 		if !item.EndDate.IsZero() && item.EndDate.Before(effectiveDate) {
 			continue
 		}

--- a/internal/types/tax.go
+++ b/internal/types/tax.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"slices"
-	"strings"
 
 	ierr "github.com/flexprice/flexprice/internal/errors"
 )
@@ -88,22 +87,7 @@ type TaxBehaviorSource string
 const (
 	// TaxBehaviorSourceExplicit means the request stated the behavior.
 	TaxBehaviorSourceExplicit TaxBehaviorSource = "explicit"
-	// TaxBehaviorSourceCurrencyDefault means the request said nothing and the behavior came
-	// from the subscription currency.
-	TaxBehaviorSourceCurrencyDefault TaxBehaviorSource = "currency_default"
+	// TaxBehaviorSourceDefault means the request said nothing and the behavior fell back
+	// to the default.
+	TaxBehaviorSourceDefault TaxBehaviorSource = "default"
 )
-
-// ExclusiveTaxCurrencies lists currencies whose default tax behavior is exclusive when
-// an association is created without an explicit behavior. Everything else defaults to
-// inclusive. Compiled-in convention — no UI, no API, no per-tenant override.
-var ExclusiveTaxCurrencies = []string{"USD", "CAD"}
-
-// DefaultTaxBehaviorForCurrency resolves the tax behavior for a subscription-level tax
-// association that was not given an explicit behavior. Used only at subscription-association
-// creation time — never re-resolved later.
-func DefaultTaxBehaviorForCurrency(currency string) TaxBehavior {
-	if slices.Contains(ExclusiveTaxCurrencies, strings.ToUpper(currency)) {
-		return TaxBehaviorExclusive
-	}
-	return TaxBehaviorInclusive
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tax behavior now defaults consistently to exclusive when no behavior is specified, regardless of currency.
  * Subscription and customer-level tax templates resolve unspecified behavior correctly when applied.
  * Future-dated subscription add-ons are no longer terminated before their start date.
  * One-time billing periods with identical start and end dates now display accurate dates in Zoho invoices.
* **Tests**
  * Added coverage for default tax behavior, future-start add-ons, and zero-width billing periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->