### PR TITLE
feat: add database read-only mode

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -121,7 +121,7 @@ func NewRouter(
 	router.Use(middleware.PyroscopeMiddleware(cfg)) // Add Pyroscope middleware
 
 	// Initialize permission middleware
-	permissionMW := middleware.NewPermissionMiddleware(rbacService, logger)
+	permissionMW := middleware.NewPermissionMiddleware(rbacService, logger, cfg.Postgres.ReadOnly)
 	write := permissionMW.RequirePermission       // shorthand used on every write route
 	read := permissionMW.RequirePermission        // shorthand used on read routes that opt in to an RBAC gate
 	superAdminOnly := middleware.SuperAdminOnly() // shorthand used on routes accessible only to super_admin users

--- a/internal/config/autobind_test.go
+++ b/internal/config/autobind_test.go
@@ -23,6 +23,7 @@ func TestAutoBindEnvCategories(t *testing.T) {
 	t.Setenv("FLEXPRICE_KAFKA_TLS_CA_CERT_FILE", "/etc/kafka-ca/ca.crt")  // no default tag
 	t.Setenv("FLEXPRICE_KAFKA_TLS_SERVER_NAME", "broker.internal")        // no default tag
 	t.Setenv("FLEXPRICE_KAFKA_SECONDARY_CONSUMER_GROUP", "gmk-dualwrite") // pointer struct field
+	t.Setenv("FLEXPRICE_POSTGRES_READONLY", "true")                       // write-freeze flag
 
 	cfg, err := NewConfig()
 	if err != nil {
@@ -45,9 +46,23 @@ func TestAutoBindEnvCategories(t *testing.T) {
 		{"kafka.tls_ca_cert_file", cfg.Kafka.TLSCACertFile, "/etc/kafka-ca/ca.crt"},
 		{"kafka.tls_server_name", cfg.Kafka.TLSServerName, "broker.internal"},
 	}
+
+	boolCases := []struct {
+		name string
+		got  bool
+		want bool
+	}{
+		{"postgres.readonly", cfg.Postgres.ReadOnly, true},
+	}
 	for _, c := range cases {
 		if c.got != c.want {
 			t.Errorf("%s = %q, want %q (env override not honored)", c.name, c.got, c.want)
+		}
+	}
+
+	for _, c := range boolCases {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v (env override not honored)", c.name, c.got, c.want)
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -602,6 +602,9 @@ type PostgresConfig struct {
 	// Reader endpoint configuration for read replicas
 	ReaderHost string `mapstructure:"reader_host"`
 	ReaderPort int    `mapstructure:"reader_port"`
+
+	// ReadOnly freezes all Postgres writes (cutover). Env: FLEXPRICE_POSTGRES_READONLY.
+	ReadOnly bool `mapstructure:"readonly"`
 }
 
 type APIKeyConfig struct {

--- a/internal/ee/service/event_test.go
+++ b/internal/ee/service/event_test.go
@@ -61,6 +61,8 @@ func (s *EventServiceSuite) TearDownTest() {
 	s.publisher.Clear()
 }
 
+// Write-freeze invariant: CreateEvent has no Postgres writer dependency —
+// only Kafka publish below proves ingestion survives a PG write-freeze.
 func (s *EventServiceSuite) TestCreateEvent() {
 	testCases := []struct {
 		name          string

--- a/internal/postgres/client.go
+++ b/internal/postgres/client.go
@@ -165,6 +165,15 @@ func NewEntClients(config *config.Configuration, logger *logger.Logger) (*EntCli
 		logger.Debug(context.Background(), "no separate reader configured, using writer for reads")
 	}
 
+	// Reject all mutations while the write-freeze is on. readerClient may be
+	// the same *ent.Client as writerClient (no separate reader configured);
+	// Use is idempotent per hook instance so registering on both is safe.
+	roHook := newReadOnlyHook(config.Postgres.ReadOnly)
+	writerClient.Use(roHook)
+	if readerClient != writerClient {
+		readerClient.Use(roHook)
+	}
+
 	return &EntClients{
 		Writer:    writerClient,
 		Reader:    readerClient,

--- a/internal/postgres/readonly_hook.go
+++ b/internal/postgres/readonly_hook.go
@@ -1,0 +1,24 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+
+	"github.com/flexprice/flexprice/ent"
+)
+
+// ErrReadOnly is returned for every mutation while the DB write-freeze is on.
+var ErrReadOnly = errors.New("database is in read-only mode (cutover in progress)")
+
+// newReadOnlyHook rejects all Create/Update/Delete mutations when enabled.
+// enabled is captured at construction; toggling requires a process restart.
+func newReadOnlyHook(enabled bool) ent.Hook {
+	return func(next ent.Mutator) ent.Mutator {
+		return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
+			if enabled {
+				return nil, ErrReadOnly
+			}
+			return next.Mutate(ctx, m)
+		})
+	}
+}

--- a/internal/postgres/readonly_hook_test.go
+++ b/internal/postgres/readonly_hook_test.go
@@ -1,0 +1,49 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/flexprice/flexprice/ent"
+)
+
+func TestReadOnlyHook(t *testing.T) {
+	sentinel := errors.New("would-mutate")
+	next := ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
+		return nil, sentinel
+	})
+
+	// enabled: mutation rejected with ErrReadOnly, next never called.
+	got := newReadOnlyHook(true)(next)
+	if _, err := got.Mutate(context.Background(), nil); !errors.Is(err, ErrReadOnly) {
+		t.Fatalf("enabled hook: want ErrReadOnly, got %v", err)
+	}
+
+	// disabled: passes through to next.
+	got = newReadOnlyHook(false)(next)
+	if _, err := got.Mutate(context.Background(), nil); !errors.Is(err, sentinel) {
+		t.Fatalf("disabled hook: want passthrough sentinel, got %v", err)
+	}
+}
+
+// TestNewEntClientsInstallsReadOnlyHook mirrors how NewEntClients wires the
+// hook onto a real *ent.Client (no driver — no query ever reaches it, since
+// the hook rejects the mutation before the driver is touched).
+func TestNewEntClientsInstallsReadOnlyHook(t *testing.T) {
+	client := ent.NewClient()
+	client.Use(newReadOnlyHook(true))
+
+	_, err := client.Environment.Create().SetName("test").SetType("dev").Save(context.Background())
+	if !errors.Is(err, ErrReadOnly) {
+		t.Fatalf("readOnly=true: want ErrReadOnly, got %v", err)
+	}
+
+	client2 := ent.NewClient()
+	client2.Use(newReadOnlyHook(false))
+
+	_, err = client2.Environment.Create().SetName("test").SetType("dev").Save(context.Background())
+	if errors.Is(err, ErrReadOnly) {
+		t.Fatalf("readOnly=false: hook must not block the mutation, got ErrReadOnly")
+	}
+}

--- a/internal/rest/middleware/permission.go
+++ b/internal/rest/middleware/permission.go
@@ -13,13 +13,15 @@ import (
 type PermissionMiddleware struct {
 	rbacService *rbac.RBACService
 	logger      *logger.Logger
+	readOnly    bool
 }
 
 // NewPermissionMiddleware creates a new permission middleware instance
-func NewPermissionMiddleware(rbacService *rbac.RBACService, logger *logger.Logger) *PermissionMiddleware {
+func NewPermissionMiddleware(rbacService *rbac.RBACService, logger *logger.Logger, readOnly bool) *PermissionMiddleware {
 	return &PermissionMiddleware{
 		rbacService: rbacService,
 		logger:      logger,
+		readOnly:    readOnly,
 	}
 }
 
@@ -56,6 +58,17 @@ func (pm *PermissionMiddleware) RequirePermission(entity types.Entity, action ty
 
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
+
+		// DB write freeze (cutover): reject writes before any RBAC/tenant
+		// check runs, since none of that matters if writes are impossible.
+		if pm.readOnly && action == types.ActionWrite {
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{
+				"error":       "read_only",
+				"message":     "database is read-only (cutover in progress)",
+				"retry_after": 30,
+			})
+			return
+		}
 
 		// Suspended tenants are blocked from all write operations. Checked first
 		// so a suspended tenant hears about the suspension rather than a narrower

--- a/internal/rest/middleware/permission_test.go
+++ b/internal/rest/middleware/permission_test.go
@@ -34,7 +34,34 @@ func newPermissionTestRouter(t *testing.T, rbacSvc *rbac.RBACService, userType s
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	pm := NewPermissionMiddleware(rbacSvc, newTestLogger(t))
+	pm := NewPermissionMiddleware(rbacSvc, newTestLogger(t), false)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := c.Request.Context()
+		if userType != "" {
+			ctx = context.WithValue(ctx, types.CtxUserType, userType)
+		}
+		if roles != nil {
+			ctx = context.WithValue(ctx, types.CtxRoles, roles)
+		}
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.POST("/customers", pm.RequirePermission(entity, action), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"created": true})
+	})
+
+	return r
+}
+
+// newPermissionTestRouterReadOnly mirrors newPermissionTestRouter but lets the
+// test control the middleware's readOnly flag, for TestRequirePermissionReadOnly.
+func newPermissionTestRouterReadOnly(t *testing.T, rbacSvc *rbac.RBACService, userType string, roles []string, entity types.Entity, action types.Action, readOnly bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	pm := NewPermissionMiddleware(rbacSvc, newTestLogger(t), readOnly)
 
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -78,7 +105,7 @@ const superAdminRolesJSON = `{
 func newSuperAdminRouter(t *testing.T, tenantStatus types.TenantInternalStatus, userType string, roles []string) *gin.Engine {
 	t.Helper()
 	log := newTestLogger(t)
-	pm := NewPermissionMiddleware(newRBACServiceWithRoles(t, superAdminRolesJSON), log)
+	pm := NewPermissionMiddleware(newRBACServiceWithRoles(t, superAdminRolesJSON), log, false)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -271,7 +298,7 @@ func newPortalSessionTestRouter(t *testing.T, rbacSvc *rbac.RBACService, userTyp
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	pm := NewPermissionMiddleware(rbacSvc, newTestLogger(t))
+	pm := NewPermissionMiddleware(rbacSvc, newTestLogger(t), false)
 
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
@@ -340,6 +367,61 @@ func TestPortalSession_AllowsWriter(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code, "a writer principal must still be able to create a portal session")
 	assert.Contains(t, w.Body.String(), "portal-jwt", "the session token must be returned on the allowed path")
+}
+
+// TestRequirePermissionReadOnly pins the 503 gate added for the DB write
+// freeze: a write route must be refused before RBAC runs when readOnly is
+// set, a read route must pass the gate, and the gate must be a no-op when
+// readOnly is false.
+func TestRequirePermissionReadOnly(t *testing.T) {
+	rbacSvc := realRBACService(t)
+
+	cases := []struct {
+		name     string
+		entity   types.Entity
+		action   types.Action
+		roles    []string
+		readOnly bool
+		want     int
+	}{
+		{
+			// The gate must fire BEFORE RBAC: a caller lacking customer:write
+			// still gets 503, not 403 — proving read-only precedes the role
+			// check. A regression that ran RBAC first would return 403 here.
+			name:     "write under readOnly, caller lacks write perm -> 503 (not 403)",
+			entity:   types.EntityCustomer,
+			action:   types.ActionWrite,
+			roles:    []string{types.RoleAllReader.String()},
+			readOnly: true,
+			want:     http.StatusServiceUnavailable,
+		},
+		{
+			name:     "read under readOnly -> passes gate (200)",
+			entity:   types.EntityCustomer,
+			action:   types.ActionRead,
+			roles:    []string{types.RoleSuperAdmin.String()},
+			readOnly: true,
+			want:     http.StatusOK,
+		},
+		{
+			name:     "write with readOnly=false -> passes gate (200)",
+			entity:   types.EntityCustomer,
+			action:   types.ActionWrite,
+			roles:    []string{types.RoleSuperAdmin.String()},
+			readOnly: false,
+			want:     http.StatusOK,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := newPermissionTestRouterReadOnly(t, rbacSvc, string(types.UserTypeUser),
+				tc.roles, tc.entity, tc.action, tc.readOnly)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/customers", nil))
+			assert.Equal(t, tc.want, w.Code, tc.name)
+		})
+	}
 }
 
 // TestPortalSession_AllowsSuperAdmin confirms a super_admin principal (wildcard

--- a/internal/rest/middleware/tenant_access_test.go
+++ b/internal/rest/middleware/tenant_access_test.go
@@ -74,7 +74,7 @@ func newTestRouter(t *testing.T, tenantID string, svc *mockTenantService) *gin.E
 	t.Helper()
 
 	log := newTestLogger(t)
-	permMW := NewPermissionMiddleware(newPermissiveRBACService(t), log)
+	permMW := NewPermissionMiddleware(newPermissiveRBACService(t), log, false)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -147,7 +147,7 @@ func newRBACServiceWithRoles(t *testing.T, rolesJSON string) *rbac.RBACService {
 func newRBACRouter(t *testing.T, rbacSvc *rbac.RBACService, tenantStatus types.TenantInternalStatus, userType string, roles []string) *gin.Engine {
 	t.Helper()
 	log := newTestLogger(t)
-	permMW := NewPermissionMiddleware(rbacSvc, log)
+	permMW := NewPermissionMiddleware(rbacSvc, log, false)
 	svc := &mockTenantService{status: tenantStatus}
 
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## What

Adds a `postgres.readonly` config flag (env `FLEXPRICE_POSTGRES_READONLY`, default false) that puts the database into read-only mode.

When enabled:
- an ent mutation hook on the writer and reader clients rejects Create/Update/Delete with `ErrReadOnly`
- `RequirePermission` returns 503 on write-action routes (keyed on the RBAC action, not HTTP method — since read endpoints may use POST)

Reads, event ingestion (Kafka-only), and login are unaffected. The disabled path is a pure passthrough with negligible overhead. Default is false, so there is no behavior change until it is explicitly enabled.

## Testing

- `go build ./internal/... ./cmd/...` — clean
- `go test ./internal/config/ ./internal/postgres/ ./internal/rest/middleware/ ./internal/ee/service/ -count=1` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable PostgreSQL read-only mode to prevent database writes during controlled transitions.
  * Write requests return HTTP 503 with a retry interval while read-only mode is active.
  * Read requests and event ingestion continue to operate during the write freeze.

* **Bug Fixes**
  * Applied read-only protection consistently across database clients and API permissions.
  * Prevented blocked write requests from proceeding through authorization checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->