### PR TITLE
Fix multi-tenant isolation gaps, ClickHouse SQL injection, and two au…

### DIFF
--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -6,7 +6,7 @@ server:
 
 auth:
   provider: "flexprice" # "flexprice" or "supabase"
-  secret: "super_secret"
+  secret: "dev-only-insecure-secret-prod-sets-FLEXPRICE_AUTH_SECRET"
   # SAML single sign-on. Per-tenant identity provider details live in the
   # tenant's saml_config setting, not here.
   saml:

--- a/internal/integration/razorpay/client.go
+++ b/internal/integration/razorpay/client.go
@@ -350,7 +350,7 @@ func (c *Client) VerifyWebhookSignature(ctx context.Context, payload []byte, sig
 	mac.Write(payload)
 	expectedSignature := hex.EncodeToString(mac.Sum(nil))
 
-	if expectedSignature != signature {
+	if !hmac.Equal([]byte(expectedSignature), []byte(signature)) {
 		c.logger.Info(ctx, "webhook signature mismatch",
 			"expected_signature_length", len(expectedSignature),
 			"received_signature_length", len(signature),

--- a/internal/repository/clickhouse/builder/query_builder.go
+++ b/internal/repository/clickhouse/builder/query_builder.go
@@ -12,18 +12,18 @@ import (
 
 type QueryBuilder struct {
 	baseQuery    string
+	baseArgs     []interface{}
 	filterQuery  string
+	filterArgs   []interface{}
 	matchedQuery string
 	finalQuery   string
-	args         map[string]interface{}
+	aggArgs      []interface{}
 	filterGroups []events.FilterGroup
 	params       *events.UsageParams
 }
 
 func NewQueryBuilder() *QueryBuilder {
-	return &QueryBuilder{
-		args: make(map[string]interface{}),
-	}
+	return &QueryBuilder{}
 }
 
 // getDeduplicationKey returns the columns used for deduplication
@@ -32,48 +32,54 @@ func (qb *QueryBuilder) getDeduplicationKey() string {
 }
 
 func (qb *QueryBuilder) WithBaseFilters(ctx context.Context, params *events.UsageParams) *QueryBuilder {
-	conditions := []string{
-		fmt.Sprintf("event_name = '%s'", params.EventName),
-	}
+	conditions := []string{"event_name = ?"}
+	qb.baseArgs = append(qb.baseArgs, params.EventName)
 
 	tenantID := types.GetTenantID(ctx)
 	if tenantID != "" {
-		conditions = append(conditions, fmt.Sprintf("tenant_id = '%s'", tenantID))
+		conditions = append(conditions, "tenant_id = ?")
+		qb.baseArgs = append(qb.baseArgs, tenantID)
 	}
 
 	// Add environment_id filter if present in context
 	environmentID := types.GetEnvironmentID(ctx)
 	if environmentID != "" {
-		conditions = append(conditions, fmt.Sprintf("environment_id = '%s'", environmentID))
+		conditions = append(conditions, "environment_id = ?")
+		qb.baseArgs = append(qb.baseArgs, environmentID)
 	}
 
 	conditions = append(conditions, parseTimeConditions(params)...)
 
 	if params.ExternalCustomerID != "" {
-		conditions = append(conditions, fmt.Sprintf("external_customer_id = '%s'", params.ExternalCustomerID))
+		conditions = append(conditions, "external_customer_id = ?")
+		qb.baseArgs = append(qb.baseArgs, params.ExternalCustomerID)
 	}
 	if params.CustomerID != "" {
-		conditions = append(conditions, fmt.Sprintf("customer_id = '%s'", params.CustomerID))
+		conditions = append(conditions, "customer_id = ?")
+		qb.baseArgs = append(qb.baseArgs, params.CustomerID)
 	}
 
 	if params.Filters != nil {
 		for property, values := range params.Filters {
-			if len(values) > 0 {
-				var condition string
-				if len(values) == 1 {
-					condition = fmt.Sprintf("JSONExtractString(properties, '%s') = '%s'", property, values[0])
-				} else {
-					quotedValues := make([]string, len(values))
-					for i, v := range values {
-						quotedValues[i] = fmt.Sprintf("'%s'", v)
-					}
-					condition = fmt.Sprintf(
-						"JSONExtractString(properties, '%s') IN (%s)",
-						property,
-						strings.Join(quotedValues, ","),
-					)
+			if len(values) == 0 {
+				continue
+			}
+			if len(values) == 1 {
+				conditions = append(conditions, "JSONExtractString(properties, ?) = ?")
+				qb.baseArgs = append(qb.baseArgs, property, values[0])
+			} else {
+				placeholders := make([]string, len(values))
+				for i := range values {
+					placeholders[i] = "?"
 				}
-				conditions = append(conditions, condition)
+				conditions = append(conditions, fmt.Sprintf(
+					"JSONExtractString(properties, ?) IN (%s)",
+					strings.Join(placeholders, ","),
+				))
+				qb.baseArgs = append(qb.baseArgs, property)
+				for _, v := range values {
+					qb.baseArgs = append(qb.baseArgs, v)
+				}
 			}
 		}
 	}
@@ -100,42 +106,46 @@ func (qb *QueryBuilder) WithFilterGroups(ctx context.Context, groups []events.Fi
 	var filterConditions []string
 	for _, group := range groups {
 		var conditions []string
+		var groupArgs []interface{}
 		for property, values := range group.Filters {
 			if len(values) == 0 {
 				continue
 			}
-			var condition string
 			if len(values) == 1 {
-				condition = fmt.Sprintf("JSONExtractString(properties, '%s') = '%s'", property, values[0])
+				conditions = append(conditions, "JSONExtractString(properties, ?) = ?")
+				groupArgs = append(groupArgs, property, values[0])
 			} else {
-				quotedValues := make([]string, len(values))
-				for i, v := range values {
-					quotedValues[i] = fmt.Sprintf("'%s'", v)
+				placeholders := make([]string, len(values))
+				for i := range values {
+					placeholders[i] = "?"
 				}
-				condition = fmt.Sprintf(
-					"JSONExtractString(properties, '%s') IN (%s)",
-					property,
-					strings.Join(quotedValues, ","),
-				)
+				conditions = append(conditions, fmt.Sprintf(
+					"JSONExtractString(properties, ?) IN (%s)",
+					strings.Join(placeholders, ","),
+				))
+				groupArgs = append(groupArgs, property)
+				for _, v := range values {
+					groupArgs = append(groupArgs, v)
+				}
 			}
-			conditions = append(conditions, condition)
 		}
 
 		// Only add the filter group if it has conditions
 		if len(conditions) > 0 {
 			filterConditions = append(filterConditions, fmt.Sprintf(
-				"('%s', %d, (%s))",
-				group.ID,
+				"(?, %d, (%s))",
 				group.Priority,
 				strings.Join(conditions, " AND "),
 			))
+			qb.filterArgs = append(qb.filterArgs, group.ID)
+			qb.filterArgs = append(qb.filterArgs, groupArgs...)
 		} else {
 			// For empty filter groups, use a constant true condition
 			filterConditions = append(filterConditions, fmt.Sprintf(
-				"('%s', %d, 1)",
-				group.ID,
+				"(?, %d, 1)",
 				group.Priority,
 			))
+			qb.filterArgs = append(qb.filterArgs, group.ID)
 		}
 	}
 
@@ -184,11 +194,14 @@ func (qb *QueryBuilder) WithAggregation(ctx context.Context, aggType types.Aggre
 	case types.AggregationCount:
 		aggClause = "COUNT(*)"
 	case types.AggregationSum:
-		aggClause = fmt.Sprintf("SUM(CAST(JSONExtractString(properties, '%s') AS Float64))", propertyName)
+		aggClause = "SUM(CAST(JSONExtractString(properties, ?) AS Float64))"
+		qb.aggArgs = append(qb.aggArgs, propertyName)
 	case types.AggregationAvg:
-		aggClause = fmt.Sprintf("AVG(CAST(JSONExtractString(properties, '%s') AS Float64))", propertyName)
+		aggClause = "AVG(CAST(JSONExtractString(properties, ?) AS Float64))"
+		qb.aggArgs = append(qb.aggArgs, propertyName)
 	case types.AggregationCountUnique:
-		aggClause = fmt.Sprintf("COUNT(DISTINCT JSONExtractString(properties, '%s'))", propertyName)
+		aggClause = "COUNT(DISTINCT JSONExtractString(properties, ?))"
+		qb.aggArgs = append(qb.aggArgs, propertyName)
 	}
 
 	qb.finalQuery = fmt.Sprintf("SELECT best_match_group as filter_group_id, %s as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group", aggClause)
@@ -196,7 +209,11 @@ func (qb *QueryBuilder) WithAggregation(ctx context.Context, aggType types.Aggre
 	return qb
 }
 
-func (qb *QueryBuilder) Build() (string, map[string]interface{}) {
+// Build returns the query text and its bind args, in the same left-to-right
+// order the `?` placeholders appear in the text: base_events, then
+// filter_matches, then the final aggregation SELECT (matched_events/
+// best_matches carry no dynamic values).
+func (qb *QueryBuilder) Build() (string, []interface{}) {
 	var ctes []string
 
 	// Add base query without WITH
@@ -222,7 +239,12 @@ func (qb *QueryBuilder) Build() (string, map[string]interface{}) {
 	// Combine CTEs with final query
 	query := fmt.Sprintf("WITH %s\n%s", ctePart, qb.finalQuery)
 
-	return query, qb.args
+	args := make([]interface{}, 0, len(qb.baseArgs)+len(qb.filterArgs)+len(qb.aggArgs))
+	args = append(args, qb.baseArgs...)
+	args = append(args, qb.filterArgs...)
+	args = append(args, qb.aggArgs...)
+
+	return query, args
 }
 
 // parseTimeConditions builds timestamp WHERE fragments with an explicit `'UTC'` third

--- a/internal/repository/clickhouse/builder/query_builder_test.go
+++ b/internal/repository/clickhouse/builder/query_builder_test.go
@@ -20,7 +20,7 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 		name     string
 		params   *events.UsageParams
 		wantSQL  string
-		wantArgs map[string]interface{}
+		wantArgs []interface{}
 	}{
 		{
 			name: "base filters with all params",
@@ -31,7 +31,8 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 				CustomerID:         "cust_123",
 				ExternalCustomerID: "ext_123",
 			},
-			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'audio_transcription' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3, 'UTC') AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3, 'UTC') AND external_customer_id = 'ext_123' AND customer_id = 'cust_123' ORDER BY tenant_id, environment_id, timestamp, id DESC))",
+			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = ? AND tenant_id = ? AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3, 'UTC') AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3, 'UTC') AND external_customer_id = ? AND customer_id = ? ORDER BY tenant_id, environment_id, timestamp, id DESC))",
+			wantArgs: []interface{}{"audio_transcription", "00000000-0000-0000-0000-000000000000", "ext_123", "cust_123"},
 		},
 		{
 			name: "base filters without customer ID",
@@ -40,7 +41,8 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 				StartTime: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 				EndTime:   time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC),
 			},
-			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'api_calls' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3, 'UTC') AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3, 'UTC') ORDER BY tenant_id, environment_id, timestamp, id DESC))",
+			wantSQL:  "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = ? AND tenant_id = ? AND timestamp >= toDateTime64('2024-01-01 00:00:00.000', 3, 'UTC') AND timestamp < toDateTime64('2024-01-02 00:00:00.000', 3, 'UTC') ORDER BY tenant_id, environment_id, timestamp, id DESC))",
+			wantArgs: []interface{}{"api_calls", "00000000-0000-0000-0000-000000000000"},
 		},
 		{
 			// Regression: non-UTC inputs must be converted to UTC clock time and the
@@ -55,7 +57,8 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 				// 12:30 in -05:00 == 17:30 UTC
 				EndTime: time.Date(2024, 1, 2, 12, 30, 0, 0, time.FixedZone("-05:00", -5*60*60)),
 			},
-			wantSQL: "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = 'api_calls' AND tenant_id = '00000000-0000-0000-0000-000000000000' AND timestamp >= toDateTime64('2024-01-01 08:00:00.000', 3, 'UTC') AND timestamp < toDateTime64('2024-01-02 17:30:00.000', 3, 'UTC') ORDER BY tenant_id, environment_id, timestamp, id DESC))",
+			wantSQL:  "WITH base_events AS (SELECT * FROM (SELECT DISTINCT ON (tenant_id, environment_id, timestamp, id) * FROM events WHERE event_name = ? AND tenant_id = ? AND timestamp >= toDateTime64('2024-01-01 08:00:00.000', 3, 'UTC') AND timestamp < toDateTime64('2024-01-02 17:30:00.000', 3, 'UTC') ORDER BY tenant_id, environment_id, timestamp, id DESC))",
+			wantArgs: []interface{}{"api_calls", "00000000-0000-0000-0000-000000000000"},
 		},
 	}
 
@@ -63,12 +66,13 @@ func TestQueryBuilder_WithBaseFilters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qb := NewQueryBuilder()
 			qb.WithBaseFilters(ctx, tt.params)
-			sql, _ := qb.Build()
+			sql, args := qb.Build()
 			sql = strings.ReplaceAll(sql, "\n", "")
 			sql = strings.ReplaceAll(sql, "\t", "")
 			expected := strings.ReplaceAll(tt.wantSQL, "\n", "")
 			expected = strings.ReplaceAll(expected, "\t", "")
 			assert.Equal(t, expected, sql)
+			assert.Equal(t, tt.wantArgs, args)
 		})
 	}
 }
@@ -79,7 +83,7 @@ func TestQueryBuilder_WithFilterGroups(t *testing.T) {
 		meterConfig *meter.Meter
 		groups      []events.FilterGroup
 		wantCTEs    []string
-		wantFilters []string
+		wantArgs    []interface{}
 	}{
 		{
 			name: "multiple filter groups with different priorities",
@@ -113,11 +117,9 @@ func TestQueryBuilder_WithFilterGroups(t *testing.T) {
 				"matched_events AS",
 				"best_matches AS",
 			},
-			wantFilters: []string{
-				"JSONExtractString(properties, 'test_group') = 'group_0'",
-				"JSONExtractString(properties, 'audio_model') = 'whisper'",
-				"JSONExtractString(properties, 'test_group') = 'group_1'",
-				"JSONExtractString(properties, 'audio_model') = 'deepgram'",
+			wantArgs: []interface{}{
+				"1", "test_group", "group_0", "audio_model", "whisper",
+				"2", "test_group", "group_1", "audio_model", "deepgram",
 			},
 		},
 		{
@@ -142,9 +144,7 @@ func TestQueryBuilder_WithFilterGroups(t *testing.T) {
 				"matched_events AS",
 				"best_matches AS",
 			},
-			wantFilters: []string{
-				"JSONExtractString(properties, 'test_group') = 'group_0'",
-			},
+			wantArgs: []interface{}{"1", "test_group", "group_0"},
 		},
 	}
 
@@ -152,17 +152,21 @@ func TestQueryBuilder_WithFilterGroups(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qb := NewQueryBuilder()
 			qb.WithFilterGroups(ctx, tt.groups)
-			sql, _ := qb.Build()
+			sql, args := qb.Build()
 
 			// Verify all CTEs are present
 			for _, cte := range tt.wantCTEs {
 				assert.Contains(t, sql, cte)
 			}
 
-			// Verify all filters are present
-			for _, filter := range tt.wantFilters {
-				assert.Contains(t, sql, filter)
-			}
+			// Verify the filter conditions are parameterized, not inlined literals
+			assert.Contains(t, sql, "JSONExtractString(properties, ?) = ?")
+			assert.NotContains(t, sql, "'group_0'")
+			assert.NotContains(t, sql, "'test_group'")
+
+			// Verify all group IDs, filter keys, and values were bound as args
+			// (map iteration order is non-deterministic within a group, so compare as sets).
+			assert.ElementsMatch(t, tt.wantArgs, args)
 		})
 	}
 }
@@ -183,25 +187,25 @@ func TestQueryBuilder_WithAggregation(t *testing.T) {
 			name:         "sum aggregation",
 			aggType:      types.AggregationSum,
 			propertyName: "duration",
-			wantSQL:      "SELECT best_match_group as filter_group_id, SUM(CAST(JSONExtractString(properties, 'duration') AS Float64)) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
+			wantSQL:      "SELECT best_match_group as filter_group_id, SUM(CAST(JSONExtractString(properties, ?) AS Float64)) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
 		},
 		{
 			name:         "avg aggregation",
 			aggType:      types.AggregationAvg,
 			propertyName: "response_time",
-			wantSQL:      "SELECT best_match_group as filter_group_id, AVG(CAST(JSONExtractString(properties, 'response_time') AS Float64)) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
+			wantSQL:      "SELECT best_match_group as filter_group_id, AVG(CAST(JSONExtractString(properties, ?) AS Float64)) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
 		},
 		{
 			name:         "count unique aggregation",
 			aggType:      types.AggregationCountUnique,
 			propertyName: "region",
-			wantSQL:      "SELECT best_match_group as filter_group_id, COUNT(DISTINCT JSONExtractString(properties, 'region')) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
+			wantSQL:      "SELECT best_match_group as filter_group_id, COUNT(DISTINCT JSONExtractString(properties, ?)) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
 		},
 		{
 			name:         "count unique aggregation with user property",
 			aggType:      types.AggregationCountUnique,
 			propertyName: "user",
-			wantSQL:      "SELECT best_match_group as filter_group_id, COUNT(DISTINCT JSONExtractString(properties, 'user')) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
+			wantSQL:      "SELECT best_match_group as filter_group_id, COUNT(DISTINCT JSONExtractString(properties, ?)) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
 		},
 	}
 
@@ -211,8 +215,11 @@ func TestQueryBuilder_WithAggregation(t *testing.T) {
 			qb.WithBaseFilters(ctx, &events.UsageParams{EventName: "test"})
 			qb.WithFilterGroups(ctx, []events.FilterGroup{{ID: "1"}})
 			qb.WithAggregation(ctx, tt.aggType, tt.propertyName)
-			sql, _ := qb.Build()
+			sql, args := qb.Build()
 			assert.Contains(t, sql, tt.wantSQL)
+			if tt.propertyName != "" {
+				assert.Contains(t, args, tt.propertyName)
+			}
 		})
 	}
 }
@@ -253,7 +260,7 @@ func TestQueryBuilder_CompleteFlow(t *testing.T) {
 				},
 			},
 			aggType: types.AggregationSum,
-			wantSQL: "SELECT best_match_group as filter_group_id, SUM(CAST(JSONExtractString(properties, 'duration') AS Float64)) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
+			wantSQL: "SELECT best_match_group as filter_group_id, SUM(CAST(JSONExtractString(properties, ?) AS Float64)) as value FROM best_matches GROUP BY best_match_group ORDER BY best_match_group",
 		},
 	}
 
@@ -263,8 +270,9 @@ func TestQueryBuilder_CompleteFlow(t *testing.T) {
 			qb.WithBaseFilters(ctx, tt.params)
 			qb.WithFilterGroups(ctx, tt.groups)
 			qb.WithAggregation(ctx, tt.aggType, "duration")
-			sql, _ := qb.Build()
+			sql, args := qb.Build()
 			assert.Contains(t, sql, tt.wantSQL)
+			assert.Contains(t, args, "duration")
 		})
 	}
 }

--- a/internal/repository/clickhouse/event.go
+++ b/internal/repository/clickhouse/event.go
@@ -446,16 +446,16 @@ func (r *EventRepository) GetUsageWithFilters(ctx context.Context, params *event
 		WithAggregation(ctx, params.AggregationType, params.PropertyName).
 		WithFilterGroups(ctx, params.FilterGroups)
 
-	query, queryParams := qb.Build()
+	query, queryArgs := qb.Build()
 
 	r.logger.Debug(ctx, "executing filter groups query",
 		"aggregation_type", params.AggregationType,
 		"event_name", params.UsageParams.EventName,
 		"filter_groups", len(params.FilterGroups),
 		"query", query,
-		"params", queryParams)
+		"args", queryArgs)
 
-	rows, err := r.store.GetConn().Query(ctx, query, queryParams)
+	rows, err := r.store.GetConn().Query(ctx, query, queryArgs...)
 	if err != nil {
 		SetSpanError(span, err)
 		return nil, ierr.WithError(err).

--- a/internal/repository/ent/price.go
+++ b/internal/repository/ent/price.go
@@ -699,7 +699,12 @@ func (r *priceRepository) GetByPlanID(ctx context.Context, planID string) ([]*do
 	client := r.client.Reader(ctx)
 
 	prices, err := client.Price.Query().
-		Where(price.EntityID(planID), price.Status(string(types.StatusPublished))).
+		Where(
+			price.EntityID(planID),
+			price.Status(string(types.StatusPublished)),
+			price.TenantID(types.GetTenantID(ctx)),
+			price.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		All(ctx)
 	if err != nil {
 		return nil, ierr.WithError(err).
@@ -756,7 +761,11 @@ func (r *priceRepository) GetByGroupIDs(ctx context.Context, groupIDs []string) 
 	client := r.client.Reader(ctx)
 
 	prices, err := client.Price.Query().
-		Where(price.GroupIDIn(groupIDs...)).
+		Where(
+			price.GroupIDIn(groupIDs...),
+			price.TenantID(types.GetTenantID(ctx)),
+			price.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		All(ctx)
 	if err != nil {
 		return nil, ierr.WithError(err).

--- a/internal/repository/ent/subscription.go
+++ b/internal/repository/ent/subscription.go
@@ -1020,6 +1020,7 @@ func (r *subscriptionRepository) GetPause(ctx context.Context, id string) (*doma
 		Where(
 			subscriptionpause.ID(id),
 			subscriptionpause.TenantID(types.GetTenantID(ctx)),
+			subscriptionpause.EnvironmentID(types.GetEnvironmentID(ctx)),
 			subscriptionpause.Status(string(types.StatusPublished)),
 		).
 		Only(ctx)
@@ -1056,6 +1057,7 @@ func (r *subscriptionRepository) UpdatePause(ctx context.Context, pause *domainS
 		Where(
 			subscriptionpause.ID(pause.ID),
 			subscriptionpause.TenantID(types.GetTenantID(ctx)),
+			subscriptionpause.EnvironmentID(types.GetEnvironmentID(ctx)),
 			subscriptionpause.Status(string(types.StatusPublished)),
 		).
 		Only(ctx)

--- a/internal/repository/ent/subscription_line_item.go
+++ b/internal/repository/ent/subscription_line_item.go
@@ -296,6 +296,10 @@ func (r *subscriptionLineItemRepository) Update(ctx context.Context, item *subsc
 
 	client := r.client.Writer(ctx)
 	builder := client.SubscriptionLineItem.UpdateOneID(item.ID).
+		Where(
+			subscriptionlineitem.TenantID(types.GetTenantID(ctx)),
+			subscriptionlineitem.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		SetNillableEntityID(types.ToNillableString(item.EntityID)).
 		SetNillablePlanDisplayName(types.ToNillableString(item.PlanDisplayName)).
 		SetPriceID(item.PriceID).
@@ -412,6 +416,7 @@ func (r *subscriptionLineItemRepository) Delete(ctx context.Context, id string) 
 		Where(
 			subscriptionlineitem.ID(id),
 			subscriptionlineitem.TenantID(types.GetTenantID(ctx)),
+			subscriptionlineitem.EnvironmentID(types.GetEnvironmentID(ctx)),
 		).
 		Exec(ctx)
 

--- a/internal/repository/ent/wallet.go
+++ b/internal/repository/ent/wallet.go
@@ -452,7 +452,11 @@ func (r *walletRepository) UpdateWalletBalance(ctx context.Context, walletID str
 	defer FinishSpan(span)
 
 	err := r.client.Writer(ctx).Wallet.Update().
-		Where(wallet.ID(walletID)).
+		Where(
+			wallet.ID(walletID),
+			wallet.TenantID(types.GetTenantID(ctx)),
+			wallet.EnvironmentID(types.GetEnvironmentID(ctx)),
+		).
 		SetBalance(finalBalance).
 		SetCreditBalance(newCreditBalance).
 		SetUpdatedBy(types.GetUserID(ctx)).


### PR DESCRIPTION
## 📝 Description
Security audit of the repo surfaced four categories of confirmed, high-confidence issues, all fixed here:

- **Multi-tenant isolation gaps** (`internal/repository/ent/`): `wallet.UpdateWalletBalance`, `subscription_line_item.Update`/`Delete`, `price.GetByPlanID`/`GetByGroupIDs`, and `subscription.GetPause`/`UpdatePause` queried/mutated rows by ID without also filtering on `tenant_id`+`environment_id`, unlike sibling methods in the same files. Per this repo's own multi-tenancy invariant ("every query filters on both — missing filter = data leak = critical bug"), these are fixed to match their siblings.
- **ClickHouse SQL injection** (`internal/repository/clickhouse/builder/query_builder.go`): the meter/price filter-group query builder interpolated event name, tenant/customer IDs, and JSON property keys/values directly into SQL text via `fmt.Sprintf`, with no escaping — unlike the sibling `meter_usage_query_builder.go`, which already uses `?` bound parameters. Switched to the same bound-parameter pattern; updated the caller in `event.go` and the builder's unit tests accordingly.
- **Non-constant-time webhook signature check** (`internal/integration/razorpay/client.go`): compared the computed HMAC to the caller-supplied signature with `!=` instead of a constant-time comparison — the only webhook verifier in the codebase that didn't already use `hmac.Equal`/`subtle.ConstantTimeCompare`.
- **Silent placeholder-secret detection gap** (`internal/config/config.yaml`): the shipped `auth.secret` default (`"super_secret"`) wasn't in `config.go`'s `placeholderSecrets` set, so `validateSecrets` — which exists specifically to warn when a non-local deployment boots on a known dev/sample secret — silently did nothing for the actual default. Changed the default to the sentinel value the check already recognizes.

---

## 🔨 Changes Made
- [x] Bug Fix (security)
- [x] Feature
- [ ] Refactor
- [ ] Documentation Update

- `internal/repository/ent`: add missing `tenant_id`/`environment_id` filters to `wallet.UpdateWalletBalance`, `subscription_line_item.Update`/`Delete`, `price.GetByPlanID`/`GetByGroupIDs`, and `subscription.GetPause`/`UpdatePause`.
- `internal/repository/clickhouse/builder`: replace unescaped `fmt.Sprintf` SQL interpolation with `?` bound parameters in `query_builder.go`; update `event.go`'s caller and `query_builder_test.go`.
- `internal/integration/razorpay`: use `hmac.Equal` instead of `!=` for webhook signature comparison.
- `internal/config/config.yaml`: fix `auth.secret` default so `validateSecrets` actually catches it in non-local deployments.

---

## ✅ Checklist
- [ ] My code follows the project's code style.
- [ ] I have added tests where applicable. *(updated existing `query_builder_test.go`; the tenant/environment filter fixes have no existing repo-level test coverage to extend — see test plan below)*
- [ ] All new and existing tests pass. *(not run locally — no Go toolchain available in the environment this was authored in; please verify with `make test`)*
- [ ] I have updated documentation (if needed). *(not needed)*

---

## 🧪 Test Plan
- [ ] `go build ./...`
- [ ] `go test ./internal/repository/clickhouse/builder/...`
- [ ] `make test` (full suite)
- [ ] Manual: confirm a wallet/subscription-line-item/price/subscription-pause lookup or write by ID scoped to tenant A does not read/mutate tenant B's row

---

## 📷 Screenshots / Demo (if applicable)
N/A — backend security fixes, no UI changes.
